### PR TITLE
Add chapter on integrating Dash with other web apps

### DIFF
--- a/tutorial/chapter_index.py
+++ b/tutorial/chapter_index.py
@@ -31,6 +31,7 @@ from tutorial import urls
 from tutorial import react_for_python_developers
 from tutorial import table
 from tutorial import devtools
+from tutorial import integrating_dash
 
 
 ## The chapters dict is used to generate the dash-docs search index
@@ -252,6 +253,14 @@ chapters = {
         'name': 'Deployment',
         'description': 'To share a Dash app, you need to "deploy" your Dash ' \
                        'app to a server'
+    },
+
+    'integrating-dash': {
+        'url': '/integrating-dash',
+        'content': integrating_dash.layout,
+        'name': 'Integrating Dash with Existing Web Apps',
+        'description': 'Strategies for integrating Dash apps with existing web ' \
+                       'apps.'
     },
 
     # 'deployment-onpremise': {

--- a/tutorial/home.py
+++ b/tutorial/home.py
@@ -110,6 +110,8 @@ layout = html.Div(className='toc', children=[
                 chapters['auth']['url']),
         Chapter(chapters['deployment']['name'],
                 chapters['deployment']['url']),
+        Chapter(chapters['integrating-dash']['name'],
+                chapters['integrating-dash']['url']),
     ]),
 
     Section('Getting Help', [

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -25,16 +25,16 @@ layout = html.Div([
     
     ## Using an `<iframe>`
 
-    Perhaps the simplest approach to embedding Dash in an existing web
-    application is to an include an `<iframe>` element in your HTML whose `src`
-    attribute points towards the address of an already running Dash
-    instance. This allows you to place your Dash app in a specific location
-    within an existing web page, with your desired dimensions:""")),
+    The simplest approach to embedding Dash in an existing web application is to
+    an include an `<iframe>` element in your HTML whose `src` attribute points
+    towards the address of an already running Dash instance. This allows you to
+    place your Dash app in a specific location within an existing web page, with
+    your desired dimensions:""")),
     Syntax(dedent("""\
     <iframe src="http://localhost:8050" width=700 height=600>
     """)),
     dcc.Markdown(dedent("""
-    ## Embedding a Dash app within an existing Flask app 
+    ## Embedding a Dash app within an Existing Flask App 
     
     As discussed in the [Deployment Chapter](/deployment), Dash uses the Flask
     web framework under the hood. It is possible to take advantage of this and
@@ -55,8 +55,7 @@ layout = html.Div([
     app = dash.Dash(
         __name__,
         server=server,
-        requests_pathname_prefix='/dash/',
-        routes_pathname_prefix='/dash/',
+        routes_pathname_prefix='/dash/'
     )
 
     app.layout = html.Div("My Dash app")
@@ -71,115 +70,20 @@ layout = html.Div([
     """)),
     html.Hr(),
     dcc.Markdown(dedent("""\
-    ## Embedding multiple Dash apps within an existing Flask app 
-    
-    If you want to combine multiple Dash apps with an existing Flask app, the
-    following project layout can be used. Here, we create two distinct Dash
-    apps, and use the Flask app defined in `server.py` as the server for both of
-    them.""")),
-    dcc.Markdown("`server.py`"),
-    Syntax(dedent("""\
-    from flask import Flask
-
-    server = Flask(__name__)
-
-    @server.route('/')
-    def index():
-        return 'Hello Flask app'
-    """)),
-    html.Hr(),
-    dcc.Markdown("`app1.py`"),
-    Syntax(dedent("""\
-    import dash
-    import dash_html_components as html
-
-    from server import server
-
-    app = dash.Dash(
-        __name__,
-        server=server,
-        requests_pathname_prefix='/app1/',
-        routes_pathname_prefix='/app1/',
-    )
-
-    app.layout = html.Div("Dash app 1")
-    """)),
-    html.Hr(),
-    dcc.Markdown("`app2.py`"),
-    Syntax(dedent("""\
-    import dash
-    import dash_html_components as html
-
-    from server import server
-
-    app = dash.Dash(
-        __name__,
-        server=server,
-        requests_pathname_prefix='/app2/',
-        routes_pathname_prefix='/app2/',
-    )
-
-    app.layout = html.Div("Dash app 2")
-    """)),
-    html.Hr(),
-    dcc.Markdown("`run.py`"),
-    Syntax(dedent("""\
-    from server import server
-    from app1 import app as app1
-    from app2 import app as app2
-
-    if __name__ == '__main__':
-        app1.enable_dev_tools(debug=True)
-        app2.enable_dev_tools(debug=True)
-        server.run(port=8050, debug=True)
-    """)),
-    html.Hr(),
-    dcc.Markdown(dedent("""\
-    Since there are multiple Dash instances, we can't launch our app with
-    `run_server`, so instead we use the `run` method of the Flask server,
-    first calling `enable_dev_tools` for each Dash instance, as this is
-    ordinarily called by Dash's `run_server`.
-
-    If you want to run this app using a WSGI server (while also having the
-    ability to use dev tools such as hot-reloading), then the following
-    `wsgi.py` can be used to run your app instead of `run.py`:
-
-    `wsgi.py`
-    """)),
-    Syntax(dedent("""\
-    from server import server
-    from app1 import app as app1
-    from app2 import app as app2
-
-    app1.enable_dev_tools(debug=True)
-    app2.enable_dev_tools(debug=True)""")),
-    html.Hr(),
-    dcc.Markdown(dedent("""\
-    To launch this app with Gunicorn you would run this command (the `--reload`
-    flag is required for hot reloading to work):
-
-    ```
-    $ gunicorn --reload wsgi:server
-    ```
-
-    > **Note:** debug mode should not be enabled in production. When deploying
-    > the above examples to production, you should set `debug=False` and not use
-    > the `--reload` flag for Gunicorn.""")),
-    dcc.Markdown(dedent("""\
-    ## Combining Dash apps with existing WSGI apps
+    ## Combining One or More Dash Apps with Existing WSGI Apps
 
     This approach uses Werkzeug's
     [`DispatcherMiddleware`](http://werkzeug.pocoo.org/docs/latest/middlewares/)
-    to combine one or more Dash apps with one more existing WSGI apps. Unlike
-    the previous approach, your existing web apps don't have to be built on
-    Flask, but instead can be any Python web application implementing the [WSGI
+    to combine one or more Dash apps with one more existing WSGI apps. With this
+    strategy, your existing web apps don't have to be built on Flask, but
+    instead can be any Python web application implementing the [WSGI
     specification](https://wsgi.readthedocs.io).
 
     The following example illustrates this approach. In this example, the
-    existing app being combined with two Dash apps is a Flask app, however it
-    could be [any WSGI
-    app](https://wsgi.readthedocs.io/en/latest/frameworks.html).
-    """)),
+    existing app being combined with two Dash apps is a Flask app, however this
+    approach enables the combination of [any WSGI
+    app](https://wsgi.readthedocs.io/en/latest/frameworks.html) with multiple
+    Dash apps (or any other WSGI apps for that matter).""")),
     dcc.Markdown("`flask_app.py`"),
     Syntax(dedent("""\
     from flask import Flask
@@ -238,27 +142,30 @@ layout = html.Div([
     have been mounted at `/app1` and `/app2`. In this approach, we do not pass
     in a Flask server to the Dash apps, but let them create their own, which the
     `DispatcherMiddleware` routes requests to based on the prefix of the
-    incoming requests. Within each Dash app, only `requests_pathname_prefix`
-    must be provided with the app's mount point, as the mount points specified
-    in the `DispatcherMiddleware` initialization has effectively already set
+    incoming requests. Within each Dash app, `requests_pathname_prefix` must be
+    provided with the app's mount point, as the mount points specified in the
+    `DispatcherMiddleware` initialization has effectively already set
     `requests_pathname_prefix` with the correct value.
+
+    In order to enable the development tools, the `enable_dev_tools` method
+    needs to be invoked manually for each Dash instance. This is because when
+    running using a WSGI server, Dash's `run_server` method (which calls
+    `enable_dev_tools`) is not used, as well as the fact that there are two
+    distinct Dash instances.
 
     Note that the `application` object in `wsgi.py` is of type
     `werkzeug.wsgi.DispatcherMiddleware`, which does not have a `run`
-    method. This can be run as a WSGI app like so:
+    method. This can be run as a WSGI app like so (the `--reload` flag is
+    required for hot reloading to work):
 
     ```
     $ gunicorn --reload wsgi:application
     ```
     
-    > **Note:** debug mode should not be enabled in production. When deploying
-    > the above examples to production, you should set `debug=False` and not use
-    > the `--reload` flag for Gunicorn.
-
     Alternatively, you can use the Werkzeug development server (which is not
     suitable for production) to run the app:
 
-    `wsgi.py`""")),
+    `run.py`""")),
     Syntax(dedent("""\
     from werkzeug.wsgi import DispatcherMiddleware
     from werkzeug.serving import run_simple
@@ -281,6 +188,11 @@ layout = html.Div([
     You would run the above with:
 
     ```
-    $ python wsgi.py
-    ```""")),
+    $ python run.py
+    ```
+
+    > **Note:** debug mode should not be enabled in production. When deploying
+    > the above examples to production, you should set `debug=False` and not use
+    > the `--reload` flag for Gunicorn.
+    """)),
     ])

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -28,7 +28,7 @@ layout = html.Div([
     The simplest approach to embedding Dash in an existing web application is to
     an include an `<iframe>` element in your HTML whose `src` attribute points
     towards the address of an already running Dash instance. This allows you to
-    place your Dash app in a specific location within an existing web page, with
+    place your Dash app in a specific location within an existing web page with
     your desired dimensions:""")),
     Syntax('<iframe src="http://localhost:8050" width=700 height=600>'),
     dcc.Markdown(dedent(
@@ -36,9 +36,10 @@ layout = html.Div([
     ## Embedding a Dash app within an Existing Flask App 
     
     As discussed in the [Deployment Chapter](/deployment), Dash uses the Flask
-    web framework under the hood. It is possible to take advantage of this and
-    embed a Dash app at a specific route of an existing Flask app. In the
-    following example, a Dash app is mounted at the `/dash` route (eg
+    web framework under the hood. This makes it fairly straightforward to 
+    embed a Dash app at a specific route of an existing Flask app.
+
+    In the following example, a Dash app is mounted at the `/dash` route (eg
     `http://localhost:8050/dash`) of a Flask app:
     """
     )),
@@ -68,7 +69,7 @@ layout = html.Div([
     )),
     dcc.Markdown(dedent(
     """
-    Note that it is important to set the `name` parameter of the Dash instance
+    > **Note**: it is important to set the `name` parameter of the Dash instance
     to the value `__name__`, so that Dash can correctly detect the location of
     any static assets inside an `assets` directory for this Dash app.
     """
@@ -80,16 +81,13 @@ layout = html.Div([
 
     This approach uses Werkzeug's
     [`DispatcherMiddleware`](http://werkzeug.pocoo.org/docs/latest/middlewares/)
-    to combine one or more Dash apps with one more existing WSGI apps. With this
-    strategy, your existing web apps don't have to be built on Flask, but
-    instead can be any Python web application implementing the [WSGI
-    specification](https://wsgi.readthedocs.io).
+    to combine one or more Dash apps with existing WSGI apps (including
+    Flask). It is useful when you want to combine multiple Dash apps or when
+    your existing app is a non-Flask WSGI app.
 
-    The following example illustrates this approach. In this example, the
-    existing app being combined with two Dash apps is a Flask app, however this
-    approach enables the combination of [any WSGI
-    app](https://wsgi.readthedocs.io/en/latest/frameworks.html) with multiple
-    Dash apps (or any other WSGI apps for that matter)."""
+    The following example illustrates this approach by combining two Dash apps
+    with a Flask app.
+    """
     )),
     dcc.Markdown("`flask_app.py`"),
     Syntax(dedent(
@@ -142,9 +140,6 @@ layout = html.Div([
     from app1 import app as app1
     from app2 import app as app2
 
-    app1.enable_dev_tools(debug=True)
-    app2.enable_dev_tools(debug=True)
-    
     application = DispatcherMiddleware(flask_app, {
         '/app1': app1.server,
         '/app2': app2.server,    
@@ -158,25 +153,17 @@ layout = html.Div([
     in a Flask server to the Dash apps, but let them create their own, which the
     `DispatcherMiddleware` routes requests to based on the prefix of the
     incoming requests. Within each Dash app, `requests_pathname_prefix` must be
-    provided with the app's mount point, as the mount points specified in the
-    `DispatcherMiddleware` initialization has effectively already set
-    `requests_pathname_prefix` with the correct value.
-
-    In order to enable the development tools, the `enable_dev_tools` method
-    needs to be invoked manually for each Dash instance. This is because when
-    running using a WSGI server, Dash's `run_server` method (which calls
-    `enable_dev_tools`) is not used, as well as the fact that there are two
-    distinct Dash instances.
+    specified as the app's mount point, in order to match the route prefix
+    set by the `DispatcherMiddleware`.
 
     Note that the `application` object in `wsgi.py` is of type
     `werkzeug.wsgi.DispatcherMiddleware`, which does not have a `run`
-    method. This can be run as a WSGI app like so (the `--reload` flag is
-    required for hot reloading to work):
-
-    ```
-    $ gunicorn --reload wsgi:application
-    ```
-    
+    method. This can be run as a WSGI app like so:
+    """
+    )),
+    Syntax("$ gunicorn wsgi:application"),
+    dcc.Markdown(dedent(
+    """
     Alternatively, you can use the Werkzeug development server (which is not
     suitable for production) to run the app:
 
@@ -191,9 +178,6 @@ layout = html.Div([
     from app1 import app as app1
     from app2 import app as app2
 
-    app1.enable_dev_tools(debug=True)
-    app2.enable_dev_tools(debug=True)
-    
     application = DispatcherMiddleware(flask_app, {
         '/app1': app1.server,
         '/app2': app2.server,    
@@ -205,15 +189,31 @@ layout = html.Div([
     )),
     dcc.Markdown(dedent(
     """
-    You would run the above with:
+    If you need access to the Dash development tools when using this approach
+    (whether running with a WSGI server, or using the Werkzeug development
+    server) you must invoke them manually for each Dash app. The following lines
+    can be added before the initialisation of the `DispatcherMiddleware` to do this:
+    """
+    )),
+    Syntax(dedent(
+    """
+    app1.enable_dev_tools(debug=True)
+    app2.enable_dev_tools(debug=True)
+    """
+    )),
+    dcc.Markdown(dedent(
+    """    
+    > **Note:** debug mode should not be enabled in production. When using debug
+        mode with Gunicorn, the `--reload` command line flag is required for hot
+        reloading to work.
 
-    ```
-    $ python run.py
-    ```
-
-    > **Note:** debug mode should not be enabled in production. When deploying
-    > the above examples to production, you should set `debug=False` and not use
-    > the `--reload` flag for Gunicorn.
+    In this example, the existing app being combined with two Dash apps is a
+    Flask app, however this approach enables the combination of any web
+    application implementing the [WSGI
+    specification](https://wsgi.readthedocs.io). A list of WSGI web frameworks
+    can be found in the [WSGI
+    documentation](https://wsgi.readthedocs.io/en/latest/frameworks.html) with
+    one or more Dash apps.
     """
     )),
     ])

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+from textwrap import dedent
+
+import dash_core_components as dcc
+import dash_html_components as html
+
+from tutorial import styles
+
+
+def Syntax(content):
+    return dcc.SyntaxHighlighter(
+        content,
+        language="python",
+        customStyle=styles.code_container
+    )
+
+
+layout = html.Div([
+    dcc.Markdown(dedent(
+    """
+    # Embedding Dash within existing web applications
+
+    This section describes three different approaches to embedding a Dash app
+    within an existing web application.
+    
+    ## Using an `<iframe>`
+
+    Perhaps the simplest approach to embedding Dash in an existing web
+    application is to an include an `<iframe>` element in your HTML whose `src`
+    attribute points towards the address of an already running Dash
+    instance. This allows you to place your Dash app in a specific location
+    within an existing web page, with your desired dimensions:""")),
+    Syntax(dedent("""\
+    <iframe src="http://localhost:8050" width=700 height=600>
+    """)),
+    dcc.Markdown(dedent("""
+    ## Embedding a Dash app within an existing Flask app 
+    
+    As discussed in the [Deployment Chapter](/deployment), Dash uses the Flask
+    web framework under the hood. It is possible to take advantage of this and
+    embed a Dash app at a specific route of an existing Flask app. In the
+    following example, a Dash app is mounted at the `/dash` route (eg
+    `http://localhost:8050/dash`) of a Flask app:""")),
+    Syntax(dedent("""\
+    import flask
+    import dash
+    import dash_html_components as html
+    
+    server = flask.Flask(__name__)
+
+    @server.route('/')
+    def index():
+        return 'Hello Flask app'
+
+    app = dash.Dash(
+        server=server,
+        requests_pathname_prefix='/dash/',
+        routes_pathname_prefix='/dash/',
+    )
+
+    app.layout = html.Div("My Dash app")
+
+    if __name__ == '__main__':
+        app.run_server(debug=True)
+    """)),
+    html.Hr(),
+    dcc.Markdown(dedent("""\
+    ## Embedding multiple Dash apps within an existing Flask app 
+    
+    If you want to combine multiple Dash apps with an existing Flask app, the
+    following project layout can be used. Here, we create two distinct Dash
+    apps, and use the Flask app defined in `server.py` as the server for both of
+    them.""")),
+    dcc.Markdown("`server.py`"),
+    Syntax(dedent("""\
+    from flask import Flask
+
+    server = Flask(__name__)
+
+    @server.route('/')
+    def index():
+        return 'Hello Flask app'
+    """)),
+    html.Hr(),
+    dcc.Markdown("`app1.py`"),
+    Syntax(dedent("""\
+    import dash
+    import dash_html_components as html
+
+    from server import server
+
+    app = dash.Dash(
+        server=server,
+        requests_pathname_prefix='/app1/',
+        routes_pathname_prefix='/app1/',
+    )
+
+    app.layout = html.Div("Dash app 1")
+    """)),
+    html.Hr(),
+    dcc.Markdown("`app2.py`"),
+    Syntax(dedent("""\
+    import dash
+    import dash_html_components as html
+
+    from server import server
+
+    app = dash.Dash(
+        server=server,
+        requests_pathname_prefix='/app2/',
+        routes_pathname_prefix='/app2/',
+    )
+
+    app.layout = html.Div("Dash app 2")
+    """)),
+    html.Hr(),
+    dcc.Markdown("`run.py`"),
+    Syntax(dedent("""\
+    from server import server
+    from app1 import app as app1
+    from app2 import app as app2
+
+    if __name__ == '__main__':
+        app1.enable_dev_tools(debug=True)
+        app2.enable_dev_tools(debug=True)
+        server.run(port=8050, debug=True)
+    """)),
+    html.Hr(),
+    dcc.Markdown(dedent("""\
+    Since there are multiple Dash instances, we can't launch our app with
+    `run_server`, so instead we use the `run` method of the Flask server,
+    first calling `enable_dev_tools` for each Dash instance, as this is
+    ordinarily called by `run_server`.
+
+    If you want to run this app using a WSGI server (while also having the
+    ability to use dev tools such as hot-reloading), then the following
+    `wsgi.py` can be used to run your app instead of `run.py`:
+
+    `wsgi.py`
+    """)),
+    Syntax(dedent("""\
+    from server import server
+    from app1 import app as app1
+    from app2 import app as app2
+
+    app1.enable_dev_tools(debug=True)
+    app2.enable_dev_tools(debug=True)""")),
+    html.Hr(),
+    dcc.Markdown(dedent("""\
+    To launch this app with Gunicorn you would run this command (the `--reload`
+    flag is required for hot reloading to work):
+
+    ```
+    $ gunicorn --reload wsgi:server
+    ```
+
+    > **Note:** debug mode should not be enabled in production. When deploying
+    > the above examples to production, you should set `debug=False` and not use
+    > the `--reload` flag for Gunicorn.""")),
+    dcc.Markdown(dedent("""\
+    ## Combining Dash apps with existing WSGI apps
+
+    This approach uses Werkzeug's
+    [`DispatcherMiddleware`](http://werkzeug.pocoo.org/docs/latest/middlewares/)
+    to combine one or more Dash apps with one more existing WSGI apps. Unlike
+    the previous approach, your existing web apps don't have to be built on
+    Flask, but instead can be any Python web application implementing the [WSGI
+    specification](https://wsgi.readthedocs.io).
+
+    The following example illustrates this approach. In this example, the
+    existing app being combined with two Dash apps is a Flask app, however it
+    could be [any WSGI
+    app](https://wsgi.readthedocs.io/en/latest/frameworks.html).
+    """)),
+    dcc.Markdown("`flask_app.py`"),
+    Syntax(dedent("""\
+    from flask import Flask
+
+    flask_app = Flask(__name__)
+
+    @flask_app.route('/')
+    def index():
+        return 'Hello Flask app'
+    """)),
+    html.Hr(),
+    dcc.Markdown("`app1.py`"),
+    Syntax(dedent("""\
+    import dash
+    import dash_html_components as html
+    
+    app = dash.Dash(requests_pathname_prefix='/app1/')
+    app.layout = html.Div("Dash app 1")
+    """)),
+    html.Hr(),
+    dcc.Markdown("`app2.py`"),
+    Syntax(dedent("""\
+    import dash
+    import dash_html_components as html
+    
+    app = dash.Dash(requests_pathname_prefix='/app2/')
+    app.layout = html.Div("Dash app 2")
+    """)),
+    html.Hr(),
+    dcc.Markdown("`wsgi.py`"),
+    Syntax(dedent("""\
+    from werkzeug.wsgi import DispatcherMiddleware
+
+    from app1 import app as app1
+    from app2 import app as app2
+
+    app1.enable_dev_tools(debug=True)
+    app2.enable_dev_tools(debug=True)
+    
+    application = DispatcherMiddleware(flask_app, {
+        '/app1': app1.server,
+        '/app2': app2.server,    
+    })
+    """)),
+    dcc.Markdown(dedent("""\
+
+    In this example, the Flask app has been mounted at `/` and the two Dash apps
+    have been mounted at `/app1` and `/app2`. In this approach, we do not pass
+    in a Flask server to the Dash apps, but let them create their own, which the
+    `DispatcherMiddleware` routes requests to based on the prefix of the
+    incoming requests. Within each Dash app, only `requests_pathname_prefix`
+    must be provided with the app's mount point, as the mount points specified
+    in the `DispatcherMiddleware` initialization has effectively already set
+    `requests_pathname_prefix` with the correct value.
+
+    Note that the `application` object in `wsgi.py` is of type
+    `werkzeug.wsgi.DispatcherMiddleware`, which does not have a `run`
+    method. This can be run as a WSGI app like so:
+
+    ```
+    $ gunicorn --reload wsgi:application
+    ```
+    
+    > **Note:** debug mode should not be enabled in production. When deploying
+    > the above examples to production, you should set `debug=False` and not use
+    > the `--reload` flag for Gunicorn.
+
+    Alternatively, you can use the Werkzeug development server (which is not
+    suitable for production) to run the app:
+
+    `wsgi.py`""")),
+    Syntax(dedent("""\
+    from werkzeug.wsgi import DispatcherMiddleware
+    from werkzeug.serving import run_simple
+
+    from app1 import app as app1
+    from app2 import app as app2
+
+    app1.enable_dev_tools(debug=True)
+    app2.enable_dev_tools(debug=True)
+    
+    application = DispatcherMiddleware(flask_app, {
+        '/app1': app1.server,
+        '/app2': app2.server,    
+    })
+
+    if __name__ == '__main__':
+        run_simple('localhost', 8050, application)
+    """)),
+    dcc.Markdown(dedent("""\
+    You would run the above with:
+
+    ```
+    $ python wsgi.py
+    ```""")),
+    ])

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -26,10 +26,10 @@ layout = html.Div([
     ## Using an `<iframe>`
 
     The simplest approach to embedding Dash in an existing web application is to
-    an include an `<iframe>` element in your HTML whose `src` attribute points
-    towards the address of an already running Dash instance. This allows you to
-    place your Dash app in a specific location within an existing web page with
-    your desired dimensions:""")),
+    include an `<iframe>` element in your HTML whose `src` attribute points
+    towards the address of a deployed Dash app. This allows you to place your
+    Dash app in a specific location within an existing web page with your
+    desired dimensions:""")),
     Syntax('<iframe src="http://localhost:8050" width=700 height=600>'),
     dcc.Markdown(dedent(
     """

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -53,6 +53,7 @@ layout = html.Div([
         return 'Hello Flask app'
 
     app = dash.Dash(
+        __name__,
         server=server,
         requests_pathname_prefix='/dash/',
         routes_pathname_prefix='/dash/',
@@ -62,6 +63,11 @@ layout = html.Div([
 
     if __name__ == '__main__':
         app.run_server(debug=True)
+    """)),
+    dcc.Markdown(dedent("""\
+    Note that it is important to set the `name` parameter of the Dash instance
+    to the value `__name__`, so that Dash can correctly detect the location of
+    any static assets inside an `assets` directory for this Dash app.
     """)),
     html.Hr(),
     dcc.Markdown(dedent("""\
@@ -90,6 +96,7 @@ layout = html.Div([
     from server import server
 
     app = dash.Dash(
+        __name__,
         server=server,
         requests_pathname_prefix='/app1/',
         routes_pathname_prefix='/app1/',
@@ -106,6 +113,7 @@ layout = html.Div([
     from server import server
 
     app = dash.Dash(
+        __name__,
         server=server,
         requests_pathname_prefix='/app2/',
         routes_pathname_prefix='/app2/',
@@ -130,7 +138,7 @@ layout = html.Div([
     Since there are multiple Dash instances, we can't launch our app with
     `run_server`, so instead we use the `run` method of the Flask server,
     first calling `enable_dev_tools` for each Dash instance, as this is
-    ordinarily called by `run_server`.
+    ordinarily called by Dash's `run_server`.
 
     If you want to run this app using a WSGI server (while also having the
     ability to use dev tools such as hot-reloading), then the following
@@ -188,7 +196,11 @@ layout = html.Div([
     import dash
     import dash_html_components as html
     
-    app = dash.Dash(requests_pathname_prefix='/app1/')
+    app = dash.Dash(
+        __name__,
+        requests_pathname_prefix='/app1/'
+    )
+
     app.layout = html.Div("Dash app 1")
     """)),
     html.Hr(),
@@ -197,7 +209,11 @@ layout = html.Div([
     import dash
     import dash_html_components as html
     
-    app = dash.Dash(requests_pathname_prefix='/app2/')
+    app = dash.Dash(
+        __name__,
+        requests_pathname_prefix='/app2/'
+    )
+
     app.layout = html.Div("Dash app 2")
     """)),
     html.Hr(),

--- a/tutorial/integrating_dash.py
+++ b/tutorial/integrating_dash.py
@@ -9,7 +9,7 @@ from tutorial import styles
 
 def Syntax(content):
     return dcc.SyntaxHighlighter(
-        content,
+        content.strip(),
         language="python",
         customStyle=styles.code_container
     )
@@ -18,7 +18,7 @@ def Syntax(content):
 layout = html.Div([
     dcc.Markdown(dedent(
     """
-    # Embedding Dash within existing web applications
+    # Integrating Dash with Existing Web Apps
 
     This section describes three different approaches to embedding a Dash app
     within an existing web application.
@@ -30,18 +30,20 @@ layout = html.Div([
     towards the address of an already running Dash instance. This allows you to
     place your Dash app in a specific location within an existing web page, with
     your desired dimensions:""")),
-    Syntax(dedent("""\
-    <iframe src="http://localhost:8050" width=700 height=600>
-    """)),
-    dcc.Markdown(dedent("""
+    Syntax('<iframe src="http://localhost:8050" width=700 height=600>'),
+    dcc.Markdown(dedent(
+    """
     ## Embedding a Dash app within an Existing Flask App 
     
     As discussed in the [Deployment Chapter](/deployment), Dash uses the Flask
     web framework under the hood. It is possible to take advantage of this and
     embed a Dash app at a specific route of an existing Flask app. In the
     following example, a Dash app is mounted at the `/dash` route (eg
-    `http://localhost:8050/dash`) of a Flask app:""")),
-    Syntax(dedent("""\
+    `http://localhost:8050/dash`) of a Flask app:
+    """
+    )),
+    Syntax(dedent(
+    """
     import flask
     import dash
     import dash_html_components as html
@@ -62,14 +64,18 @@ layout = html.Div([
 
     if __name__ == '__main__':
         app.run_server(debug=True)
-    """)),
-    dcc.Markdown(dedent("""\
+    """
+    )),
+    dcc.Markdown(dedent(
+    """
     Note that it is important to set the `name` parameter of the Dash instance
     to the value `__name__`, so that Dash can correctly detect the location of
     any static assets inside an `assets` directory for this Dash app.
-    """)),
+    """
+    )),
     html.Hr(),
-    dcc.Markdown(dedent("""\
+    dcc.Markdown(dedent(
+    """
     ## Combining One or More Dash Apps with Existing WSGI Apps
 
     This approach uses Werkzeug's
@@ -83,9 +89,11 @@ layout = html.Div([
     existing app being combined with two Dash apps is a Flask app, however this
     approach enables the combination of [any WSGI
     app](https://wsgi.readthedocs.io/en/latest/frameworks.html) with multiple
-    Dash apps (or any other WSGI apps for that matter).""")),
+    Dash apps (or any other WSGI apps for that matter)."""
+    )),
     dcc.Markdown("`flask_app.py`"),
-    Syntax(dedent("""\
+    Syntax(dedent(
+    """
     from flask import Flask
 
     flask_app = Flask(__name__)
@@ -93,10 +101,12 @@ layout = html.Div([
     @flask_app.route('/')
     def index():
         return 'Hello Flask app'
-    """)),
+    """
+    )),
     html.Hr(),
     dcc.Markdown("`app1.py`"),
-    Syntax(dedent("""\
+    Syntax(dedent(
+    """
     import dash
     import dash_html_components as html
     
@@ -106,10 +116,12 @@ layout = html.Div([
     )
 
     app.layout = html.Div("Dash app 1")
-    """)),
+    """
+    )),
     html.Hr(),
     dcc.Markdown("`app2.py`"),
-    Syntax(dedent("""\
+    Syntax(dedent(
+    """
     import dash
     import dash_html_components as html
     
@@ -119,10 +131,12 @@ layout = html.Div([
     )
 
     app.layout = html.Div("Dash app 2")
-    """)),
+    """
+    )),
     html.Hr(),
     dcc.Markdown("`wsgi.py`"),
-    Syntax(dedent("""\
+    Syntax(dedent(
+    """
     from werkzeug.wsgi import DispatcherMiddleware
 
     from app1 import app as app1
@@ -135,9 +149,10 @@ layout = html.Div([
         '/app1': app1.server,
         '/app2': app2.server,    
     })
-    """)),
-    dcc.Markdown(dedent("""\
-
+    """
+    )),
+    dcc.Markdown(dedent(
+    """
     In this example, the Flask app has been mounted at `/` and the two Dash apps
     have been mounted at `/app1` and `/app2`. In this approach, we do not pass
     in a Flask server to the Dash apps, but let them create their own, which the
@@ -165,8 +180,11 @@ layout = html.Div([
     Alternatively, you can use the Werkzeug development server (which is not
     suitable for production) to run the app:
 
-    `run.py`""")),
-    Syntax(dedent("""\
+    `run.py`
+    """
+    )),
+    Syntax(dedent(
+    """
     from werkzeug.wsgi import DispatcherMiddleware
     from werkzeug.serving import run_simple
 
@@ -183,8 +201,10 @@ layout = html.Div([
 
     if __name__ == '__main__':
         run_simple('localhost', 8050, application)
-    """)),
-    dcc.Markdown(dedent("""\
+    """
+    )),
+    dcc.Markdown(dedent(
+    """
     You would run the above with:
 
     ```
@@ -194,5 +214,6 @@ layout = html.Div([
     > **Note:** debug mode should not be enabled in production. When deploying
     > the above examples to production, you should set `debug=False` and not use
     > the `--reload` flag for Gunicorn.
-    """)),
+    """
+    )),
     ])


### PR DESCRIPTION
This chapter provides examples of different approaches to integrating Dash apps with existing Dash apps:

- using a simple <iframe> in an HTML page
- mounting a single Dash app within an existing Flask app
- mounting multiple Dash apps within an existing Flask app
- Using `werkzeug.wsgi.DispatcherMiddleware` to mount multiple Dash apps with an existing WSGI app

Fix #246 and plotly/dash#214