### PR TITLE
Edits to markdown copy in tutorial chapters

### DIFF
--- a/tutorial/gallery.py
+++ b/tutorial/gallery.py
@@ -92,7 +92,7 @@ layout = html.Div(className='gallery', children=[
         with a `Graph` and filters data using a Pandas `DataFrame`.
         The `animate` property in the `Graph` component was set to `True`
         so that the points transition smoothly.
-        Some interactivity is built-in to the `Graph` component including
+        Some interactivity is built into the `Graph` component, including
         hovering over values, clicking on legend items to toggle traces, and
         zooming into regions.
     
@@ -110,7 +110,7 @@ layout = html.Div(className='gallery', children=[
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/stock-tickers.png',
             description='''
             This app queries data from Google Finance and displays the results as candlestick
-            charts. Dash comes with several financial chart types including candlestick
+            charts. Dash comes with several financial chart types including: candlestick
             charts, OHLC graphs, time series, and range sliders.
         
             This app was written in just around 100 lines of code.
@@ -135,7 +135,7 @@ layout = html.Div(className='gallery', children=[
         
             With PDF styles, you can hide and show elements depending on whether
             the app is being viewed in the web browser or in print, using the
-            same framework for the rich interactive applications as the static
+            same framework for both the rich interactive applications and the static
             PDF reports.
             '''
 
@@ -144,17 +144,17 @@ layout = html.Div(className='gallery', children=[
 
     reusable.Row([
         AppSection(
-            app_name='3D Yield Curve',
+            app_name='3-D Yield Curve',
             app_link='https://dash-yield-curve.plot.ly',
             code_link='https://github.com/plotly/dash-yield-curve',
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/dash-yield-curve-app.png',
             description='''
-            This Dash app adapts the excellent NY Times
-            report [A 3-D View of a Chart That Predicts The Economic Future: The Yield Curve](https://www.nytimes.com/interactive/2015/03/19/upshot/3d-yield-curve-economic-growth.html).
+            This Dash app adapts the New York Times' excellent
+            report: [A 3-D View of a Chart That Predicts The Economic Future: The Yield Curve](https://www.nytimes.com/interactive/2015/03/19/upshot/3d-yield-curve-economic-growth.html).
 
-            Dash comes with a wide range of interactive 3D chart types,
-            such as 3D scatter plots, surface plots, network graphs and ribbon plots.
-            [View more 3D chart examples](https://plot.ly/python/3d-charts/).
+            Dash comes with a wide range of interactive 3-D chart types,
+            such as 3-D scatter plots, surface plots, network graphs and ribbon plots.
+            [View more 3-D chart examples](https://plot.ly/python/3d-charts/).
             '''
         ),
 
@@ -166,7 +166,7 @@ layout = html.Div(className='gallery', children=[
             description='''
             485 lines of Python code, including text copy.
         
-            This Dash app was adapted from NYTimes's excellent
+            This Dash app was adapted from The New York Times' excellent report: 
             [How the Recession Reshaped the Economy in 255 Charts](https://www.nytimes.com/interactive/2014/06/05/upshot/how-the-recession-reshaped-the-economy-in-255-charts.html).
         
             This Dash app displays its content linearly, like an
@@ -182,7 +182,7 @@ layout = html.Div(className='gallery', children=[
         
             The text in the application is centered and its width is restricted
             to improve the reading experience. The graphs are full bleed:
-            the extend past the narrow column of text the edges of page.
+            they extend past the narrow column of text to the edges of the page.
             '''
         )
     ]),
@@ -226,7 +226,7 @@ layout = html.Div(className='gallery', children=[
     ]),
 
     # LIFE SCIENCES SECTION
-    SectionTitle('Life sciences'),
+    SectionTitle('Life Sciences'),
 
     reusable.Row([
         AppSection(
@@ -252,7 +252,7 @@ layout = html.Div(className='gallery', children=[
             code_link='https://github.com/plotly/dash-brain-surface-viewer',
             img_src='https://raw.githubusercontent.com/plotly/dash-brain-surface-viewer/master/ZOMBIE_BRAIN.png',
             description='''
-            🐭 Explore human and mice brains in 3d.
+            🐭 Explore human and mice brains in 3-D.
             
             Add interactive labels to points on the brain surface and change the surface colorscale.
             '''
@@ -261,13 +261,13 @@ layout = html.Div(className='gallery', children=[
 
     reusable.Row([
         AppSection(
-            app_name='Phylogeny trees and global spread of 6 viruses',
+            app_name='Phylogeny trees and global spread of six viruses',
             app_link='https://dash-phylogeny.herokuapp.com/',
             code_link='https://github.com/plotly/dash-phylogeny',
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/dash-phylo-tree.gif',
             description='''
-            Interactively explore the propagation of 6 viruses, by time and/or by geolocalisation. 
-            In the online app, you can select a virus, and the evolution of the virus as a phylogeny tree will display with a map and time series of the virus's global spread.
+            Interactively explore the propagation of six viruses, by time and/or by location. 
+            In the online app, you can select a virus to display its evolution as a phylogeny tree, along with a map and time series of the virus's global spread.
         ''',
             width=12
         )
@@ -300,7 +300,7 @@ layout = html.Div(className='gallery', children=[
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/dash-object-detection.gif',
             description='''
             This object-detection app provides useful visualizations about 
-            what's happening inside a complex video in real-time. The data 
+            what's happening inside a complex video in real time. The data 
             is generated using 
             [MobileNet v1](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md) 
             in Tensorflow, trained on the COCO dataset. The video is 
@@ -315,11 +315,9 @@ layout = html.Div(className='gallery', children=[
             code_link='https://github.com/plotly/dash-live-model-training',
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/dash-live-model-training.gif',
             description='''
-            For every Deep Learning models, keeping track of accuracy 
-            and loss is an essential part of the training process, 
-            since they indicate how good your models are. This app is 
-            a real-time visualization app that monitors core metrics 
-            of your Tensorflow graphs during the training, so that you 
+            Tracking accuracy and loss is an essential part of the training process 
+            for deep learning models. This real-time visualization app monitors 
+            core metrics of your Tensorflow graphs during the training so that you 
             can quickly detect anomalies within your model.
             '''
         ),
@@ -365,8 +363,8 @@ layout = html.Div(className='gallery', children=[
             code_link='https://github.com/plotly/dash-svm',
             img_src='https://raw.githubusercontent.com/plotly/dash-docs/master/images/dash-svm.gif',
             description='''
-            This app lets you explore Support Vector Clustering (a type 
-            of Support Vector Machine) with UI input parameters. Toy datasets 
+            This app lets you explore support vector clustering (a type 
+            of support vector machine) with UI input parameters. Toy datasets 
             and useful ML metrics plots are included. It is fully written in 
             Dash + scikit-learn.
             ''',
@@ -395,7 +393,7 @@ layout = html.Div(className='gallery', children=[
 
     reusable.Row([
         AppSection(
-            app_name='Window Speed Measurement',
+            app_name='Wind Speed Measurement',
             app_link='https://dash-live-wind-data.plot.ly',
             code_link='https://github.com/plotly/dash-wind-streaming',
             img_src='https://raw.githubusercontent.com/plotly/dash-wind-streaming/d84b15eebf2c502372740416d445e8e3f23d0619/Gif/dash-wind-streaming.gif',
@@ -450,8 +448,8 @@ layout = html.Div(className='gallery', children=[
         The Dash community has built many of their component libraries, like 
         [Video Components](https://community.plot.ly/t/modifying-a-dom-property-in-html-video/7649/11) 
         and [Large File Upload](https://community.plot.ly/t/show-and-tell-dash-resumable-upload/9519). 
-        View more community maintained components and other projects in the Dash Community Forum’s 
-        [Show and Tell Thread](https://community.plot.ly/t/show-and-tell-community-thread/7554)
+        View more community-maintained components and other projects in the Dash Community Forum’s 
+        [Show and Tell Thread](https://community.plot.ly/t/show-and-tell-community-thread/7554).
         '''
         )
     ]),
@@ -691,7 +689,7 @@ layout = html.Div(className='gallery', children=[
 
     reusable.Row([
         dcc.Markdown(dedent('''
-        These Dash docs that you're looking at? They are itself a Dash app!
+        These Dash docs that you're looking at? They themselves are a Dash app!
         ''')),
 
         AppSection(

--- a/tutorial/getting_started_part_2.py
+++ b/tutorial/getting_started_part_2.py
@@ -37,7 +37,7 @@ layout = html.Div([
         that the `app.layout` describes what the app looks like and is
         a hierarchical tree of components.
         The `dash_html_components` library provides classes for all of the HTML
-        tags and the keyword arguments describe the HTML attributes like `style`,
+        tags, and the keyword arguments describe the HTML attributes like `style`,
         `className`, and `id`. The `dash_core_components` library
         generates higher-level components like controls and graphs.
 
@@ -152,12 +152,12 @@ layout = html.Div([
 
     #### Multiple inputs
 
-    In Dash any "`Output`" can have multiple "`Input`" components.
-    Here's a simple example that binds 5 Inputs
+    In Dash, any "`Output`" can have multiple "`Input`" components.
+    Here's a simple example that binds five Inputs
     (the `value` property of 2 `Dropdown` components, 2 `RadioItems` components,
     and 1 `Slider` component) to 1 Output component
     (the `figure` property of the `Graph` component).
-    Notice how the `app.callback` lists all 5 `dash.dependencies.Input` inside
+    Notice how the `app.callback` lists all five `dash.dependencies.Input` inside
     a list in the second argument.
 
     '''.replace('    ', '')),
@@ -180,7 +180,7 @@ layout = html.Div([
     change.
 
     The input arguments of the `update_graph` function are the new or current
-    value of the each of the `Input` properties, in the order that they were
+    value of each of the `Input` properties, in the order that they were
     specified.
 
     Even though only a single `Input` changes at a time (a user can only change

--- a/tutorial/graphing.py
+++ b/tutorial/graphing.py
@@ -40,9 +40,9 @@ layout = html.Div([
     to learn more.
 
     Dash components are described declaratively by a set of attributes.
-    All of these attributes can be updated by callback functions but only
-    a subset of these attributes are updated through user interaction.
-    For example, when you click on an option in a `dcc.Dropdown` component, the
+    All of these attributes can be updated by callback functions, but only
+    a subset of these attributes are updated through user interaction, such as  
+    when you click on an option in a `dcc.Dropdown` component and the
     `value` property of that component changes.
 
     The `dcc.Graph` component has four attributes that can change
@@ -83,7 +83,7 @@ layout = html.Div([
 
     Syntax(examples['crossfilter-recipe'][0], summary="""
     Here's a slightly more generic example for crossfiltering across
-    a six column data set. Each scatter plot's selection filters the
+    a six-column data set. Each scatter plot's selection filters the
     underlying dataset.
     """),
 
@@ -114,7 +114,7 @@ layout = html.Div([
 
     There are a few limitations in graph interactions right now.
     - Clicking points does not accumulate: you cannot accumulate the number
-      of points that you have clicked on nor is there the concept of
+      of points that you have clicked on, nor is there the concept of
       "unselecting" a point. This issue is being worked on in [https://github.com/plotly/plotly.js/issues/1848](https://github.com/plotly/plotly.js/issues/1848).
     - It is not currently possible to customize the style of the hover
       interactions or the select box.

--- a/tutorial/html_components.py
+++ b/tutorial/html_components.py
@@ -34,7 +34,7 @@ html.Div([
         'following HTML in your web-app:'
     ),
     dcc.SyntaxHighlighter('''<div>
-    <h1>Hello</h1>
+    <h1>Hello Dash</h1>
     <div>
         <p>Dash converts Python classes into HTML</p>
         <p>This conversion happens behind the scenes by Dash's JavaScript front-end</p>
@@ -77,7 +77,7 @@ html.Div([
                  containerProps={'className': 'example-container'}),
 
     dcc.Markdown('''
-        If you're using HTML components, then you also access to
+        If you're using HTML components, then you also have access to
         properties like `style`, `class`, and `id`.
         All of these attributes are available in the Python classes.
 

--- a/tutorial/introduction.py
+++ b/tutorial/introduction.py
@@ -24,7 +24,7 @@ layout = html.Div([
         cross-platform and mobile ready.
 
         There is a lot behind the framework. To learn more about how it is built
-        and what motivated dash, watch our talk from
+        and what motivated Dash, watch our talk from
         [Plotcon](https://plotcon.plot.ly) below
         or read our [announcement letter](https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503).
 

--- a/tutorial/sharing_state.py
+++ b/tutorial/sharing_state.py
@@ -127,17 +127,17 @@ def update_output_1(value):
     return len(filtered_df)
 ''', summary='''
     To fix this example, simply re-assign the filter to a new
-    variable inside the callback or follow one of the strategies
+    variable inside the callback, or follow one of the strategies
     outlined in the next part of this guide.'''),
 
     dcc.Markdown(s('''
         ## Sharing Data Between Callbacks
 
-        In order for to share data safely across multiple python
+        In order to share data safely across multiple python
         processes, we need to store the data somewhere that is accessible to
         each of the processes.
 
-        There are 3 main places to store this data:
+        There are three main places to store this data:
 
         1 - In the user's browser session
 
@@ -161,7 +161,7 @@ def update_output_1(value):
             callbacks within the session.
           - As such, unlike with caching, this method doesn't increase the
             memory footprint of the app.
-          - There could be a cost in network transport. If your sharing 10MB
+          - There could be a cost in network transport. If you're sharing 10MB
             of data between callbacks, then that data will be transported over
             the network between each callback.
            - If the network cost is too high, then compute the aggregations
@@ -174,7 +174,7 @@ def update_output_1(value):
         summary=('''
         This example outlines how you can perform an expensive data processing
         step in one callback, serialize the output at JSON, and provide it
-        as an input to the other callbacks. This example uses standard dash
+        as an input to the other callbacks. This example uses standard Dash
         callbacks and stores the JSON-ified data inside a hidden div in
         the app.
     '''), children=s('''
@@ -288,10 +288,10 @@ def update_output_1(value):
 
         This example:
         - Uses Redis via Flask-Cache for storing “global variables”.
-          This data is accessed through a function who’s output is
+          This data is accessed through a function, the output of which is
           cached and keyed by its input arguments.
         - Uses the hidden div solution to send a signal to the other
-          callbacks when the expensive computation is complete
+          callbacks when the expensive computation is complete.
         - Note that instead of Redis, you could also save this to the file
           system. See https://flask-caching.readthedocs.io/en/latest/
           for more details.
@@ -299,25 +299,25 @@ def update_output_1(value):
           computation to only take up one process.
           Without this type of signaling, each callback could end up
           computing the expensive computation in parallel,
-          locking 4 processes instead of 1.
+          locking four processes instead of one.
 
-        This approach also has the advantage that future sessions
+        This approach is also advantageous in that future sessions can 
         use the pre-computed value.
         This will work well for apps that have a small number of inputs.
 
         Here’s what this example looks like. Some things to note:
 
         - I’ve simulated an expensive process by using a time.sleep(5).
-        - When the app loads, it takes 5 seconds to render all 4 graphs
-        - The initial computation only blocks 1 process
-        - Once the computation is complete, the signal is sent and 4 callbacks
+        - When the app loads, it takes five seconds to render all four graphs.
+        - The initial computation only blocks one process.
+        - Once the computation is complete, the signal is sent and four callbacks
           are executed in parallel to render the graphs.
           Each of these callbacks retrieves the data from the
-          “global store”: the redis or filesystem cache.
+          “global store”: the Redis or filesystem cache.
         - I’ve set processes=6 in app.run_server so that multiple callbacks
           can be executed in parallel. In production, this is done with
           something like $ gunicorn --workers 6 --threads 2 app:server
-        - Selecting a value in the dropdown will take less than 5 seconds
+        - Selecting a value in the dropdown will take less than five seconds
           if it has already been selected in the past.
           This is because the value is being pulled from the cache.
         - Similarly, reloading the page or opening the app in a new window
@@ -333,7 +333,7 @@ def update_output_1(value):
         className="gallery"
     ),
 
-    Syntax(summary="Here's what this example looks like in code",
+    Syntax(summary="Here's what this example looks like in code:",
            children=s('''
         import os
         import copy
@@ -494,16 +494,16 @@ def update_output_1(value):
         as demonstrated in the first example.
 
         Another way to do this is to save the data on the
-        filesystem cache with with a seession id and reference the data
-        using that session id. In this method, since data is saved on the server,
-        instead of transported over the network, it is generally faster than the
+        filesystem cache with a session ID and then reference the data
+        using that session ID. Because data is saved on the server
+        instead of transported over the network, this method is generally faster than the
         "hidden div" method.
 
         This example was originally discussed in a
         [Dash Community Forum thread](https://community.plot.ly/t/capture-window-tab-closing-event/7375/2?u=chriddyp).
 
         This example:
-        - Caches data using the `flask_caching` filesystem cache. You can also save to an in-memory database like Redis..
+        - Caches data using the `flask_caching` filesystem cache. You can also save to an in-memory database like Redis.
         - Serializes the data as JSON.
             - If you are using Pandas, consider serializing
             with Apache Arrow. [Community thread](https://community.plot.ly/t/fast-way-to-share-data-between-callbacks/8024/2)
@@ -522,7 +522,7 @@ def update_output_1(value):
 
     Syntax(
         examples['filesystem-session-cache'][0],
-        summary="Here's what this example looks like in code"
+        summary="Here's what this example looks like in code:"
     ),
 
     html.Div(
@@ -536,13 +536,13 @@ def update_output_1(value):
         There are three things to notice in this example:
         - The timestamps of the dataframe don't update when we retrieve
         the data. This data is cached as part of the user's session.
-        - Retrieving the data initially takes 5 seconds but successive queries
+        - Retrieving the data initially takes five seconds but successive queries
         are instant, as the data has been cached.
         - The second session displays different data than the first session:
         the data that is shared between callbacks is isolated to individual
         user sessions.
 
         Questions? Discuss these examples on the
-        [Dash Community Forum](https://community.plot.ly/c/dash)
+        [Dash Community Forum](https://community.plot.ly/c/dash).
     '''))
 ])

--- a/tutorial/state.py
+++ b/tutorial/state.py
@@ -16,14 +16,15 @@ layout = html.Div([
     dcc.Markdown(s('''
         > This is the *4th* chapter of the [Dash Tutorial](/).
         > The [previous chapter](/getting-started-part-2) covered Dash Callbacks
-        > and the [next chapter](/interactive-graphing) covers interactive
+        > and the [next chapter](/interactive-graphing) covers interactive 
+        > graphing and crossfiltering.
         > Just getting started? Make sure to
         > [install the necessary dependencies](/installation).
     ''')),
 
     dcc.Markdown(s('''
         In the previous chapter on
-        [basic dash callbacks](/getting-started-part-2),
+        [basic Dash callbacks](/getting-started-part-2),
         our callbacks looked something like:
     ''')),
     Syntax(examples['basic-input'][0]),
@@ -59,7 +60,7 @@ layout = html.Div([
     dcc.Markdown('''
     ***
 
-    The next chapter of the user guide explains how to use callbacks
+    The next chapter of the user guide explains how to use callback
     principles with the `dash_core_components.Graph` component
     to make applications that
     respond to interactions with graphs on the page.


### PR DESCRIPTION
Additional observations:

**graphing.py:** The "world indicators" example graph (around line 72) invites user to mouse over scatter plot points, but none are visible.

**sharing_state.py:** Line 104, markdown italics formatting isn't displaying in the docs.