### PR TITLE
[Dash 0.40] Removing 'setProps undefined` from gotchas and react-for-python-devs

### DIFF
--- a/tutorial/faqs.py
+++ b/tutorial/faqs.py
@@ -217,6 +217,21 @@ layout = html.Div([
     `Inputs` or `States` is determined by a user's input, then you must
     pre-define up front every permutation of callback that a user can
     potentially trigger. For an example of how this can be done programmatically
-    using the `callback` decorator, see this [Dash Community forum
-    post](https://community.plot.ly/t/callback-for-dynamically-created-graph/5511). '''))
+  using the `callback` decorator, see this [Dash Community forum
+    post](https://community.plot.ly/t/callback-for-dynamically-created-graph/5511).
+
+    ### All Dash Core Components in a layout should be registered with a callback.
+
+    Note: This section is present for legacy purposes. Prior to v0.40.0, setProps was only defined if the component was connected to a
+    callback. This required complex state management within the component like [this](https://github.com/plotly/dash-core-components/blob/63be1c258c15b419a82fb66366e1a31e66fbfaef/src/components/Input.react.js#L51-L59).
+    Now, setProps is always defined which should simplify your component's state
+    management. Learn more in this [community forum topic](TBD).
+
+    If a Dash Core Component is present in the layout but not registered with a
+    callback (either as an `Input`, `State`, or `Output`) then any changes to its
+    value by the user will be reset to the original value when any callback
+    updates the page.
+
+    This is a known issue and you can track its status in this [GitHub
+    Issue](https://github.com/plotly/dash-renderer/issues/40). '''))
 ])

--- a/tutorial/faqs.py
+++ b/tutorial/faqs.py
@@ -128,7 +128,6 @@ layout = html.Div([
       which is frequently why one might want to use jQuery. You can however use
       parts of jQuery's functionality that do not touch the DOM, such as
       registering event listeners to cause a page redirect on a keystroke.
-
       In general, if you are looking to add custom clientside behavior in your
       application, we recommend encapsulating that behavior in a [custom Dash
       component](https://dash.plot.ly/plugins).

--- a/tutorial/faqs.py
+++ b/tutorial/faqs.py
@@ -219,15 +219,4 @@ layout = html.Div([
     potentially trigger. For an example of how this can be done programmatically
     using the `callback` decorator, see this [Dash Community forum
     post](https://community.plot.ly/t/callback-for-dynamically-created-graph/5511).
-
-
-    ### All Dash Core Components in a layout should be registered with a callback.
-
-    If a Dash Core Component is present in the layout but not registered with a
-    callback (either as an `Input`, `State`, or `Output`) then any changes to its
-    value by the user will be reset to the original value when any callback
-    updates the page.
-
-    This is a known issue and you can track its status in this [GitHub
-    Issue](https://github.com/plotly/dash-renderer/issues/40). '''))
 ])

--- a/tutorial/faqs.py
+++ b/tutorial/faqs.py
@@ -128,6 +128,7 @@ layout = html.Div([
       which is frequently why one might want to use jQuery. You can however use
       parts of jQuery's functionality that do not touch the DOM, such as
       registering event listeners to cause a page redirect on a keystroke.
+
       In general, if you are looking to add custom clientside behavior in your
       application, we recommend encapsulating that behavior in a [custom Dash
       component](https://dash.plot.ly/plugins).

--- a/tutorial/faqs.py
+++ b/tutorial/faqs.py
@@ -218,5 +218,5 @@ layout = html.Div([
     pre-define up front every permutation of callback that a user can
     potentially trigger. For an example of how this can be done programmatically
     using the `callback` decorator, see this [Dash Community forum
-    post](https://community.plot.ly/t/callback-for-dynamically-created-graph/5511).
+    post](https://community.plot.ly/t/callback-for-dynamically-created-graph/5511). '''))
 ])

--- a/tutorial/react_for_python_developers.py
+++ b/tutorial/react_for_python_developers.py
@@ -700,48 +700,6 @@ layout = html.Div([dcc.Markdown('''
 
   In Dash apps, the `dash-renderer` project is very similar to `App.js`. It contains all of the "state" of the application and it passes those properties into the individual components. When a component's properties change through user interaction (e.g. typing into an `<input/>` or hovering on a graph), the component needs to call `setProps` with the new values of the property. Dash's frontend (`dash-renderer`) will then rerender the component with the new property _and_ make the necessary API calls to Dash's Python server callbacks.
 
-  ##### Handling the case when `setProps` isn't defined
-
-  In Dash, `setProps` *is only defined if the particular component is referenced in an `@app.callback`*. If the component isn't referenced in a callback, then Dash's frontend will not pass in the `setProps` property and it will be undefined.
-
-  > As an aside, why does Dash do that? In some cases, it could be computationally expensive to determine the new properties. In these cases, Dash allows component authors to skip doing these computations if the Dash app author doesn't actually need the properties. That is, if the component isn't in any `@app.callback`, then it doesn't need to go through the "effort" to compute it's new properties and inform Dash.
-  >
-
-  In most cases, this is a non-issue. After all, why would you render an `Input` on the page if you didn't want to use it as an `@app.callback`? However, sometimes we still want to be able to interact with the component, even if it isn't connected to Dash's backend. In this case, we'll manage our state locally _or_ through the parent. That is:
-  1. If `setProps` is defined, then the component will call this function when its properties change and Dash will faithfully rerender the component with the new properties that it passed up.
-  2. If `setProps` isn't defined, then the component isn't "connected" to Dash's backend through a callback and it will manage its state locally.
-
-  Here's an example with our `TextInput` component:
-  ```
-  component TextInput extends Component {
-    constructor() {
-      super(props)
-      this.state = props;
-    }
-
-      handleInputChange = (e) => {
-        const newValue = e.target.value;
-        this.props.setProps({value: newValue});
-      }
-
-      render() {
-        let value;
-        if (this.props.setProps) {
-          value = this.props.value;
-        } else {
-          value = this.state.value;
-        }
-        return (
-            <div>
-              <label>{this.props.label}</label>
-              <input value={value} onChange={this.handleInputChange}/>
-              <p>{value}</p>
-            </div>
-          )
-      }
-  }
-  ```
-
 ##### Annotate your function with `propTypes`
 
 The final step in authoring your Dash component is to describe which properties are available.


### PR DESCRIPTION
With https://github.com/plotly/dash-renderer/pull/126, the gotchas and additional instructions are moot.

To be pushed when Dash 0.40.0 is released.