### PR TITLE
Use the same value in the description and sample code (Basic Dash Callbacks)

### DIFF
--- a/tutorial/getting_started_part_2.py
+++ b/tutorial/getting_started_part_2.py
@@ -253,7 +253,7 @@ layout = html.Div([
     If you change the `value` of the countries `RadioItems` component, Dash
     will wait until the `value` of the cities component is updated
     before calling the final callback. This prevents your callbacks from being
-    called with inconsistent state like with `"USA"` and `"Montréal"`.
+    called with inconsistent state like with `"America"` and `"Montréal"`.
 
     ''')),
 


### PR DESCRIPTION
I noticed that the value in the description was different from the value of the `RadioItems` in the sample code.
(The former is `USA`. But the latter is `America`.)

**Basic Dash Callback | Dash User Guide**
https://dash.plot.ly/getting-started-part-2

I replaced the value in the description with the value in sample code (America).

---------------------------------------
Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
