### PR TITLE
Dash table issue217

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dash-core-components==0.36.0
 dash-dangerously-set-inner-html==0.0.1
 dash-html-components==0.13.2
 dash-renderer==0.14.3
-dash_table==3.1.4
+dash_table==3.1.5
 dash-table-experiments==0.6.0
 decorator==4.3.0
 enum34==1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dash-core-components==0.36.0
 dash-dangerously-set-inner-html==0.0.1
 dash-html-components==0.13.2
 dash-renderer==0.14.3
-dash_table==3.1.3
+dash_table==3.1.4
 dash-table-experiments==0.6.0
 decorator==4.3.0
 enum34==1.1.6

--- a/tutorial/examples/table/interactivity_connected_to_graph.py
+++ b/tutorial/examples/table/interactivity_connected_to_graph.py
@@ -31,18 +31,18 @@ app.layout = html.Div([
     Output('datatable-interactivity-container', "children"),
     [Input('datatable-interactivity', "derived_virtual_data"),
      Input('datatable-interactivity', "derived_virtual_selected_rows")])
-def update_graph(rows, selected_rows):
+def update_graph(rows, derived_virtual_selected_rows):
     # When the table is first rendered, `derived_virtual_data` and
     # `derived_virtual_selected_rows` will be `None`. This is due to an
     # idiosyncracy in Dash (unsupplied properties are always None and Dash
     # calls the dependent callbacks when the component is first rendered).
-    # So, if `selected_rows` is `None`, then the component was just rendered
+    # So, if `rows` is `None`, then the component was just rendered
     # and its value will be the same as the component's dataframe.
     # Instead of setting `None` in here, you could also set
     # `derived_virtual_data=df.to_rows('dict')` when you initialize
     # the component.
-    if selected_rows is None:
-        selected_rows = []
+    if derived_virtual_selected_rows is None:
+        derived_virtual_selected_rows = []
 
     if rows is None:
         dff = df
@@ -51,7 +51,7 @@ def update_graph(rows, selected_rows):
 
     colors = []
     for i in range(len(dff)):
-        if i in selected_rows:
+        if i in derived_virtual_selected_rows:
             colors.append("#7FDBFF")
         else:
             colors.append("#0074D9")

--- a/tutorial/examples/table/interactivity_connected_to_graph.py
+++ b/tutorial/examples/table/interactivity_connected_to_graph.py
@@ -32,17 +32,20 @@ app.layout = html.Div([
 @app.callback(
     Output('datatable-interactivity-container', "children"),
     [Input('datatable-interactivity', "derived_virtual_data"),
-     Input('datatable-interactivity', "selected_rows")])
+     Input('datatable-interactivity', "derived_virtual_selected_rows")])
 def update_graph(rows, selected_rows):
-    # When the table is first rendered, `derived_virtual_data`
-    # will be `None`. This is due to an idiosyncracy in Dash
-    # (unsupplied properties are always None and Dash calls the dependent
-    # callbacks when the component is first rendered).
+    # When the table is first rendered, `derived_virtual_data` and
+    # `derived_virtual_selected_rows` will be `None`. This is due to an
+    # idiosyncracy in Dash (unsupplied properties are always None and Dash
+    # calls the dependent callbacks when the component is first rendered).
     # So, if `selected_rows` is `None`, then the component was just rendered
     # and its value will be the same as the component's dataframe.
     # Instead of setting `None` in here, you could also set
     # `derived_virtual_data=df.to_rows('dict')` when you initialize
     # the component.
+    if selected_rows is None:
+        selected_rows = []
+
     if rows is None:
         dff = df
     else:


### PR DESCRIPTION
This is a follow up to https://github.com/plotly/dash-table/pull/227

Update dash-table to 3.1.4
Update interactive usage to use derived_virtual_selected_rows