### PR TITLE
Fix a broken markup (Dash Core Component)

### DIFF
--- a/tutorial/core_components.py
+++ b/tutorial/core_components.py
@@ -207,9 +207,13 @@ dcc.RadioItems(
     html.Br(),
     dcc.Link(html.A('More Button Examples and Reference'),
              href="/dash-core-components/button"),
-    dcc.Markdown(
-        "For more on `dash.dependencies.State`, see the tutorial on [Dash State](/state)."
-    ),
+    html.P([
+        'For more on ',
+        html.Code('dash.dependencies.State'),
+        ', see the tutorial on ',
+        dcc.Link('Dash State', href='/state'),
+        '.'
+    ]),
 
     html.Hr(),
 

--- a/tutorial/core_components.py
+++ b/tutorial/core_components.py
@@ -207,11 +207,9 @@ dcc.RadioItems(
     html.Br(),
     dcc.Link(html.A('More Button Examples and Reference'),
              href="/dash-core-components/button"),
-    html.P([
-        '''For more on `dash.dependencies.State`, see the tutorial on ''',
-        dcc.Link('Dash State', href='/state'),
-        '.'
-    ]),
+    dcc.Markdown(
+        "For more on `dash.dependencies.State`, see the tutorial on [Dash State](/state)."
+    ),
 
     html.Hr(),
 


### PR DESCRIPTION
I found a broken markup and fixed it.
(Markdown was used in `html.P`. I replaced it with `dcc.Markdown`)

**Dash Core Components | User Guide**
“Button” section   
https://dash.plot.ly/dash-core-components/

**Before:**
![image](https://user-images.githubusercontent.com/31801148/59167331-a7884d00-8b6b-11e9-8f15-4bc76df1cfef.png)

**After:**
![image](https://user-images.githubusercontent.com/31801148/59167338-b0791e80-8b6b-11e9-931d-06d4e0c543e5.png)

----------------------------------
Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
