### PR TITLE
Bump dcc to 0.34.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==6.7
 configparser==3.5.0
 dash==0.28.2
 dash-auth==1.2.0
-dash-core-components==0.33.1
+dash-core-components==0.34.0
 dash-dangerously-set-inner-html==0.0.1
 dash-html-components==0.13.2
 dash-renderer==0.14.3


### PR DESCRIPTION
This updates dash-core-components to it's latest version, containing updates for the Tabs component.