### PR TITLE
Corrected Running an app locally instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ source activate dash_docs
 ```
 
 2. `pip install -r requirements.txt`
-3. `gunicorn tutorial.run:server`
+3. `gunicorn run:server`
 4. open http://127.0.0.1:8000 in your browser
 
 
 on Windows systems `waitress` can be a replacement for `gunicorn`
 3. `pip install waitress`
-4. `waitress-serve --listen=*:8000 tutorial.run:server`
+4. `waitress-serve --listen=*:8000 run:server`
 5. open http://127.0.0.1:8000 in your browser
 
 


### PR DESCRIPTION
For some reason, the `run.py` file is not located inside the `tutorial` folder, so the command to run the app doesn't work if you follow the instructions.