### PR TITLE
Fix env var name in map local directories example

### DIFF
--- a/tutorial/dash_deployment_server_examples.py
+++ b/tutorial/dash_deployment_server_examples.py
@@ -1092,7 +1092,7 @@ LocalDir = html.Div(children=[
     ''')),
 
     dcc.SyntaxHighlighter(
-"""if 'DASH_APP' in os.environ:
+"""if 'DASH_APP_NAME' in os.environ:
     # this is a deployed app
     filepath = os.path.join(os.sep, 'data', 'my-dataset.csv')
 else:


### PR DESCRIPTION
There is no env var named DASH_APP in DDS so the old code fails if deployed.