### PR TITLE
ssh-add -k should be lower case k

### DIFF
--- a/tutorial/on_premise_deployment.py
+++ b/tutorial/on_premise_deployment.py
@@ -99,7 +99,7 @@ def generate_instructions(chapter, platform):
 
             dcc.SyntaxHighlighter(
                 ('$ ssh-add ~/.ssh/id_rsa' if platform == 'Windows' else
-                 '$ ssh-add -K ~/.ssh/id_rsa'),
+                 '$ ssh-add -k ~/.ssh/id_rsa'),
                 customStyle=styles.code_container,
                 language='python'
             ),


### PR DESCRIPTION
http://man.openbsd.org/ssh-add#k
Upper case K errors out for linux

cc @michaelbabyn @chriddyp 