### PR TITLE
add '--no-cache' flag to pip install.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
               sudo pip install virtualenv --upgrade
               python -m venv venv || virtualenv venv
               . venv/bin/activate
-              pip install -r requirements.txt
+              pip install -r requirements.txt --no-cache
 
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "circlejob.txt" }}


### PR DESCRIPTION
Without this you need to wait a few minutes after updating packages to run CI.