### PR TITLE
Add 3d brain example

### DIFF
--- a/tutorial/gallery.py
+++ b/tutorial/gallery.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import dash_html_components as html
 import dash_core_components as dcc
 

--- a/tutorial/gallery.py
+++ b/tutorial/gallery.py
@@ -289,7 +289,28 @@ layout = html.Div(className='gallery', children=[
 
     [View the app](https://plot.ly/dash/gallery/yield-curve) | [View the source code](https://github.com/plotly/dash-yield-curve)
 
+    ***
+    
+    ## Brain Surface Viewer
+    
+    🐭 Explore human and mice brains in 3d. 
+    
+    Add interactive labels to points on the brain surface and change the surface colorscale.
+    
+    '''.replace('    ', '')),
 
+    html.A(
+        className='image-link',
+        href='http://brain-surface-viewer.herokuapp.com/',
+        children=html.Img(
+            src='https://raw.githubusercontent.com/plotly/dash-brain-surface-viewer/master/ZOMBIE_BRAIN.png',
+            alt='Screenshot of brain surface viewer'
+        )
+    ),
+    dcc.Markdown('''
+
+    [View the app](http://brain-surface-viewer.herokuapp.com/) | [View the source code](https://github.com/plotly/dash-brain-surface-viewer)
+    
     ***
 
     ## Dash Documentation


### PR DESCRIPTION
Adds https://github.com/plotly/dash-brain-surface-viewer to the gallery page