### PR TITLE
Only one percy build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,15 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.6-stretch-browsers
+    environment:
+      PERCY_ENABLE: 0
 
   "python-3.7":
     <<: *test-template
     docker:
       - image: circleci/python:3.7-stretch-browsers
+    environment:
+      PERCY_ENABLE: 0
 
 
 workflows:


### PR DESCRIPTION
Only run percy in python 2.7, plotly/dash#370.