### PR TITLE
improve import order across all examples

### DIFF
--- a/tutorial/auth.py
+++ b/tutorial/auth.py
@@ -75,8 +75,8 @@ layout = html.Div([
 
     dcc.SyntaxHighlighter('''import dash
 import dash_auth
-import dash_html_components as html
 import dash_core_components as dcc
+import dash_html_components as html
 import plotly
 
 # Keep this out of source code repository - save in a file or a database
@@ -152,8 +152,8 @@ pip install dash-auth==0.0.4''', customStyle=styles.code_container),
 
     dcc.SyntaxHighlighter('''import dash
 import dash_auth
-import dash_html_components as html
 import dash_core_components as dcc
+import dash_html_components as html
 import plotly
 
 

--- a/tutorial/deployment.py
+++ b/tutorial/deployment.py
@@ -129,10 +129,12 @@ Create the following files in your project folder:
 **`app.py`**
 '''),
 
-          dcc.SyntaxHighlighter('''import dash
+          dcc.SyntaxHighlighter('''import os
+
+import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import os
+
 
 app = dash.Dash(__name__)
 server = app.server

--- a/tutorial/examples/basic-input.py
+++ b/tutorial/examples/basic-input.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/basic-state.py
+++ b/tutorial/examples/basic-state.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import dash
-from dash.dependencies import Input, Output, State
 import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output, State
 
 app = dash.Dash()
 

--- a/tutorial/examples/basic_callbacks_events.py
+++ b/tutorial/examples/basic_callbacks_events.py
@@ -1,10 +1,10 @@
 from datetime import datetime as dt
-import dash
-import dash_html_components as html
-import dash_core_components as dcc
-from dash.dependencies import State, Event, Output
-import plotly.graph_objs as go
 
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+import plotly.graph_objs as go
+from dash.dependencies import State, Event, Output
 from pandas_datareader import data as web
 
 app = dash.Dash('')

--- a/tutorial/examples/basic_callbacks_example_1.py
+++ b/tutorial/examples/basic_callbacks_example_1.py
@@ -1,11 +1,11 @@
 from datetime import datetime as dt
+
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-
-from pandas_datareader import data as web
 import plotly.graph_objs as go
+from dash.dependencies import Input, Output
+from pandas_datareader import data as web
 
 app = dash.Dash('')
 

--- a/tutorial/examples/basic_callbacks_example_2.py
+++ b/tutorial/examples/basic_callbacks_example_2.py
@@ -1,9 +1,9 @@
 from datetime import datetime as dt
+
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-
+from dash.dependencies import Input, Output
 from pandas_datareader import data as web
 import plotly.graph_objs as go
 

--- a/tutorial/examples/callbacks_with_dependencies.py
+++ b/tutorial/examples/callbacks_with_dependencies.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import time
+
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/chart_explorer.py
+++ b/tutorial/examples/chart_explorer.py
@@ -1,10 +1,9 @@
+from collections import OrderedDict
+
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-
 import plotly.plotly as py
-
-from collections import OrderedDict
 
 graphs = OrderedDict([
     ['scatter', {

--- a/tutorial/examples/crossfilter_recipe.py
+++ b/tutorial/examples/crossfilter_recipe.py
@@ -1,10 +1,9 @@
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-
 import numpy as np
 import pandas as pd
+from dash.dependencies import Input, Output
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started.py
+++ b/tutorial/examples/getting_started.py
@@ -1,11 +1,11 @@
 from datetime import datetime as dt
+
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-
-from plotly import graph_objs as go
+from dash.dependencies import Input, Output
 from pandas_datareader import data as web
+from plotly import graph_objs as go
 
 app = dash.Dash('Hello World')
 

--- a/tutorial/examples/getting_started_callback_chain.py
+++ b/tutorial/examples/getting_started_callback_chain.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/getting_started_core_components.py
+++ b/tutorial/examples/getting_started_core_components.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import dash
-import dash_html_components as html
 import dash_core_components as dcc
+import dash_html_components as html
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started_crossfilter.py
+++ b/tutorial/examples/getting_started_crossfilter.py
@@ -1,8 +1,8 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started_graph.py
+++ b/tutorial/examples/getting_started_graph.py
@@ -1,8 +1,8 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
 
 df = pd.read_csv(
     'https://raw.githubusercontent.com/plotly/'

--- a/tutorial/examples/getting_started_interactive_simple.py
+++ b/tutorial/examples/getting_started_interactive_simple.py
@@ -1,7 +1,7 @@
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started_markdown.py
+++ b/tutorial/examples/getting_started_markdown.py
@@ -1,6 +1,6 @@
+import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import dash
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started_multiple_viz.py
+++ b/tutorial/examples/getting_started_multiple_viz.py
@@ -1,8 +1,8 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
 
 app = dash.Dash()
 

--- a/tutorial/examples/getting_started_table.py
+++ b/tutorial/examples/getting_started_table.py
@@ -1,7 +1,6 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-
 import pandas as pd
 
 df = pd.read_csv(

--- a/tutorial/examples/getting_started_viz.py
+++ b/tutorial/examples/getting_started_viz.py
@@ -1,8 +1,8 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
 
 app = dash.Dash()
 

--- a/tutorial/examples/graph_callbacks_simple.py
+++ b/tutorial/examples/graph_callbacks_simple.py
@@ -1,10 +1,10 @@
 import json
 from textwrap import dedent as d
+
 import dash
-from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
-
+from dash.dependencies import Input, Output
 
 app = dash.Dash(__name__)
 

--- a/tutorial/examples/performance_flask_caching.py
+++ b/tutorial/examples/performance_flask_caching.py
@@ -1,11 +1,11 @@
-import dash
-from dash.dependencies import Input, Output
-import dash_html_components as html
-import dash_core_components as dcc
 import datetime
 import os
-from flask_caching import Cache
 
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from flask_caching import Cache
 
 app = dash.Dash(__name__)
 cache = Cache(app.server, config={

--- a/tutorial/examples/performance_flask_caching_dataset.py
+++ b/tutorial/examples/performance_flask_caching_dataset.py
@@ -1,13 +1,14 @@
-import dash
-from dash.dependencies import Input, Output
-import dash_html_components as html
-import dash_core_components as dcc
 import datetime as dt
-from flask_caching import Cache
-import numpy as np
 import os
-import pandas as pd
 import time
+
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+import numpy as np
+import pandas as pd
+from dash.dependencies import Input, Output
+from flask_caching import Cache
 
 app = dash.Dash(__name__)
 cache = Cache(app.server, config={

--- a/tutorial/examples/performance_memoization.py
+++ b/tutorial/examples/performance_memoization.py
@@ -1,9 +1,10 @@
-import dash
-from dash.dependencies import Input, Output
-import dash_html_components as html
-import dash_core_components as dcc
 import sys
 import time
+
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
 
 if sys.version_info < (3, 2, 0):
     from functools32 import lru_cache

--- a/tutorial/examples/walmart.py
+++ b/tutorial/examples/walmart.py
@@ -1,8 +1,8 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
 
 app = dash.Dash()
 

--- a/tutorial/live_updates.py
+++ b/tutorial/live_updates.py
@@ -35,13 +35,14 @@ the callback on a predefined interval.
 This example pulls data from live satellite feeds and updates the graph
 and the text every second.
 '''),
-    dcc.SyntaxHighlighter('''import dash
-from dash.dependencies import Input, Output
+    dcc.SyntaxHighlighter('''import datetime
+
+import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import datetime
 import plotly
-
+from dash.dependencies import Input, Output
+    
 # pip install pyorbital
 from pyorbital.orbital import Orbital
 satellite = Orbital('TERRA')
@@ -145,9 +146,10 @@ on every page load.
 For example, if your `app.layout` looked like this:
 
 ```
+import datetime
+
 import dash
 import dash_html_components as html
-import datetime
 
 app.layout = html.H1('The time is: ' + str(datetime.datetime.now()))
 
@@ -161,9 +163,10 @@ If you change this to a function, then a new `datetime` will get computed
 everytime you refresh the page. Give it a try:
 
 ```
+import datetime
+
 import dash
 import dash_html_components as html
-import datetime
 
 def serve_layout():
     return html.H1('The time is: ' + str(datetime.datetime.now()))

--- a/tutorial/sharing_state.py
+++ b/tutorial/sharing_state.py
@@ -315,17 +315,18 @@ def update_output_1(value):
 
     Syntax(summary="Here's what this example looks like in code",
            children=s('''
-        import copy
-        import dash
-        from dash.dependencies import Input, Output
-        import dash_html_components as html
-        import dash_core_components as dcc
-        import datetime
-        from flask_caching import Cache
-        import numpy as np
         import os
-        import pandas as pd
+        import copy
         import time
+        import datetime
+
+        import dash
+        import dash_core_components as dcc
+        import dash_html_components as html
+        import numpy as np
+        import pandas as pd
+        from dash.dependencies import Input, Output
+        from flask_caching import Cache
 
 
         app = dash.Dash(__name__)

--- a/tutorial/urls.py
+++ b/tutorial/urls.py
@@ -217,9 +217,9 @@ app.config.suppress_callback_exceptions = True
 `apps/app1.py`
 '''),
 
-          dcc.SyntaxHighlighter('''from dash.dependencies import Input, Output
+          dcc.SyntaxHighlighter('''import dash_core_components as dcc
 import dash_html_components as html
-import dash_core_components as dcc
+from dash.dependencies import Input, Output
 
 from app import app
 
@@ -254,10 +254,9 @@ And similarly for other apps
 `index.py` loads different apps on different urls like this:
 '''),
 
-          dcc.SyntaxHighlighter('''
-from dash.dependencies import Input, Output
-import dash_core_components as dcc
+          dcc.SyntaxHighlighter('''import dash_core_components as dcc
 import dash_html_components as html
+from dash.dependencies import Input, Output
 
 from app import app
 from apps import app1, app2


### PR DESCRIPTION
This improves the import order across examples in the Dash guide. 

Firstly, imports are now PEP8 compliant. As a reference document that is likely to be read by many people new to Python, I think it's desirable to model best practice. PEP8 compliant imports are also easier to read quickly.

Secondly, this also moves `from X import Y` style imports to below `import X` style imports. While this is not  required by PEP8, it's a convention that many adhere to, again, for readability. Additionally, it has the useful effect of putting the imports of both `dash_html_components` and `dash_core_components` before doing `from dash.dependencies import Input, State, Event`. Combined with the changes from plotly/dash-core-components#177 and plotly/dash-html-components#39 this will result in users getting a more helpful error message when they name the their script `dash.py`, which will fail due to shadowing the Dash package itself. 

