### PR TITLE
:bug: remove the dangerous-inner-html dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ configparser==3.5.0
 dash==0.42.0
 dash-auth==1.2.0
 dash-cytoscape==0.0.5
-dash-dangerously-set-inner-html==0.0.1
 dash-daq==0.1.0
 dash-canvas>=0.0.10
 decorator==4.3.0

--- a/tutorial/search.py
+++ b/tutorial/search.py
@@ -1,7 +1,6 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import dash_dangerously_set_inner_html
 
 
 layout = html.Div(style={'padding': 20},


### PR DESCRIPTION
this fix #481  the root cause is another side effect of react and dev-tools change. we should also fix the dangerous-inner-html component, but it seems the `search.py` code doesn't use it anymore, this PR simply removes the dependency. 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
