### PR TITLE
Add docs for the ConfirmDialog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==6.7
 configparser==3.5.0
 dash==0.24.1
 dash-auth==1.0.0
-dash-core-components==0.26.0
+dash-core-components==0.27.1
 dash-dangerously-set-inner-html==0.0.1
 dash-html-components==0.11.0
 dash-renderer==0.13.0

--- a/tutorial/chapter_index.py
+++ b/tutorial/chapter_index.py
@@ -341,4 +341,18 @@ chapters = {
         'name': '',
         'description': 'Search the Dash Docs'
     },
+
+    'confirm-examples': {
+        'url': '/dash-core-components/confirm',
+        'content': examples.ConfirmDialog,
+        'name': 'ConfirmDialog Component',
+        'description': 'ConfirmDialog examples, properties, and reference'
+    },
+
+    'confirm-provider-examples': {
+        'url': '/dash-core-components/confirm-provider',
+        'content': examples.ConfirmDialogProvider,
+        'name': 'ConfirmDialogProvider Component',
+        'description': 'ConfirmDialogProvider examples, properties and reference'
+    }
 }

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -25,7 +25,7 @@ examples = {
     'upload-datafile':  tools.load_example('tutorial/examples/core_components/upload-datafile.py'),
     'upload-gallery':  tools.load_example('tutorial/examples/core_components/upload-gallery.py'),
     'confirm': tools.load_example('tutorial/examples/core_components/confirm.py'),
-    'confirm-provider': tools.load_example('tutorial/examples/core_components/confirm_provider.py')
+    'confirm-provider': tools.load_example('tutorial/examples/core_components/confirm_provider.py'),
     'tabs_simple':  tools.load_example('tutorial/examples/core_components/tabs_simple.py'),
     'tabs_callback':  tools.load_example('tutorial/examples/core_components/tabs_callback_graph.py'),
 }

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -1046,7 +1046,7 @@ Tabs = html.Div(children=[
 Upload = html.Div([
     html.H1('Upload Component'),
     dcc.Markdown(s('''
-    The Dash upload component allows your app's veiwers to upload files,
+    The Dash upload component allows your app's viewers to upload files,
     like excel spreadsheets or images, into your application.
     Your Dash app can access the contents of an upload by listening to
     the `contents` property of the `dcc.Upload` component.

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -24,6 +24,8 @@ examples = {
     'upload-image':  tools.load_example('tutorial/examples/core_components/upload-image.py'),
     'upload-datafile':  tools.load_example('tutorial/examples/core_components/upload-datafile.py'),
     'upload-gallery':  tools.load_example('tutorial/examples/core_components/upload-gallery.py'),
+    'confirm': tools.load_example('tutorial/examples/core_components/confirm.py'),
+    'confirm-provider': tools.load_example('tutorial/examples/core_components/confirm_provider.py')
     'tabs_simple':  tools.load_example('tutorial/examples/core_components/tabs_simple.py'),
     'tabs_callback':  tools.load_example('tutorial/examples/core_components/tabs_callback_graph.py'),
 }
@@ -1088,4 +1090,30 @@ Upload = html.Div([
 
     html.H2('Upload Component Properties'),
     generate_prop_table('Upload')
+])
+
+# ConfirmDialog
+ConfirmDialog = html.Div([
+    html.H1('ConfirmDialog component'),
+    dcc.Markdown(s('''
+    ConfirmDialog is used to display the browser's native "confirm" modal,
+    with an optional message and two buttons ("OK" and "Cancel").
+    This ConfirmDialog can be used in conjunction with buttons when the user
+    is performing an action that should require an extra step of verification.
+    ''')),
+    Syntax(examples['confirm'][0]),
+    Example(examples['confirm'][1]),
+    generate_prop_table('ConfirmDialog')
+])
+
+# ConfirmDialogProvider
+ConfirmDialogProvider = html.Div([
+    html.H1('ConfirmDialogProvider component'),
+    dcc.Markdown(s('''
+    Send a [ConfirmDialog](/dash-core-components/confirm) when the user
+    clicks the children of this component, usually a button.
+    ''')),
+    Syntax(examples['confirm-provider'][0]),
+    Example(examples['confirm-provider'][1]),
+    generate_prop_table('ConfirmDialogProvider')
 ])

--- a/tutorial/core_components.py
+++ b/tutorial/core_components.py
@@ -396,5 +396,54 @@ dcc.Graph(
     html.Br(),
     dcc.Markdown('View the [plotly.py docs](https://plot.ly/python).'),
 
+    dcc.Markdown('***'),
+
+    html.H3(dcc.Link('ConfirmDialog', href='/dash-core-components/confirm')),
+
+    dcc.Markdown('''
+The `dcc.ConfirmDialog` component send a dialog to the browser 
+asking the user to confirm or cancel with a custom message.
+    '''),
+
+    ComponentBlock('''
+import dash_core_components as dcc
+
+confirm = dcc.ConfirmDialog(
+    id='confirm',
+    message='Danger danger! Are you sure you want to continue?'
+)
+    '''),
+
+    html.Br(),
+
+    dcc.Link('More ConfirmDialog Examples and Reference',
+             href='/dash-core-components/confirm'),
+
+    html.Br(),
+    dcc.Markdown('***'),
+
+    dcc.Markdown('There is also a `dcc.ConfirmDialogProvider`,'
+                 ' it will automatically wrap a child component '
+                 ' to send a `dcc.ConfirmDialog` when clicked.'),
+
+    ComponentBlock('''
+import dash_core_components as dcc
+import dash_html_components as html
+
+confirm = dcc.ConfirmDialogProvider(
+    children=html.Button(
+        'Click Me',
+    ),
+    id='danger-danger',
+    message='Danger danger! Are you sure you want to continue?'
+)
+    '''),
+    html.Br(),
+
+    dcc.Link('More ConfirmDialogProvider Examples and Reference',
+             href='/dash-core-components/confirm-provider'),
+
+    html.Br(),
+
     html.Div(id='hidden', style={'display': 'none'})
 ])

--- a/tutorial/examples/core_components/confirm.py
+++ b/tutorial/examples/core_components/confirm.py
@@ -1,0 +1,42 @@
+import dash
+from dash.dependencies import Input, Output
+import dash_html_components as html
+import dash_core_components as dcc
+
+app = dash.Dash()
+
+
+app.layout = html.Div([
+    dcc.ConfirmDialog(
+        id='confirm',
+        message='Danger danger! Are you sure you want to continue?',
+    ),
+
+    dcc.Dropdown(
+        options=[
+            {'label': i, 'value': i}
+            for i in ['Safe', 'Danger!!']
+        ],
+        id='dropdown'
+    ),
+    html.Div(id='output-confirm')
+])
+
+
+@app.callback(Output('confirm', 'displayed'),
+              [Input('dropdown', 'value')])
+def display_confirm(value):
+    if value == 'Danger!!':
+        return True
+    return False
+
+
+@app.callback(Output('output-confirm', 'children'),
+              [Input('confirm', 'submit_n_clicks')])
+def update_output(submit_n_clicks):
+    if submit_n_clicks:
+        return 'It wasnt easy but we did it {}'.format(submit_n_clicks)
+
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/tutorial/examples/core_components/confirm_provider.py
+++ b/tutorial/examples/core_components/confirm_provider.py
@@ -1,0 +1,32 @@
+import dash
+from dash.dependencies import Input, Output
+import dash_html_components as html
+import dash_core_components as dcc
+
+app = dash.Dash()
+
+app.layout = html.Div([
+    dcc.ConfirmDialogProvider(
+        children=html.Button(
+            'Click Me',
+        ),
+        id='danger-danger-provider',
+        message='Danger danger! Are you sure you want to continue?'
+    ),
+    html.Div(id='output-provider')
+])
+
+
+@app.callback(Output('output-provider', 'children'),
+              [Input('danger-danger-provider', 'submit_n_clicks')])
+def update_output(submit_n_clicks):
+    if not submit_n_clicks:
+        return ''
+    return """
+        It was dangerous but we did it!
+        Submitted {} times
+    """.format(submit_n_clicks)
+
+
+if __name__ == '__main__':
+    app.run_server(debug=True)


### PR DESCRIPTION
Updated the version of dash-core-components to use `0.25.1`  and added examples and references for the new `dcc.ConfirmDialog` and `dcc.ConfirmDialogProvider`.