### PR TITLE
Add external css/js `Dash.__init__` documentation.

### DIFF
--- a/tutorial/chapter_index.py
+++ b/tutorial/chapter_index.py
@@ -157,7 +157,7 @@ chapters = {
     'external': {
         'url': '/external-resources',
         'content': external_css_and_js.layout,
-        'name': 'Adding Local CSS & JS and Overriding the Page-Load Template',
+        'name': 'Adding CSS & JS and Overriding the Page-Load Template',
         'description': '''
             New in dash v0.22.0! Learn how to add custom CSS and JS to your
             application with the `assets` directory. Also, learn how to

--- a/tutorial/examples/external_css_and_js/external-resources-init.py
+++ b/tutorial/examples/external_css_and_js/external-resources-init.py
@@ -1,0 +1,33 @@
+import dash
+import dash_html_components as html
+
+
+external_js = [
+    'https://www.google-analytics.com/analytics.js',
+    {'src': 'https://cdn.polyfill.io/v2/polyfill.min.js'},
+    {
+        'src': 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js',
+        'integrity': 'sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=',
+        'crossorigin': 'anonymous'
+    }
+]
+
+external_css = [
+    'https://codepen.io/chriddyp/pen/bWLwgP.css',
+    {
+        'href': 'https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css',
+        'rel': 'stylesheet',
+        'integrity': 'sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO',
+        'crossorigin': 'anonymous'
+    }
+]
+
+
+app = dash.Dash(__name__,
+                external_scripts=external_js,
+                external_stylesheets=external_css)
+
+app.layout = html.Div()
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/tutorial/external_css_and_js.py
+++ b/tutorial/external_css_and_js.py
@@ -20,7 +20,9 @@ examples = {
     'dash-meta-tags': read_file(
         'tutorial/examples/external_css_and_js/dash-meta-tags.py'
     ),
-
+    'external-resources-init': read_file(
+        'tutorial/examples/external_css_and_js/external-resources-init.py'
+    ),
 }
 
 
@@ -37,6 +39,7 @@ layout = html.Div([
 
     **Table of Contents**
     - Adding Your Own CSS and JavaScript to Dash Apps
+    - Adding external CSS and JavaScript
     - Customizing Dash's HTML Index Template
     - Adding Meta Tags
     - Serving Dash's Component Libraries Locally or from a CDN
@@ -178,6 +181,28 @@ h1, h2, h3, h4, h5, h6 {
 
     ***
 
+    ## Adding external CSS/Javascript
+    
+    You can add resources hosted externally to your Dash app with the 
+    `external_scripts/stylesheets` init keywords.
+    
+    The resources can be either a string or a dict containing the tag attributes
+    (`src`, `integrity`, `crossorigin`, etc). You can mix both.
+
+    External css/js files are loaded before the assets.
+
+    **Example:**
+    ''')),
+
+    dcc.SyntaxHighlighter(
+        examples['external-resources-init'],
+        language='python',
+        customStyle=styles.code_container
+    ),
+
+    dcc.Markdown(s('''
+    ***
+    
     ## Customizing Dash's HTML Index Template
 
     **New in dash 0.22.0**

--- a/tutorial/external_css_and_js.py
+++ b/tutorial/external_css_and_js.py
@@ -27,7 +27,7 @@ examples = {
 
 
 layout = html.Div([
-    html.H1('Adding Local CSS & JS and Overriding the Page-Load Template'),
+    html.H1('Adding CSS & JS and Overriding the Page-Load Template'),
 
     dcc.Markdown(s('''
     Dash applications are rendered in the web browser with CSS and JavaScript.
@@ -39,7 +39,7 @@ layout = html.Div([
 
     **Table of Contents**
     - Adding Your Own CSS and JavaScript to Dash Apps
-    - Adding external CSS and JavaScript
+    - Adding External CSS and JavaScript
     - Customizing Dash's HTML Index Template
     - Adding Meta Tags
     - Serving Dash's Component Libraries Locally or from a CDN


### PR DESCRIPTION
Add documentation for using the `external_scripts` and `external_stylesheets` keywords from plotly/dash#305.