### PR TITLE
Add scale worker note

### DIFF
--- a/tutorial/dash_deployment_server_examples.py
+++ b/tutorial/dash_deployment_server_examples.py
@@ -398,6 +398,22 @@ if __name__ == '__main__':
 
                     dcc.Markdown(s(
                     '''
+                    For some applications, you may require using the `worker` 
+                    process. For example, the [Dash Redis Demo](https://github.com/plotly/dash-redis-demo) 
+                    includes Celery - an asynchronous task queue/job queue. 
+                    When using a `worker` process in your `Procfile`, 
+                    you will have to explicitly start it after deploying. To 
+                    scale a `worker` process: 
+
+                    `ssh dokku@dash-server ps:scale APP-NAME worker=1`. 
+                    
+                    Note that this requires 
+                    [Authenticating to Dash Deployment Server with SSH](/dash-deployment-server/ssh).
+
+                    ''')),
+
+                    dcc.Markdown(s(
+                    '''
                     ***
 
                     **`requirements.txt`**


### PR DESCRIPTION
addresses https://github.com/plotly/streambed/issues/11411

- adds scaling `worker` content to `/dash-deployment-server/deployment`

@cldougl I'm not entirely convinced this is the best place for this. Open to suggestions if you think it is better in say Application Structure, Troubleshooting. etc.. 

