### PR TITLE
have multiple remotes for multiple dash apps

### DIFF
--- a/tutorial/on_premise_deployment.py
+++ b/tutorial/on_premise_deployment.py
@@ -255,7 +255,7 @@ def generate_instructions(chapter, platform):
             ''')),
 
             dcc.SyntaxHighlighter(s('''$ cd dash-on-premise-sample-app
-                $ git remote add plotly dokku@your-dash-app-manager:your-dash-app-name'''),
+                $ git remote add plotly-[your-dash-app-name] dokku@your-dash-app-manager:your-dash-app-name'''),
                 customStyle=styles.code_container,
                 language='python'
             ),


### PR DESCRIPTION
If a user deploys/work on multiple dash apps, they can't rename all remotes related to the apps with the same name, so we can have a remote for each dash app that the dev works on.

I suggest the name plotly-[dash-app-name]