### PR TITLE
Add dcc 0.41.0 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==6.7
 configparser==3.5.0
 dash==0.32.2
 dash-auth==1.2.0
-dash-core-components==0.40.3
+dash-core-components==0.41.0
 dash-dangerously-set-inner-html==0.0.1
 dash-html-components==0.13.2
 dash-renderer==0.15.2


### PR DESCRIPTION
Updates to latest release of dash-core-components.