### PR TITLE
Fixes the 'Chapter' function to output the correct type of link: html…

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -19,7 +19,7 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 /* plotly.js's modebar's z-index is outta the roof by default - lower it down */
 .js-plotly-plot .plotly .modebar {
-    z-index: 0 important!;
+    z-index: 0 !important;
 }
 
 /* Grid

--- a/tutorial/examples/walmart.py
+++ b/tutorial/examples/walmart.py
@@ -51,6 +51,7 @@ def update_text(hoverData):
         )
     )
 
+
 app.css.append_css({
     'external_url': 'https://codepen.io/chriddyp/pen/bWLwgP.css'
 })

--- a/tutorial/home.py
+++ b/tutorial/home.py
@@ -14,7 +14,7 @@ styles = {
 
 
 def Chapter(name, href=None, caption=None):
-    linkComponent = html.A if href.startswith('http') else dcc.Link
+    linkComponent = html.A
     return html.Div([
         html.Li(
             linkComponent(

--- a/tutorial/home.py
+++ b/tutorial/home.py
@@ -15,11 +15,12 @@ styles = {
 
 def Chapter(name, href=None, caption=None):
     linkComponent = html.A
+    anchor = '' if href.startswith('http') else '#chapter'
     return html.Div([
         html.Li(
             linkComponent(
                 name,
-                href=href,
+                href=href + anchor,
                 style={'paddingLeft': 0},
                 id=href
             )

--- a/tutorial/run.py
+++ b/tutorial/run.py
@@ -278,7 +278,7 @@ app.layout = html.Div(
 
 
 @app.callback(Output('chapter', 'children'),
-    [Input('location', 'pathname')])
+              [Input('location', 'pathname')])
 def display_content(pathname):
     if pathname is None:
         return ''

--- a/tutorial/run.py
+++ b/tutorial/run.py
@@ -291,7 +291,7 @@ def display_content(pathname):
         content = html.Div([
             html.Div(chapters[matched[0]]['content']),
             html.Hr(),
-            dcc.Link(html.A('Back to the Table of Contents'), href='/dash/'),
+            html.A('Back to the Table of Contents', href='/dash/'),
             html.Div(id='wait-for-page-{}'.format(pathname)),
         ])
     else:


### PR DESCRIPTION
….A.  With this update the links on the dash docs homepage page now link correctly to the top of the page that opens when clicked.  Previously if you were on the homepage https://plot.ly/dash/ and clicked on 'URL Routing and Multiple Apps' it would open the next page and scroll the browser down missing the intended target heading.  This also allows the link to show up in the status bar at the bottom of the web browser. Also PEP8 fix by adding an extra line.  Added the extra anchor '#chapter' to href.  In Firefox when you scroll to the bottom of the page you can hit the url again and it will scroll back to the top of the page where the id="chapter" or page heading is defined.