### PR TITLE
Use suppress spelling instead of supress for the guide

### DIFF
--- a/tutorial/architecture.py
+++ b/tutorial/architecture.py
@@ -826,7 +826,7 @@ def update_figure(value):
 **Raise if ids don't exist**
 We can check `layout` for the IDs and throw an exception if they don't exist.
 If the user is generating the IDs through dynamic components, then we can
-provide a method for them to supress the exceptions.
+provide a method for them to suppress the exceptions.
 
 If they suppress the exceptions then we can still show them an error
 modal in the front-end if the ID doesn't exist.

--- a/tutorial/examples/dynamic_content.py
+++ b/tutorial/examples/dynamic_content.py
@@ -3,7 +3,7 @@ from dash.dependencies import Event, Output
 import dash_html_components as html
 
 app = dash.Dash(__name__)
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 
 app.layout = html.Div([
     html.Button('Click to load children', id='display-children-button'),

--- a/tutorial/examples/performance_flask_caching.py
+++ b/tutorial/examples/performance_flask_caching.py
@@ -13,7 +13,7 @@ cache = Cache(app.server, config={
     'CACHE_TYPE': 'redis',
     'CACHE_REDIS_URL': os.environ.get('REDIS_URL', '')
 })
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 
 timeout = 20
 app.layout = html.Div([

--- a/tutorial/examples/performance_memoization.py
+++ b/tutorial/examples/performance_memoization.py
@@ -11,7 +11,7 @@ else:
     from functools import lru_cache
 
 app = dash.Dash(__name__)
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 
 app.layout = html.Div([
     html.Div(id='memoized-children'),

--- a/tutorial/examples/url_part_2.py
+++ b/tutorial/examples/url_part_2.py
@@ -11,7 +11,7 @@ app = dash.Dash()
 # doing something wrong.
 # In this case, we're adding the elements through a callback, so we can ignore
 # the exception.
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 
 app.layout = html.Div([
     dcc.Location(id='url', refresh=False),

--- a/tutorial/server.py
+++ b/tutorial/server.py
@@ -12,4 +12,4 @@ server = Flask(__name__, static_url_path='/dash/static', static_folder='./static
 server.secret_key = os.environ.get('secret_key', 'secret')
 app = Dash(__name__, server=server, url_base_pathname='/dash/', csrf_protect=False)
 
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True

--- a/tutorial/urls.py
+++ b/tutorial/urls.py
@@ -91,7 +91,7 @@ app = dash.Dash()
 # doing something wrong.
 # In this case, we're adding the elements through a callback, so we can ignore
 # the exception.
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 
 app.layout = html.Div([
     dcc.Location(id='url', refresh=False),
@@ -178,7 +178,7 @@ callbacks with their initial values.
 - Since we're adding callbacks to elements that don't exist in the app.layout,
 Dash will raise an exception to warn us that we might be doing something
 wrong.  In this case, we're adding the elements through a callback, so we can
-ignore the exception by setting `app.config.supress_callback_exceptions = True`
+ignore the exception by setting `app.config.suppress_callback_exceptions = True`
 - You can modify this example to import the different page's `layout`s in different files.
 - This Dash Userguide that you're looking at is itself a multi-page Dash app, using
 rendered with these same principles.
@@ -211,7 +211,7 @@ dcc.SyntaxHighlighter('''import dash
 
 app = dash.Dash()
 server = app.server
-app.config.supress_callback_exceptions = True
+app.config.suppress_callback_exceptions = True
 ''', language='python', customStyle=styles.code_container),
 
 dcc.Markdown('''


### PR DESCRIPTION
Since the typo has been fixed in Dash and both versions are handled for backward compatibility (https://github.com/plotly/dash/pull/131), should we use the right spelling for the guide?