### PR TITLE
specify workers via env variables

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --workers 8 run:server
+web: gunicorn run:server

--- a/app.json
+++ b/app.json
@@ -5,7 +5,8 @@
   "env": {
     "accesstoken": {
       "required": true
-    }
+    },
+    "WEB_CONCURRENCY": 2
   },
   "formation": {
   },

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "accesstoken": {
       "required": true
     },
-    "WEB_CONCURRENCY": 2
+    "WEB_CONCURRENCY": "2"
   },
   "formation": {
   },


### PR DESCRIPTION
- app.json is used by review apps: https://devcenter.heroku.com/articles/github-integration-review-apps#the-app-json-file
- Specify number of workers via env variables instead of hard-coding. `WEB_CONCURRENCY` is used by `gunicorn`: http://docs.gunicorn.org/en/stable/settings.html#workers
- Supply a ENV variable in the heroku UI for production, setting workers to 8