### PR TITLE
Add documentation for multiple file project structure

### DIFF
--- a/tutorial/chapter_index.py
+++ b/tutorial/chapter_index.py
@@ -17,6 +17,7 @@ from tutorial import introduction
 from tutorial import live_updates
 from tutorial import performance
 from tutorial import plugins
+from tutorial import project_structure
 from tutorial import search
 from tutorial import sharing_state
 from tutorial import state
@@ -195,6 +196,16 @@ chapters = {
                        '`dcc.Location`) that allow you to easily make ' \
                        'fast multipage apps using its own "Single Page ' \
                        'App (SPA)" design pattern.'
+    },
+
+    'project-structure': {
+        'url': '/project-structure',
+        'content': project_structure.layout,
+        'name': 'Structuring Dash apps for maintainability',
+        'description': 'As your Dash apps grow ' \
+                       'it becomes useful to separate the code into multiple files. ' \
+                       'This improves maintainability, ' \
+                       'by separating project code along conceptual and functional boundaries.'
     },
 
     'auth': {

--- a/tutorial/home.py
+++ b/tutorial/home.py
@@ -121,7 +121,10 @@ layout = html.Div(className='toc', children=[
                 chapters['external']['description']),
         Chapter(chapters['urls']['name'],
                 chapters['urls']['url'],
-                chapters['urls']['description'])
+                chapters['urls']['description']),
+        Chapter(chapters['project-structure']['name'],
+                chapters['project-structure']['url'],
+                chapters['project-structure']['description']),
     ]),
 
     Section('Production', [

--- a/tutorial/multiple_file_project_structure.py
+++ b/tutorial/multiple_file_project_structure.py
@@ -1,0 +1,1 @@
+# Placeholder

--- a/tutorial/multiple_file_project_structure.py
+++ b/tutorial/multiple_file_project_structure.py
@@ -1,1 +1,0 @@
-# Placeholder

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -42,8 +42,9 @@ if __name__ == '__main__':
 
     dcc.Markdown("""
 ## Server
-`server.py` is where we actually define the Dash app instance, and possibly grab a reference to the Flask 
-server instance:"""),
+`server.py` is where we actually define the Dash app instance and attach the app layout. 
+
+    """),
 
     dcc.SyntaxHighlighter("""
 # Required import

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -96,7 +96,7 @@ from server import app
 # Create one or more callbacks
 @app.callback(Output(...),
                [Input(...)])
-def do something(n_intervals):
+def do something(input_argument):
     pass
 )
 """, customStyle=styles.code_container),

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -12,6 +12,7 @@ our code, namely:
 - data - functions for fetching and preparing data
 - layouts - structure of the app
 - callbacks - the reactive event handler functions
+- routes - optional routing logic for multi-page Dash apps
 - utils - other functions, which may be shared between callbacks
 
 This chapter will briefly describe how to separate out your app code into multiple files, for improved maintainability.

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -17,6 +17,50 @@ our code, namely:
 
 This chapter will briefly describe how to separate out your app code into multiple files, for improved maintainability.
 
+## Main entrypoint
+Each Dash app needs a main entrypoint, which is basically the file you run with `python app.py` in a monolithic Dash app.
+
+In our case, we will fall back to a long-standing convention in web development, and call our entry point `index.py`.
+The `index.py` file will be fairly minimal, containing only logic to run the app, e.g.
+
+```py
+# Import the app and server instances
+from server import app, server
+
+# Optionally set the app title
+app.title = 'My Dash app'
+
+# Optionally override the app basic HTML structure
+app.index_string = '''
+<!DOCTYPE html>
+<html>
+    <head>
+        {%metas%}
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta
+            name="description"
+            content="My Dash app is great!"
+        >
+        <title>{%title%}</title>
+        {%favicon%}
+        {%css%}
+    </head>
+    <body>
+        {%app_entry%}
+        <footer>
+            {%config%}
+            {%scripts%}
+        </footer>
+    </body>
+</html>
+'''
+
+# Run the app if this file is called directly
+if __name__ == '__main__':
+    app.run_server(debug=True, threaded=True, port=8050)
+
+```
+
 ## Related resources
 This chapter is informed and inspired by the following resource(s) and discussion(s):
 

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -1,5 +1,7 @@
 import dash_core_components as dcc
 
+from tutorial import styles
+
 layout = [
     dcc.Markdown(
 """
@@ -26,8 +28,9 @@ Each Dash app needs a main entrypoint, which is basically the file you run with 
 
 In our case, we will fall back to a long-standing convention in web development, and call our entry point `index.py`.
 The `index.py` file will be fairly minimal, containing only logic to run the app, e.g.
+"""),
 
-```py
+    dcc.SyntaxHighlighter("""
 # Import the app and server instances
 from server import app, server
 
@@ -63,13 +66,15 @@ app.index_string = '''
 if __name__ == '__main__':
     app.run_server(debug=True, threaded=True, port=8050)
 
-```
+""", customStyle=styles.code_container),
+
+    dcc.Markdown("""
 
 ## Server
 `server.py` is where we actually define the Dash app instance, and possibly grab a reference to the Flask 
-server instance:
+server instance:"""),
 
-```py
+    dcc.SyntaxHighlighter("""
 # Required import
 from dash import Dash
 
@@ -105,24 +110,28 @@ server = app.server
 app.css.config.serve_locally = True
 app.scripts.config.serve_locally = True
 
-# This is necessary to prevent warnings as callbacks will be defined in separate file
+# This is necessary to prevent warnings 
+# as callbacks will be defined in separate file
 app.config.suppress_callback_exceptions = True
 
 # Optionally add server routes, e.g.
 @server.route('/favicon.ico')
 def favicon():
-    """Serve the favicon"""
+    '''Serve the favicon'''
     return send_from_directory(
         app._assets_folder,
         'favicon.ico',
         mimetype='image/x-icon')
-```
+    """, customStyle=styles.code_container),
 
+
+    dcc.Markdown("""
 ## Layouts
 Layouts are structural in nature, defining the tree of components to render on the page. For our project structure,
 we will define layouts in `layouts.py`.
+    """),
 
-```py
+    dcc.SyntaxHighlighter("""
 # Import Dash Core Components and HTML as needed
 import dash_core_components as dcc
 import dash_html_components as html
@@ -133,8 +142,9 @@ main_layout = html.Div(
         # Additional HTML or DCC children
     ]
 )
-```
+""", customStyle=styles.code_container),
 
+    dcc.Markdown("""
 ## Related resources
 This chapter is informed and inspired by the following resource(s) and discussion(s):
 

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -70,7 +70,7 @@ server instance:
 from dash import Dash
 
 # Useful import
-from flask import Flask
+from flask import Flask, send_from_directory
 
 
 # external JavaScript files
@@ -97,6 +97,15 @@ app.scripts.config.serve_locally = True
 
 # This is necessary to prevent warnings as callbacks will be defined in separate file
 app.config.suppress_callback_exceptions = True
+
+# Optionally add server routes, e.g.
+@server.route('/favicon.ico')
+def favicon():
+    """Serve the favicon"""
+    return send_from_directory(
+        app._assets_folder,
+        'favicon.ico',
+        mimetype='image/x-icon')
 ```
 
 ## Related resources

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -84,6 +84,26 @@ main_layout = html.Div(
 )
 """, customStyle=styles.code_container),
 
+dcc.Markdown("""
+## Callbacks
+Callbacks are functional, responding to user input or other events. We will define callbacks in `callbacks.py`.
+    """),
+
+    dcc.SyntaxHighlighter("""
+# Import Dash Input and Output
+from dash.dependencies import Input, Output
+
+# Import app instance
+from server import app
+
+# Create one or more callbacks
+@app.callback(Output(...),
+               [Input(...)])
+def do something(n_intervals):
+    pass
+)
+""", customStyle=styles.code_container),
+
     dcc.Markdown("""
 ## Related resources
 This chapter is informed and inspired by the following resource(s) and discussion(s):

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -76,6 +76,9 @@ from dash import Dash
 # Useful import
 from flask import Flask, send_from_directory
 
+# Import main layout (e.g. placeholder elements)
+from .layouts import main_layout
+
 
 # external JavaScript files
 external_scripts = [ ... ]
@@ -90,6 +93,9 @@ app = Dash(
     external_scripts=external_scripts,
     external_stylesheets=external_stylesheets,
 )
+
+# Attach the main layout
+app.layout = main_layout
 
 # Get a reference to Flask server
 # Optional, but may be useful for routing, authentication, etc.
@@ -110,6 +116,23 @@ def favicon():
         app._assets_folder,
         'favicon.ico',
         mimetype='image/x-icon')
+```
+
+## Layouts
+Layouts are structural in nature, defining the tree of components to render on the page. For our project structure,
+we will define layouts in `layouts.py`.
+
+```py
+# Import Dash Core Components and HTML as needed
+import dash_core_components as dcc
+import dash_html_components as html
+
+# Define a main layout
+main_layout = html.Div(
+    children=[
+        # Additional HTML or DCC children
+    ]
+)
 ```
 
 ## Related resources

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -16,6 +16,12 @@ our code, namely:
 - utils - other functions, which may be shared between callbacks
 
 This chapter will briefly describe how to separate out your app code into multiple files, for improved maintainability.
+
+## Related resources
+This chapter is informed and inspired by the following resource(s) and discussion(s):
+
+- [Splitting callback definitions in multiple files](https://community.plot.ly/t/splitting-callback-definitions-in-multiple-files/10583/2)
+- [Slapdash](https://github.com/ned2/slapdash) - boilerplate for bootstrapping scalable multi-page Dash applications
 """
     ),
 ]

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -3,7 +3,18 @@ import dash_core_components as dcc
 layout = [
     dcc.Markdown(
 """
-Hello world.
+# Project structure
+As your Dash app grows, keeping everything in a single app.py quickly becomes a hassle. At some point, it is natural to
+break things out into separate files. In a typical Dash app, there are a few 'natural' boundaries along which to divide 
+our code, namely:
+
+- app - the Dash app initialization
+- data - functions for fetching and preparing data
+- layouts - structure of the app
+- callbacks - the reactive event handler functions
+- utils - other functions, which may be shared between callbacks
+
+This chapter will briefly describe how to separate out your app code into multiple files, for improved maintainability.
 """
     ),
 ]

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -61,6 +61,44 @@ if __name__ == '__main__':
 
 ```
 
+## Server
+`server.py` is where we actually define the Dash app instance, and possibly grab a reference to the Flask 
+server instance:
+
+```py
+# Required import
+from dash import Dash
+
+# Useful import
+from flask import Flask
+
+
+# external JavaScript files
+external_scripts = [ ... ]
+
+# external CSS stylesheets
+external_stylesheets = [ ... ]
+
+# Create Dash instance
+# optionally attach external scripts and stylesheets
+app = Dash(
+    __name__,
+    external_scripts=external_scripts,
+    external_stylesheets=external_stylesheets,
+)
+
+# Get a reference to Flask server
+# Optional, but may be useful for routing, authentication, etc.
+server = app.server
+
+# Optional settings for local development/debugging
+app.css.config.serve_locally = True
+app.scripts.config.serve_locally = True
+
+# This is necessary to prevent warnings as callbacks will be defined in separate file
+app.config.suppress_callback_exceptions = True
+```
+
 ## Related resources
 This chapter is informed and inspired by the following resource(s) and discussion(s):
 

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -1,0 +1,9 @@
+import dash_core_components as dcc
+
+layout = [
+    dcc.Markdown(
+"""
+Hello world.
+"""
+    ),
+]

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -58,10 +58,6 @@ app = Dash()
 
 # Attach the main layout
 app.layout = main_layout
-
-# This is necessary to prevent warnings 
-# as callbacks will be defined in separate file
-app.config.suppress_callback_exceptions = True
     """, customStyle=styles.code_container),
 
 

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -32,35 +32,7 @@ The `index.py` file will be fairly minimal, containing only logic to run the app
 
     dcc.SyntaxHighlighter("""
 # Import the app and server instances
-from server import app, server
-
-# Optionally set the app title
-app.title = 'My Dash app'
-
-# Optionally override the app basic HTML structure
-app.index_string = '''
-<!DOCTYPE html>
-<html>
-    <head>
-        {%metas%}
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta
-            name="description"
-            content="My Dash app is great!"
-        >
-        <title>{%title%}</title>
-        {%favicon%}
-        {%css%}
-    </head>
-    <body>
-        {%app_entry%}
-        <footer>
-            {%config%}
-            {%scripts%}
-        </footer>
-    </body>
-</html>
-'''
+from server import app
 
 # Run the app if this file is called directly
 if __name__ == '__main__':
@@ -69,7 +41,6 @@ if __name__ == '__main__':
 """, customStyle=styles.code_container),
 
     dcc.Markdown("""
-
 ## Server
 `server.py` is where we actually define the Dash app instance, and possibly grab a reference to the Flask 
 server instance:"""),
@@ -78,50 +49,19 @@ server instance:"""),
 # Required import
 from dash import Dash
 
-# Useful import
-from flask import Flask, send_from_directory
-
 # Import main layout (e.g. placeholder elements)
-from .layouts import main_layout
-
-
-# external JavaScript files
-external_scripts = [ ... ]
-
-# external CSS stylesheets
-external_stylesheets = [ ... ]
+from layouts import main_layout
 
 # Create Dash instance
 # optionally attach external scripts and stylesheets
-app = Dash(
-    __name__,
-    external_scripts=external_scripts,
-    external_stylesheets=external_stylesheets,
-)
+app = Dash()
 
 # Attach the main layout
 app.layout = main_layout
 
-# Get a reference to Flask server
-# Optional, but may be useful for routing, authentication, etc.
-server = app.server
-
-# Optional settings for local development/debugging
-app.css.config.serve_locally = True
-app.scripts.config.serve_locally = True
-
 # This is necessary to prevent warnings 
 # as callbacks will be defined in separate file
 app.config.suppress_callback_exceptions = True
-
-# Optionally add server routes, e.g.
-@server.route('/favicon.ico')
-def favicon():
-    '''Serve the favicon'''
-    return send_from_directory(
-        app._assets_folder,
-        'favicon.ico',
-        mimetype='image/x-icon')
     """, customStyle=styles.code_container),
 
 
@@ -150,6 +90,5 @@ This chapter is informed and inspired by the following resource(s) and discussio
 
 - [Splitting callback definitions in multiple files](https://community.plot.ly/t/splitting-callback-definitions-in-multiple-files/10583/2)
 - [Slapdash](https://github.com/ned2/slapdash) - boilerplate for bootstrapping scalable multi-page Dash applications
-"""
-    ),
+    """),
 ]

--- a/tutorial/project_structure.py
+++ b/tutorial/project_structure.py
@@ -17,6 +17,10 @@ our code, namely:
 
 This chapter will briefly describe how to separate out your app code into multiple files, for improved maintainability.
 
+## Package initialization
+A package architecture is key to allowing Python projects to be spread across files. To tell Python that the Dash app
+folder is a package, simply add an empty `__init__.py` file to the project directory.
+
 ## Main entrypoint
 Each Dash app needs a main entrypoint, which is basically the file you run with `python app.py` in a monolithic Dash app.
 


### PR DESCRIPTION
Ready for review.

Closes #244

This PR is intended to document an example, or recommendation, for separating Dash apps into multiple files. E.g.

- index.py - main entrypoint
- app.py - app initialization and layout binding
- layout.py - layout definition
- callbacks.py - callbacks related to layout

This PR intentionally leaves out routing and some other code examples, to focus on clarity and simplicity of the text.