### PR TITLE
Follow PEP 8 standards.  Remove unnecessary parens - (). Surround top-level function and class…

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -45,12 +45,12 @@ with open('tutorial/examples/getting_started.py', 'r') as f:
 
     # return the layout instead of assigning it to the global app
     if 'app.layout = ' not in example:
-        raise Exception("app.layout not assigned")
+        raise Exception('app.layout not assigned')
     example = example.replace('app.layout = ', 'layout = ')
 
     # Remove the "# Run the server" commands
     if 'app.run_server' not in example:
-        raise Exception("app.run_server missing")
+        raise Exception('app.run_server missing')
     example = example.replace(
         '\n    app.run_server',
         'print("Running")\n    # app.run_server'

--- a/tutorial/examples/basic-input.py
+++ b/tutorial/examples/basic-input.py
@@ -7,8 +7,8 @@ import dash_html_components as html
 app = dash.Dash(__name__)
 
 app.layout = html.Div([
-    dcc.Input(id='input-1', type="text", value='Montréal'),
-    dcc.Input(id='input-2', type="text", value='Canada'),
+    dcc.Input(id='input-1', type='text', value='Montréal'),
+    dcc.Input(id='input-2', type='text', value='Canada'),
     html.Div(id='output')
 ])
 

--- a/tutorial/examples/basic-state.py
+++ b/tutorial/examples/basic-state.py
@@ -7,8 +7,8 @@ import dash_html_components as html
 app = dash.Dash()
 
 app.layout = html.Div([
-    dcc.Input(id='input-1-state', type="text", value='Montréal'),
-    dcc.Input(id='input-2-state', type="text", value='Canada'),
+    dcc.Input(id='input-1-state', type='text', value='Montréal'),
+    dcc.Input(id='input-2-state', type='text', value='Canada'),
     html.Button(id='submit-button', n_clicks=0, children='Submit'),
     html.Div(id='output-state')
 ])

--- a/tutorial/examples/basic_callbacks_events.py
+++ b/tutorial/examples/basic_callbacks_events.py
@@ -1,3 +1,4 @@
+from datetime import datetime as dt
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
@@ -5,7 +6,6 @@ from dash.dependencies import State, Event, Output
 import plotly.graph_objs as go
 
 from pandas_datareader import data as web
-from datetime import datetime as dt
 
 app = dash.Dash('')
 

--- a/tutorial/examples/basic_callbacks_example_1.py
+++ b/tutorial/examples/basic_callbacks_example_1.py
@@ -1,9 +1,9 @@
+from datetime import datetime as dt
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 
-from datetime import datetime as dt
 from pandas_datareader import data as web
 import plotly.graph_objs as go
 
@@ -61,6 +61,7 @@ def update_graph(selected_dropdown_value):
         }],
         layout={'margin': {'l': 30, 'r': 0, 'b': 20, 't': 10}}
     )
+
 
 # Run the app
 if __name__ == '__main__':

--- a/tutorial/examples/basic_callbacks_example_2.py
+++ b/tutorial/examples/basic_callbacks_example_2.py
@@ -1,9 +1,9 @@
+from datetime import datetime as dt
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 
-from datetime import datetime as dt
 from pandas_datareader import data as web
 import plotly.graph_objs as go
 
@@ -58,6 +58,7 @@ def update_graph(stock_ticker, column):
             margin=go.Margin(l=40, r=0, t=10, b=30)
         )
     )
+
 
 # Run the app
 if __name__ == '__main__':

--- a/tutorial/examples/callbacks_with_dependencies.py
+++ b/tutorial/examples/callbacks_with_dependencies.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+import time
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-import time
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/core_components/button.py
+++ b/tutorial/examples/core_components/button.py
@@ -4,21 +4,23 @@ import dash_core_components as dcc
 
 app = dash.Dash()
 app.layout = html.Div([
-    html.Div(dcc.Input(id='input-box', type="text")),
+    html.Div(dcc.Input(id='input-box', type='text')),
     html.Button('Submit', id='button'),
     html.Div(id='output-container-button',
-             children="Enter a value and press submit")
+             children='Enter a value and press submit')
 ])
+
 
 @app.callback(
     dash.dependencies.Output('output-container-button', 'children'),
     [dash.dependencies.Input('button', 'n_clicks')],
     [dash.dependencies.State('input-box', 'value')])
 def update_output(n_clicks, value):
-    return "The input value was \"{}\" and the button has been clicked {} times".format(
+    return 'The input value was "{}" and the button has been clicked {} times'.format(
         value,
         n_clicks
     )
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/date_picker_range.py
+++ b/tutorial/examples/core_components/date_picker_range.py
@@ -1,7 +1,7 @@
+from datetime import datetime as dt
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
-from datetime import datetime as dt
 
 app = dash.Dash()
 app.layout = html.Div([
@@ -21,17 +21,17 @@ app.layout = html.Div([
     [dash.dependencies.Input('my-date-picker-range', 'start_date'),
      dash.dependencies.Input('my-date-picker-range', 'end_date')])
 def update_output(start_date, end_date):
-    string_prefix = "You have selected: "
+    string_prefix = 'You have selected: '
     if start_date is not None:
         start_date = dt.strptime(start_date, '%Y-%m-%d')
         start_date_string = start_date.strftime('%B %d, %Y')
-        string_prefix = string_prefix + "Start Date: " + start_date_string + " | "
+        string_prefix = string_prefix + 'Start Date: ' + start_date_string + ' | '
     if end_date is not None:
         end_date = dt.strptime(end_date, '%Y-%m-%d')
         end_date_string = end_date.strftime('%B %d, %Y')
-        string_prefix = string_prefix + "End Date: " + end_date_string
-    if(len(string_prefix) == len("You have selected: ")):
-        return "Select a date to see it displayed here"
+        string_prefix = string_prefix + 'End Date: ' + end_date_string
+    if len(string_prefix) == len('You have selected: '):
+        return 'Select a date to see it displayed here'
     else:
         return string_prefix
 

--- a/tutorial/examples/core_components/date_picker_single.py
+++ b/tutorial/examples/core_components/date_picker_single.py
@@ -1,7 +1,7 @@
+from datetime import datetime as dt
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
-from datetime import datetime as dt
 
 app = dash.Dash()
 app.layout = html.Div([
@@ -25,6 +25,7 @@ def update_output(date):
         date = dt.strptime(date, '%Y-%m-%d')
         date_string = date.strftime('%B %d, %Y')
         return string_prefix + date_string
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/dropdown.py
+++ b/tutorial/examples/core_components/dropdown.py
@@ -11,16 +11,18 @@ app.layout = html.Div([
             {'label': 'Montreal', 'value': 'MTL'},
             {'label': 'San Francisco', 'value': 'SF'}
         ],
-       value='NYC'
+        value='NYC'
     ),
     html.Div(id='output-container')
 ])
+
 
 @app.callback(
     dash.dependencies.Output('output-container', 'children'),
     [dash.dependencies.Input('my-dropdown', 'value')])
 def update_output(value):
     return 'You have selected "{}"'.format(value)
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/rangeslider.py
+++ b/tutorial/examples/core_components/rangeslider.py
@@ -14,11 +14,13 @@ app.layout = html.Div([
     html.Div(id='output-container-range-slider')
 ])
 
+
 @app.callback(
     dash.dependencies.Output('output-container-range-slider', 'children'),
     [dash.dependencies.Input('my-range-slider', 'value')])
 def update_output(value):
     return 'You have selected "{}"'.format(value)
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/rangeslider_nonlinear.py
+++ b/tutorial/examples/core_components/rangeslider_nonlinear.py
@@ -10,10 +10,11 @@ app = dash.Dash('')
 def transform_value(value):
     return 10 ** value
 
+
 app.layout = html.Div([
     dcc.RangeSlider(
         id='non-linear-range-slider',
-        marks={(i): '{}'.format(10 ** i) for i in range(4)},
+        marks={i: '{}'.format(10 ** i) for i in range(4)},
         max=3,
         value=[0.1, 2],
         dots=False,
@@ -22,6 +23,7 @@ app.layout = html.Div([
     ),
     html.Div(id='output-container-range-slider-non-linear', style={'margin-top': 20})
 ])
+
 
 @app.callback(
     Output('output-container-range-slider-non-linear', 'children'),

--- a/tutorial/examples/core_components/slider.py
+++ b/tutorial/examples/core_components/slider.py
@@ -14,11 +14,13 @@ app.layout = html.Div([
     html.Div(id='slider-output-container')
 ])
 
+
 @app.callback(
     dash.dependencies.Output('slider-output-container', 'children'),
     [dash.dependencies.Input('my-slider', 'value')])
 def update_output(value):
     return 'You have selected "{}"'.format(value)
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/slider_updatemode.py
+++ b/tutorial/examples/core_components/slider_updatemode.py
@@ -10,10 +10,11 @@ app = dash.Dash()
 def transform_value(value):
     return 10 ** value
 
+
 app.layout = html.Div([
     dcc.Slider(
         id='slider-updatemode',
-        marks={(i): '{}'.format(10 ** i) for i in range(4)},
+        marks={i: '{}'.format(10 ** i) for i in range(4)},
         max=3,
         value=2,
         step=0.01,
@@ -22,8 +23,9 @@ app.layout = html.Div([
     html.Div(id='updatemode-output-container', style={'margin-top': 20})
 ])
 
+
 @app.callback(Output('updatemode-output-container', 'children'),
-          [Input('slider-updatemode', 'value')])
+              [Input('slider-updatemode', 'value')])
 def display_value(value):
     return 'Linear Value: {} | \
             Log Value: {:0.2f}'.format(value, transform_value(value))

--- a/tutorial/examples/core_components/upload-datafile.py
+++ b/tutorial/examples/core_components/upload-datafile.py
@@ -72,8 +72,7 @@ def parse_contents(contents, filename, date):
         html.Div('Raw Content'),
         html.Pre(contents[0:200] + '...', style={
             'whiteSpace': 'pre-wrap',
-            'wordBreak': 'break-all',
-            'whiteSpace': 'normal'
+            'wordBreak': 'break-all'
         })
     ])
 
@@ -91,7 +90,7 @@ def update_output(list_of_contents, list_of_names, list_of_dates):
 
 
 app.css.append_css({
-    "external_url": "https://codepen.io/chriddyp/pen/bWLwgP.css"
+    'external_url': 'https://codepen.io/chriddyp/pen/bWLwgP.css'
 })
 
 if __name__ == '__main__':

--- a/tutorial/examples/core_components/upload-image.py
+++ b/tutorial/examples/core_components/upload-image.py
@@ -51,8 +51,7 @@ def parse_contents(contents, filename, date):
         html.Div('Raw Content'),
         html.Pre(contents[0:200] + '...', style={
             'whiteSpace': 'pre-wrap',
-            'wordBreak': 'break-all',
-            'whiteSpace': 'normal'
+            'wordBreak': 'break-all'
         })
     ])
 
@@ -70,7 +69,7 @@ def update_output(list_of_contents, list_of_names, list_of_dates):
 
 
 app.css.append_css({
-    "external_url": "https://codepen.io/chriddyp/pen/bWLwgP.css"
+    'external_url': 'https://codepen.io/chriddyp/pen/bWLwgP.css'
 })
 
 if __name__ == '__main__':

--- a/tutorial/examples/crossfilter_recipe.py
+++ b/tutorial/examples/crossfilter_recipe.py
@@ -118,7 +118,7 @@ def highlight(x, y):
 
 
 app.css.append_css({
-    "external_url": "https://codepen.io/chriddyp/pen/bWLwgP.css"})
+    'external_url': 'https://codepen.io/chriddyp/pen/bWLwgP.css'})
 
 # app.callback is a decorator which means that it takes a function
 # as its argument.

--- a/tutorial/examples/excel.py
+++ b/tutorial/examples/excel.py
@@ -28,15 +28,18 @@ app.layout = html.Div([
     'marginTop': 40
 })
 
+
 @app.callback(Output('amount', 'children'),
               [Input('hours', 'value'), Input('rate', 'value')])
 def compute_amount(hours, rate):
     return float(hours) * float(rate)
 
+
 @app.callback(Output('amount-per-week', 'children'),
               [Input('amount', 'children')])
 def compute_amount(amount):
     return float(amount) * 7
+
 
 app.css.append_css({
     'external_url': (

--- a/tutorial/examples/getting_started.py
+++ b/tutorial/examples/getting_started.py
@@ -1,3 +1,4 @@
+from datetime import datetime as dt
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
@@ -5,7 +6,6 @@ import dash_html_components as html
 
 from plotly import graph_objs as go
 from pandas_datareader import data as web
-from datetime import datetime as dt
 
 app = dash.Dash('Hello World')
 
@@ -45,6 +45,7 @@ def update_graph(selected_dropdown_value):
             'margin': {'l': 20, 'r': 10, 't': 20, 'b': 30}
         }
     )
+
 
 # Run the server
 if __name__ == '__main__':

--- a/tutorial/examples/getting_started_callback_chain.py
+++ b/tutorial/examples/getting_started_callback_chain.py
@@ -26,17 +26,20 @@ app.layout = html.Div([
     html.Div(id='display-selected-values')
 ])
 
+
 @app.callback(
     dash.dependencies.Output('cities-dropdown', 'options'),
     [dash.dependencies.Input('countries-dropdown', 'value')])
 def set_cities_options(selected_country):
     return [{'label': i, 'value': i} for i in all_options[selected_country]]
 
+
 @app.callback(
     dash.dependencies.Output('cities-dropdown', 'value'),
     [dash.dependencies.Input('cities-dropdown', 'options')])
 def set_cities_value(available_options):
     return available_options[0]['value']
+
 
 @app.callback(
     dash.dependencies.Output('display-selected-values', 'children'),
@@ -46,6 +49,7 @@ def set_display_children(selected_country, selected_city):
     return u'{} is a city in {}'.format(
         selected_city, selected_country,
     )
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/tutorial/examples/getting_started_crossfilter.py
+++ b/tutorial/examples/getting_started_crossfilter.py
@@ -72,6 +72,7 @@ app.layout = html.Div([
     ), style={'width': '49%', 'padding': '0px 20px 20px 20px'})
 ])
 
+
 @app.callback(
     dash.dependencies.Output('crossfilter-indicator-scatter', 'figure'),
     [dash.dependencies.Input('crossfilter-xaxis-column', 'value'),
@@ -112,6 +113,7 @@ def update_graph(xaxis_column_name, yaxis_column_name,
         )
     }
 
+
 def create_time_series(dff, axis_type, title):
     return {
         'data': [go.Scatter(
@@ -133,6 +135,7 @@ def create_time_series(dff, axis_type, title):
         }
     }
 
+
 @app.callback(
     dash.dependencies.Output('x-time-series', 'figure'),
     [dash.dependencies.Input('crossfilter-indicator-scatter', 'hoverData'),
@@ -145,6 +148,7 @@ def update_y_timeseries(hoverData, xaxis_column_name, axis_type):
     title = '<b>{}</b><br>{}'.format(country_name, xaxis_column_name)
     return create_time_series(dff, axis_type, title)
 
+
 @app.callback(
     dash.dependencies.Output('y-time-series', 'figure'),
     [dash.dependencies.Input('crossfilter-indicator-scatter', 'hoverData'),
@@ -154,6 +158,7 @@ def update_x_timeseries(hoverData, yaxis_column_name, axis_type):
     dff = df[df['Country Name'] == hoverData['points'][0]['customdata']]
     dff = dff[dff['Indicator Name'] == yaxis_column_name]
     return create_time_series(dff, axis_type, yaxis_column_name)
+
 
 if __name__ == '__main__':
     app.run_server()

--- a/tutorial/examples/getting_started_graph.py
+++ b/tutorial/examples/getting_started_graph.py
@@ -22,6 +22,7 @@ app.layout = html.Div([
     )
 ])
 
+
 @app.callback(
     dash.dependencies.Output('graph-with-slider', 'figure'),
     [dash.dependencies.Input('year-slider', 'value')])
@@ -53,6 +54,7 @@ def update_figure(selected_year):
             hovermode='closest'
         )
     }
+
 
 if __name__ == '__main__':
     app.run_server()

--- a/tutorial/examples/getting_started_interactive_simple.py
+++ b/tutorial/examples/getting_started_interactive_simple.py
@@ -10,12 +10,14 @@ app.layout = html.Div([
     html.Div(id='my-div')
 ])
 
+
 @app.callback(
     Output(component_id='my-div', component_property='children'),
     [Input(component_id='my-id', component_property='value')]
 )
 def update_output_div(input_value):
     return 'You\'ve entered "{}"'.format(input_value)
+
 
 if __name__ == '__main__':
     app.run_server()

--- a/tutorial/examples/getting_started_multiple_outputs_1.py
+++ b/tutorial/examples/getting_started_multiple_outputs_1.py
@@ -21,17 +21,20 @@ app.layout = html.Div([
 
 ])
 
+
 @app.callback(
     dash.dependencies.Output('output-a', 'children'),
     [dash.dependencies.Input('dropdown-a', 'value')])
 def callback_a(dropdown_value):
     return 'You\'ve selected "{}"'.format(dropdown_value)
 
+
 @app.callback(
     dash.dependencies.Output('output-b', 'children'),
     [dash.dependencies.Input('dropdown-b', 'value')])
 def callback_b(dropdown_value):
     return 'You\'ve selected "{}"'.format(dropdown_value)
+
 
 if __name__ == '__main__':
     app.run_server()

--- a/tutorial/examples/getting_started_multiple_viz.py
+++ b/tutorial/examples/getting_started_multiple_viz.py
@@ -97,5 +97,6 @@ def update_graph(xaxis_column_name, yaxis_column_name,
         )
     }
 
+
 if __name__ == '__main__':
     app.run_server()

--- a/tutorial/examples/getting_started_table.py
+++ b/tutorial/examples/getting_started_table.py
@@ -10,6 +10,7 @@ df = pd.read_csv(
     'c353e8ef842413cae56ae3920b8fd78468aa4cb2/'
     'usa-agricultural-exports-2011.csv')
 
+
 def generate_table(dataframe, max_rows=10):
     return html.Table(
         # Header
@@ -20,6 +21,7 @@ def generate_table(dataframe, max_rows=10):
             html.Td(dataframe.iloc[i][col]) for col in dataframe.columns
         ]) for i in range(min(len(dataframe), max_rows))]
     )
+
 
 app = dash.Dash()
 

--- a/tutorial/examples/graph_callbacks_crossfiltering.py
+++ b/tutorial/examples/graph_callbacks_crossfiltering.py
@@ -1,9 +1,10 @@
+import math
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 import pandas as pd
-import math
+
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/graph_callbacks_same_graph.py
+++ b/tutorial/examples/graph_callbacks_same_graph.py
@@ -1,9 +1,9 @@
+import math
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 import pandas as pd
-import math
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/graph_callbacks_simple.py
+++ b/tutorial/examples/graph_callbacks_simple.py
@@ -1,9 +1,9 @@
+import json
+from textwrap import dedent as d
 import dash
 from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-import json
-from textwrap import dedent as d
 
 
 app = dash.Dash(__name__)

--- a/tutorial/examples/live_updates.py
+++ b/tutorial/examples/live_updates.py
@@ -1,8 +1,8 @@
+import datetime
 import dash
 from dash.dependencies import Input, Output, Event
 import dash_core_components as dcc
 import dash_html_components as html
-import datetime
 import plotly
 
 # pip install pyorbital


### PR DESCRIPTION
… definitions with two blank lines.  https://www.python.org/dev/peps/pep-0008/#blank-lines  Use single quotes consistently. Remove duplicate whiteSpace key from Python dictionary. Indent Python code.  Standard import "from datetime import datetime as dt" should be placed before "import dash" (wrong-import-order). Standard import "import time" should be placed before "import dash" (wrong-import-order). Standard import "import math" should be placed before "import dash" (wrong-import-order). Standard imports "import json" and "from textwrap import dedent as d" should be placed before "import dash" (wrong-import-order). Standard import "import datetime" should be placed before "import dash" (wrong-import-order)