### PR TITLE
#425 add edge cases and docs

### DIFF
--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -793,14 +793,12 @@ DatePickerSingle = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
     dcc.Markdown("This is a simple example of a `DatePickerSingle` \
-                component tied to a callback. The 'date` property is recommended \
-                to use python `datetime.date` or `datetime.datetime` objects.\
-                The `min_date_allowed` and \
-                `max_date_allowed` properties define the minimum and \
-                maximum selectable \
-                dates on the calendar while `initial_visible_month` defines \
-                the calendar month that is first displayed when the \
-                `DatePickerSingle` component is opened."),
+                component tied to a callback. The `date` property is recommended \
+                to use python `datetime.date` or `datetime.datetime` objects. \
+                The `min_date_allowed` and `max_date_allowed` properties \
+                define the minimum and maximum selectable dates on the calendar \
+                while `initial_visible_month` defines the calendar month that is first \
+                displayed when the `DatePickerSingle` component is opened."),
     dcc.SyntaxHighlighter(
         examples['date_picker_single'][0],
         language='python',

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -650,7 +650,7 @@ DatePickerRange = html.Div(children=[
 from datetime import datetime as dt
 
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21),
+    end_date=dt(2017,6,21,23,59,59,999999),
     display_format='MMM Do, YY',
     start_date_placeholder_text='MMM Do, YY'
 )'''),
@@ -658,7 +658,7 @@ dcc.DatePickerRange(
     ComponentBlock('''import dash_core_components as dcc
 from datetime import datetime as dt
 dcc.DatePickerRange(
-    end_date=dt.now(),
+    end_date=dt(2017,6,21),
     display_format='M-D-Y-Q',
     start_date_placeholder_text='M-D-Y-Q'
 )'''),
@@ -667,7 +667,7 @@ dcc.DatePickerRange(
 from datetime import datetime as dt
 
 dcc.DatePickerRange(
-    end_date=dt.now(),
+    end_date=dt(2017,6,21),
     display_format='MMMM Y, DD',
     start_date_placeholder_text='MMMM Y, DD'
 )'''),
@@ -676,7 +676,7 @@ dcc.DatePickerRange(
 from datetime import datetime as dt
 
 dcc.DatePickerRange(
-    end_date=dt.now(),
+    end_date=dt(2017,6,21),
     display_format='X',
     start_date_placeholder_text='X'
 )''', language='python', customStyle=styles.code_container),
@@ -694,7 +694,7 @@ from datetime import datetime as dt
 dcc.DatePickerRange(
     month_format='MMM Do, YY',
     end_date_placeholder_text='MMM Do, YY',
-    start_date=dt.now()
+    start_date=dt(2017,6,21)
 )'''),
     ComponentBlock('''import dash_core_components as dcc
 from datetime import datetime as dt
@@ -702,7 +702,7 @@ from datetime import datetime as dt
 dcc.DatePickerRange(
     month_format='M-D-Y-Q',
     end_date_placeholder_text='M-D-Y-Q',
-    start_date=dt.now()
+    start_date=dt(2017,6,21)
 )'''),
     ComponentBlock('''import dash_core_components as dcc
 from datetime import datetime as dt
@@ -710,7 +710,7 @@ from datetime import datetime as dt
 dcc.DatePickerRange(
     month_format='MMMM Y',
     end_date_placeholder_text='MMMM Y',
-    start_date=dt.now()
+    start_date=dt(2017,6,21)
 )'''),
     ComponentBlock('''import dash_core_components as dcc
 from datetime import datetime as dt
@@ -718,7 +718,7 @@ from datetime import datetime as dt
 dcc.DatePickerRange(
     month_format='X',
     end_date_placeholder_text='X',
-    start_date=dt.now()
+    start_date=dt(2017,6,21)
 )'''),
 
     html.Hr(),
@@ -793,12 +793,14 @@ DatePickerSingle = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
     dcc.Markdown("This is a simple example of a `DatePickerSingle` \
-                 component tied to a callback. The `min_date_allowed` and \
-                 `max_date_allowed` properties define the minimum and \
-                 maximum selectable \
-                 dates on the calendar while `initial_visible_month` defines \
-                 the calendar month that is first displayed when the \
-                 `DatePickerSingle` component is opened."),
+                component tied to a callback. The 'date` property is recommended \
+                to use python `datetime.date` or `datetime.datetime` objects.\
+                The `min_date_allowed` and \
+                `max_date_allowed` properties define the minimum and \
+                maximum selectable \
+                dates on the calendar while `initial_visible_month` defines \
+                the calendar month that is first displayed when the \
+                `DatePickerSingle` component is opened."),
     dcc.SyntaxHighlighter(
         examples['date_picker_single'][0],
         language='python',
@@ -894,7 +896,7 @@ DatePickerSingle = html.Div(children=[
 from datetime import datetime as dt
 
 dcc.DatePickerSingle(
-    date=dt(2017,6,21),
+    date='2017-06-21',
     display_format='MMM Do, YY'
 )'''),
 
@@ -945,12 +947,12 @@ dcc.DatePickerSingle(
 )'''),
 
     ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+import datetime
 
 dcc.DatePickerSingle(
     month_format='MMMM Y',
     placeholder='MMMM Y',
-    date=dt(2017,6,21)
+    date=datetime.date(2020,2,29)
 )'''),
 
     ComponentBlock('''import dash_core_components as dcc
@@ -959,7 +961,7 @@ from datetime import datetime as dt
 dcc.DatePickerSingle(
     month_format='X',
     placeholder='X',
-    date=dt(2017,6,21)
+    date=dt(2017,6,21,0,0,0,0)
 )''', language='python', customStyle=styles.code_container),
     html.Hr(),
     html.H3("Vertical Calendar and Placeholder Text"),

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -793,11 +793,13 @@ DatePickerSingle = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
     dcc.Markdown("This is a simple example of a `DatePickerSingle` \
-        component tied to a callback. It is safe to use the string \
-        format of `datetime.date` or `datetime.datetime` objects for the \
-        `date` property, be aware of the extra time in `datetime` object will \
-        be ignored. The `min_date_allowed` and `max_date_allowed` properties \
-        define the minimum and maximum selectable dates on the calendar \
+        component tied to a callback. You can use either date objects \
+        (`datetime.date` or `datetime.datetime`) or strings in the form \
+        `YYYY-MM-DD` to provide dates to Dash components. Strings are \
+        preferred because that's the form dates take as callback arguments. \
+        Be aware that any time information included in a datetime object \
+        or string will be ignored. The `min_date_allowed` and `max_date_allowed` \
+        properties define the minimum and maximum selectable dates on the calendar \
         while `initial_visible_month` defines the calendar month that is \
         first displayed when the `DatePickerSingle` component is opened."),
     dcc.SyntaxHighlighter(

--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -793,12 +793,13 @@ DatePickerSingle = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
     dcc.Markdown("This is a simple example of a `DatePickerSingle` \
-                component tied to a callback. The `date` property is recommended \
-                to use python `datetime.date` or `datetime.datetime` objects. \
-                The `min_date_allowed` and `max_date_allowed` properties \
-                define the minimum and maximum selectable dates on the calendar \
-                while `initial_visible_month` defines the calendar month that is first \
-                displayed when the `DatePickerSingle` component is opened."),
+        component tied to a callback. It is safe to use the string \
+        format of `datetime.date` or `datetime.datetime` objects for the \
+        `date` property, be aware of the extra time in `datetime` object will \
+        be ignored. The `min_date_allowed` and `max_date_allowed` properties \
+        define the minimum and maximum selectable dates on the calendar \
+        while `initial_visible_month` defines the calendar month that is \
+        first displayed when the `DatePickerSingle` component is opened."),
     dcc.SyntaxHighlighter(
         examples['date_picker_single'][0],
         language='python',
@@ -1443,18 +1444,18 @@ LogoutButton = html.Div([
     dcc.Markdown(s('''
     Please note that no authentication is performed in Dash by default
     and you have to implement the authentication yourself.
-    
+
     ## List of packages that provide authentication methods:
-    
+
     - [flask-login](https://flask-login.readthedocs.io/en/latest/)
     - [dash-auth](https://github.com/plotly/dash-auth)
-    
+
     You can also use these packages for custom authentication:
-    
+
     ### Password hashes:
     - [bcrypt](https://github.com/pyca/bcrypt/)
     - [passlib](https://passlib.readthedocs.io/en/stable/)
-    
+
     ### Session/cookies
     - [flask-session](https://pythonhosted.org/Flask-Session/)
     - [itsdangerous](https://pythonhosted.org/itsdangerous/)

--- a/tutorial/examples/core_components/date_picker_single.py
+++ b/tutorial/examples/core_components/date_picker_single.py
@@ -12,7 +12,7 @@ app.layout = html.Div([
         min_date_allowed=dt(1995, 8, 5),
         max_date_allowed=dt(2017, 9, 19),
         initial_visible_month=dt(2017, 8, 5),
-        date=dt(2017, 8, 25)
+        date=str(dt(2017, 8, 25, 23, 59, 59))
     ),
     html.Div(id='output-container-date-picker-single')
 ])


### PR DESCRIPTION
- add few edges case like the hour boundaries, leap year, string date
- the single and range has slightly different explanation regarding the date, and I think we should recommend users to use `datetime.date` object as it's purely about date. I also like the simple string solution as 'YYYY-MM-DD'.  this will need a fix in DCC repo

```
Specifies the starting date for the component, best practice is to pass value via datetime object

Specifies the starting date for the component. Accepts datetime.datetime objects or strings in the format 'YYYY-MM-DD'
```