### PR TITLE
consistent intros

### DIFF
--- a/tutorial/getting_started_part_1.py
+++ b/tutorial/getting_started_part_1.py
@@ -5,13 +5,14 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 import plotly
+from textwrap import dedent as s
 
 import styles
 from tools import load_example
 from components import Example, Syntax
 
 examples = [
-    load_example(s) for s in [
+    load_example(example) for example in [
         'tutorial/examples/getting_started_layout_1.py',
         'tutorial/examples/getting_started_layout_2.py',
         'tutorial/examples/getting_started_table.py',
@@ -24,66 +25,29 @@ examples = [
 
 layout = html.Div([
 
-    dcc.Markdown('''
-    # Dash Tutorial - Part 1: App Layout
 
-    This tutorial will walk you through the fundamentals of creating Dash apps
-    through {} self-contained apps.
+    dcc.Markdown(s('''
+    # Dash Layout
+
+    > This is the *2nd* chapter of the [Dash Tutorial](/).
+    > The [previous chapter](/installation) covered installation
+    > and the [next chapter](/getting-started-part-2) covers Dash callbacks.
+    ''')),
+
+
+    dcc.Markdown('''
+
+    This tutorial will walk you through a fundamental aspect of Dash apps, the
+    app `layout`, through {} self-contained apps.
 
     '''.format(len(examples)).replace('    ', '')),
 
     dcc.Markdown('''***
 
-1. [Installation](#installation)
-2. [Dash App Layout](#dash-app-layout)
-    - Generating HTML with Dash
-    - Data Visualization in Dash
-    - Markdown
-    - Core Components
-    - Calling `help`
-3. [Interactivity](/getting-started-part-2)
-    - Fundamentals
-    - Multiple Inputs
-    - Multiple Outputs
-    - Graph Crossfiltering
-
-  ***'''),
-
-    html.H2('''
-    Installation
-    ''', id='installation'),
-
-    dcc.Markdown('''
-
-    In your terminal, install several dash libraries.
-    These libraries are under active development,
-    so install and upgrade frequently.
-    Python 2 and 3 are supported.'''.replace('    ', '')),
-
-    dcc.SyntaxHighlighter('''pip install dash=={}  # The core dash backend
-        pip install dash-renderer=={}  # The dash front-end
-        pip install dash-html-components=={}  # HTML components
-        pip install dash-core-components=={}  # Supercharged components
-        pip install plotly --upgrade  # Latest Plotly graphing library
-    '''.replace('    ', '').format(
-        dash.__version__,
-        dash_renderer.__version__,
-        html.__version__,
-        dcc.__version__,
-        plotly.__version__
-    ), customStyle=styles.code_container),
-
-    html.H2('''
-    Dash App Layout
-    ''', id='dash-app-layout'),
-
-    dcc.Markdown('''***
-
-    #### Generating HTML with Dash
-
     Dash apps are composed of two parts. The first part is the "`layout`" of
     the app and it describes what the application looks like.
-    The second part describes the interactivity of the application.
+    The second part describes the interactivity of the application and will be
+    covered in the [next chapter](/getting-started-part-2).
 
     Dash provides Python classes for all of the visual components of
     the application. We maintain a set of components in the
@@ -338,7 +302,7 @@ class Dropdown(dash.development.base_component.Component)
     '''),
 
     dcc.Link(
-        'Dash Tutorial - Part 2: Basic Callbacks',
+        'Dash Tutorial Part 3: Basic Callbacks',
         href="/getting-started-part-2"
     )
 

--- a/tutorial/getting_started_part_2.py
+++ b/tutorial/getting_started_part_2.py
@@ -5,12 +5,13 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 import plotly
+from textwrap import dedent as s
 
 import styles
 from tools import load_example
 
 examples = [
-    load_example(s) for s in [
+    load_example(example) for example in [
         'tutorial/examples/getting_started_interactive_simple.py',
         'tutorial/examples/getting_started_graph.py',
         'tutorial/examples/getting_started_multiple_viz.py',
@@ -22,71 +23,28 @@ examples = [
 
 layout = html.Div([
 
-    dcc.Markdown('''
-    # Dash Tutorial - Part 2: Interactivity
+    dcc.Markdown(s('''
+    # Basic Dash Callbacks
 
-    This tutorial will walk you through the fundamentals of creating Dash apps
-    through {} self-contained apps.
+    > This is the *3rd* chapter of the [Dash Tutorial](/).
+    > The [previous chapter](/getting-started-) covered the Dash app `layout`
+    > and the [next chapter](/state) covers an additional concept of callbacks
+    > known as `state`.
+    > Just getting started? Make sure to [install the necessary dependencies](/installation).
 
-    '''.format(len(examples)).replace('    ', '')),
-
-    dcc.Markdown('''***
-
-1. [Installation](#installation)
-2. [Dash App Layout](/getting-started-part-1)
-    - Generating HTML with Dash
-    - Data Visualization in Dash
-    - Markdown
-    - Core Components
-    - Calling `help`
-3. [Interactivity](#interactivity)
-    - Fundamentals
-    - Multiple Inputs
-    - Multiple Outputs
-    - Graph Crossfiltering
-
-  ***'''),
-
-    html.H2('''
-    Installation
-    ''', id='installation'),
+    ''')),
 
     dcc.Markdown('''
 
-    In your terminal, install several dash libraries.
-    These libraries are under active development,
-    so install and upgrade frequently.
-    Python 2 and 3 are supported.'''.replace('    ', '')),
-
-    dcc.SyntaxHighlighter('''pip install dash=={}  # The core dash backend
-        pip install dash-renderer=={}  # The dash front-end
-        pip install dash-html-components=={}  # HTML components
-        pip install dash-core-components=={}  # Supercharged components
-        pip install plotly=={}  # Plotly graphing library used in examples
-    '''.replace('    ', '').format(
-        dash.__version__,
-        dash_renderer.__version__,
-        html.__version__,
-        dcc.__version__,
-        plotly.__version__
-    ), customStyle=styles.code_container),
-
-    html.H2('''
-    Interactivity
-    ''', id='interactivity'),
-
-    dcc.Markdown('''
-
-        The [first part](/getting-started) of this tutorial
-        covered the `layout` of Dash apps. The `layout` of a Dash app
-        describes what the app looks like.
-        It is a hierarchical tree of components.
+        In the [previous chapter on the `app.layout`](/getting-started) we learned
+        that the `app.layout` describes what the app looks like and is
+        a hierarchical tree of components.
         The `dash_html_components` library provides classes for all of the HTML
         tags and the keyword arguments describe the HTML attributes like `style`,
         `className`, and `id`. The `dash_core_components` library
         generates higher-level components like controls and graphs.
 
-        The second part of the tutorial describes how to make your
+        This chapter describes how to make your
         Dash apps interactive.
 
         Let's get started with a simple example.
@@ -299,14 +257,17 @@ layout = html.Div([
 
     '''.replace('    ', '')),
 
-    dcc.Markdown('''
-    The next chapter explains how to use these principles with the
-    `dash_core_components.Graph` component to make applications that
-    respond to interactions with graphs on the page.
-    '''.replace('    ', '')),
+
+    dcc.Markdown(s('''
+        The next part of the Dash tutorial covers an additional concept of
+        Dash callbacks: `State`
+        interactive.
+    ''')),
 
     dcc.Link(
-        html.A('Part 3 - Interactive Graphing'),
-        href='/interactive-graphing')
+        'Dash Tutorial Part 4: State',
+        href="/state"
+    )
+
 
 ])

--- a/tutorial/graphing.py
+++ b/tutorial/graphing.py
@@ -20,6 +20,12 @@ layout = html.Div([
     dcc.Markdown('''
     # Interactive Visualizations
 
+    > This is the *5th* chapter of the [Dash Tutorial](/).
+    > The [previous chapter](/state) covered callbacks with `State`
+    > and the [next chapter](/sharing-data-between-callbacks) describes how to
+    > share data between callbacks.
+    > Just getting started? Make sure to [install the necessary dependencies](/installation).
+
     The `dash_core_components` library includes a component called `Graph`.
 
     `Graph` renders interactive data visualizations using the open source
@@ -122,11 +128,13 @@ layout = html.Div([
 
     ***
 
-    The final chapter of the Dash tutorial explains one last concept of dash:
-    Callbacks with `dash.dependencies.State`.
-    `State` is useful for UIs that contain forms or buttons.
+    The next chapter of the Dash User Guide explains how to share data between
+    callbacks.
     ''')),
 
-    dcc.Link('Dash Tutorial Part 4. Callbacks With State', href='/state')
+    dcc.Link(
+        'Dash Tutorial Part 6. Sharing Data Between Callbacks',
+        href='/sharing-data-between-callbacks'
+    )
 
 ])

--- a/tutorial/installation.py
+++ b/tutorial/installation.py
@@ -32,8 +32,8 @@ layout = html.Div([
     ), customStyle=styles.code_container),
 
     html.Div([
-        'Ready? Now, get started with the ',
-        dcc.Link('Dash Tutorial - Part 1', href='/getting-started'),
+        'Ready? Now, let\'s ',
+        dcc.Link('make your first Dash app', href='/getting-started'),
         '.'
     ])
 

--- a/tutorial/sharing_state.py
+++ b/tutorial/sharing_state.py
@@ -14,9 +14,16 @@ examples = {
 
 
 layout = html.Div([
-    html.H1('Sharing State Between Callbacks'),
-
     dcc.Markdown(s('''
+    # Sharing State Between Callbacks
+
+    > This is the *6th* and final chapter of the essential [Dash Tutorial](/).
+    > The [previous chapter](/interactive-graphing) covered how to use callbacks
+    > with the `dash_core_components.Graph` component.
+    > The [rest of the Dash documentation](/) covers other topics like multi-page
+    > apps and component libraries.
+    > Just getting started? Make sure to [install the necessary dependencies](/installation).
+
     One of the core Dash principles explained in the
     [Getting Started Guide on Callbacks](/getting-started-part-2)
     is that **Dash Callbacks must never modify variables outside of their
@@ -491,7 +498,6 @@ def update_output_1(value):
         using that session id. In this method, since data is saved on the server,
         instead of transported over the network, it is generally faster than the
         "hidden div" method.
-
 
         This example was originally discussed in a
         [Dash Community Forum thread](https://community.plot.ly/t/capture-window-tab-closing-event/7375/2?u=chriddyp).

--- a/tutorial/state.py
+++ b/tutorial/state.py
@@ -14,6 +14,14 @@ layout = html.Div([
     html.H1('Dash State'),
 
     dcc.Markdown(s('''
+        > This is the *4th* chapter of the [Dash Tutorial](/).
+        > The [previous chapter](/getting-started-part-2) covered Dash Callbacks
+        > and the [next chapter](/interactive-graphing) covers interactive
+        > Just getting started? Make sure to
+        > [install the necessary dependencies](/installation).
+    ''')),
+
+    dcc.Markdown(s('''
         In the previous chapter on
         [basic dash callbacks](/getting-started-part-2),
         our callbacks looked something like:
@@ -46,5 +54,19 @@ layout = html.Div([
         clicked on. It is available in every component in the
         `dash_html_components` library.
 
-    '''))
+    ''')),
+
+    dcc.Markdown('''
+    ***
+
+    The next chapter of the user guide explains how to use callbacks
+    principles with the `dash_core_components.Graph` component
+    to make applications that
+    respond to interactions with graphs on the page.
+    '''.replace('    ', '')),
+
+    dcc.Link(
+        html.A('Dash Tutorial Part 5. Interactive Graphing'),
+        href='/interactive-graphing'),
+
 ])


### PR DESCRIPTION
@cldougl here’s some improvements based off of what we discussed today:
- “Part 1”, “Part 2”, etc is now consistent
- There is a little intro at the top of each page in the tutorials that describe the previous and the next chapters
- A little outro provides a link to the next tutorial