### PR TITLE
Make Store examples' syntax match their code

### DIFF
--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -1247,186 +1247,12 @@ Store = html.Div([
     See https://github.com/plotly/dash-renderer/pull/81 for further discussion.
     ''')),
     html.H2('Store clicks example'),
-    Syntax(s('''
-    import dash
-
-    import dash_html_components as html
-    import dash_core_components as dcc
-    from dash.dependencies import Output, Input, State
-    from dash.exceptions import PreventUpdate
-
-    # This stylesheet makes the buttons and table pretty.
-    external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
-
-    app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-
-    app.layout = html.Div([
-        # The memory store will always get the default on page refreshes
-        dcc.Store(id='memory'),
-        # The local store will take the initial data
-        # only the first time the page is loaded
-        # and keep it until it is cleared.
-        dcc.Store(id='local', storage_type='local'),
-        # Same as the local store but will lose the data
-        # when the browser/tab closes.
-        dcc.Store(id='session', storage_type='session'),
-
-        html.Div([
-            html.Button('Click to store in memory', id='memory-button'),
-            html.Button('Click to store in localStorage', id='local-button'),
-            html.Button('Click to store in sessionStorage', id='session-button')
-        ]),
-
-        html.Div([
-            html.Table([
-                html.Thead([
-                    html.Tr([
-                        html.Th('Memory clicks'),
-                        html.Th('Local clicks'),
-                        html.Th('Session clicks')
-                    ])
-                ]),
-                html.Tbody([
-                    html.Tr([
-                        html.Td(0, id='memory-clicks'),
-                        html.Td(0, id='local-clicks'),
-                        html.Td(0, id='session-clicks')
-                    ])
-                ])
-            ])
-        ])
-    ])
-
-    # Create two callback for every store.
-    for store in ('memory', 'local', 'session'):
-
-        # add a click to the appropriate store.
-        @app.callback(Output(store, 'data'),
-                      [Input('{}-button'.format(store), 'n_clicks')],
-                      [State(store, 'data')])
-        def on_click(n_clicks, data):
-            if n_clicks is None:
-                # Preventing the None callbacks is important with the store component,
-                # you don't want to update the store for nothing.
-                raise PreventUpdate
-
-            # Give a default data dict with 0 clicks if there's no data.
-            data = data or {'clicks': 0}
-
-            data['clicks'] = data['clicks'] + 1
-            return data
-
-        # output the stored clicks in the table cell.
-        @app.callback(Output('{}-clicks'.format(store), 'children'),
-                      [Input(store, 'modified_timestamp')],
-                      [State(store, 'data')])
-        def on_data(ts, data):
-            if ts is None:
-                raise PreventUpdate
-
-            data = data or {}
-
-            return data.get('clicks', 0)
-
-
-    if __name__ == '__main__':
-        app.run_server(debug=True, port=8077, threaded=True)
-
-    ''')),
+    Syntax(examples['store-clicks'][0]),
     Example(examples['store-clicks'][1]),
 
     html.H2('Share data between callbacks'),
 
-    Syntax(s('''
-    import collections
-    import dash
-    import pandas as pd
-
-    from dash.dependencies import Output, Input
-    from dash.exceptions import PreventUpdate
-
-    import dash_html_components as html
-    import dash_core_components as dcc
-    import dash_table
-
-    app = dash.Dash(__name__)
-
-    df = pd.read_csv(
-        'https://raw.githubusercontent.com/'
-        'plotly/datasets/master/gapminderDataFiveYear.csv')
-
-    countries = set(df['country'])
-
-
-    app.layout = html.Div([
-        dcc.Store(id='memory-output'),
-        dcc.Dropdown(id='memory-countries', options=[
-            {'value': x, 'label': x} for x in countries
-        ], multi=True, value=['Canada', 'United States']),
-        dcc.Dropdown(id='memory-field', options=[
-            {'value': 'lifeExp', 'label': 'Life expectancy'},
-            {'value': 'gdpPercap', 'label': 'GDP per capita'},
-        ], value='lifeExp'),
-        html.Div([
-            dcc.Graph(id='memory-graph'),
-            dash_table.DataTable(
-                id='memory-table',
-                columns=[{'name': i, 'id': i} for i in df.columns]
-            ),
-        ])
-    ])
-
-
-    @app.callback(Output('memory-output', 'data'),
-                  [Input('memory-countries', 'value')])
-    def filter_countries(countries_selected):
-        if not countries_selected:
-            # Return all the rows on initial load/no country selected.
-            return df.to_dict('records')
-
-        filtered = df.query('country in @countries_selected')
-
-        return filtered.to_dict('records')
-
-
-    @app.callback(Output('memory-table', 'data'),
-                  [Input('memory-output', 'data')])
-    def on_data_set_table(data):
-        if data is None:
-            raise PreventUpdate
-
-        return data
-
-
-    @app.callback(Output('memory-graph', 'figure'),
-                  [Input('memory-output', 'data'),
-                   Input('memory-field', 'value')])
-    def on_data_set_graph(data, field):
-        if data is None:
-            raise PreventUpdate
-
-        aggregation = collections.defaultdict(
-            lambda: collections.defaultdict(list)
-        )
-
-        for row in data:
-
-            a = aggregation[row['country']]
-
-            a['name'] = row['country']
-            a['mode'] = 'lines+markers'
-
-            a['x'].append(row[field])
-            a['y'].append(row['year'])
-
-        return {
-            'data': aggregation.values()
-        }
-
-
-    if __name__ == '__main__':
-        app.run_server(debug=True, threaded=True, port=10450)
-    ''')),
+    Syntax(examples['store-share'][0]),
     Example(examples['store-share'][1]),
 
     generate_prop_table('Store'),
@@ -1490,7 +1316,7 @@ Location = html.Div([
     dcc.Markdown(s('''
     The location component represents the location bar in your web browser. Through its `href`, `pathname`,
     `search` and `hash` properties you can access different portions of your app's url.
-    
+
     For example, given the url `http://127.0.0.1:8050/page-2?a=test#quiz`:
 
     - `href` = `"http://127.0.0.1:8050/page-2?a=test#quiz"`

--- a/tutorial/examples/core_components/store_clicks.py
+++ b/tutorial/examples/core_components/store_clicks.py
@@ -1,7 +1,7 @@
 import dash
 
 import dash_html_components as html
-import dash_core_components as dcc  # no-run
+import dash_core_components as dcc  # no-exec
 from dash.dependencies import Output, Input, State
 from dash.exceptions import PreventUpdate
 
@@ -11,15 +11,15 @@ external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 
 app.layout = html.Div([
-    # The memory store will always get the default on page refreshes
-    dcc.Store(id='memory'),  # no-run - stores are loaded from the beginning
+    # The memory store reverts to the default on every page refresh
+    dcc.Store(id='memory'),  # no-exec - stores are loaded from the beginning
     # The local store will take the initial data
     # only the first time the page is loaded
     # and keep it until it is cleared.
-    dcc.Store(id='local', storage_type='local'),  # no-run
+    dcc.Store(id='local', storage_type='local'),  # no-exec
     # Same as the local store but will lose the data
     # when the browser/tab closes.
-    dcc.Store(id='session', storage_type='session'),  # no-run
+    dcc.Store(id='session', storage_type='session'),  # no-exec
     html.Div([
         html.Button('Click to store in memory', id='memory-button'),
         html.Button('Click to store in localStorage', id='local-button'),

--- a/tutorial/examples/core_components/store_clicks.py
+++ b/tutorial/examples/core_components/store_clicks.py
@@ -20,27 +20,25 @@ app.layout = html.Div([
     # Same as the local store but will lose the data
     # when the browser/tab closes.
     dcc.Store(id='session', storage_type='session'),  # no-exec
-    html.Div([
-        html.Button('Click to store in memory', id='memory-button'),
-        html.Button('Click to store in localStorage', id='local-button'),
-        html.Button('Click to store in sessionStorage', id='session-button')
-    ]),
-
-    html.Div([
-        html.Table([
-            html.Thead([
-                html.Tr([
-                    html.Th('Memory clicks'),
-                    html.Th('Local clicks'),
-                    html.Th('Session clicks')
-                ])
+    html.Table([
+        html.Thead([
+            html.Tr(html.Th('Click to store in:', colSpan="3")),
+            html.Tr([
+                html.Th(html.Button('memory', id='memory-button')),
+                html.Th(html.Button('localStorage', id='local-button')),
+                html.Th(html.Button('sessionStorage', id='session-button'))
             ]),
-            html.Tbody([
-                html.Tr([
-                    html.Td(0, id='memory-clicks'),
-                    html.Td(0, id='local-clicks'),
-                    html.Td(0, id='session-clicks')
-                ])
+            html.Tr([
+                html.Th('Memory clicks'),
+                html.Th('Local clicks'),
+                html.Th('Session clicks')
+            ])
+        ]),
+        html.Tbody([
+            html.Tr([
+                html.Td(0, id='memory-clicks'),
+                html.Td(0, id='local-clicks'),
+                html.Td(0, id='session-clicks')
             ])
         ])
     ])

--- a/tutorial/examples/core_components/store_clicks.py
+++ b/tutorial/examples/core_components/store_clicks.py
@@ -1,7 +1,7 @@
 import dash
 
 import dash_html_components as html
-import dash_core_components as dcc
+import dash_core_components as dcc  # no-run
 from dash.dependencies import Output, Input, State
 from dash.exceptions import PreventUpdate
 
@@ -11,8 +11,15 @@ external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 
 app.layout = html.Div([
-
-
+    # The memory store will always get the default on page refreshes
+    dcc.Store(id='memory'),  # no-run - stores are loaded from the beginning
+    # The local store will take the initial data
+    # only the first time the page is loaded
+    # and keep it until it is cleared.
+    dcc.Store(id='local', storage_type='local'),  # no-run
+    # Same as the local store but will lose the data
+    # when the browser/tab closes.
+    dcc.Store(id='session', storage_type='session'),  # no-run
     html.Div([
         html.Button('Click to store in memory', id='memory-button'),
         html.Button('Click to store in localStorage', id='local-button'),

--- a/tutorial/examples/core_components/store_share.py
+++ b/tutorial/examples/core_components/store_share.py
@@ -19,7 +19,7 @@ countries = set(df['country'])
 
 
 app.layout = html.Div([
-
+    dcc.Store(id='memory-output'),  # no-run
     dcc.Dropdown(id='memory-countries', options=[
         {'value': x, 'label': x} for x in countries
     ], multi=True, value=['Canada', 'United States']),

--- a/tutorial/examples/core_components/store_share.py
+++ b/tutorial/examples/core_components/store_share.py
@@ -19,7 +19,7 @@ countries = set(df['country'])
 
 
 app.layout = html.Div([
-    dcc.Store(id='memory-output'),  # no-run
+    dcc.Store(id='memory-output'),  # no-exec
     dcc.Dropdown(id='memory-countries', options=[
         {'value': x, 'label': x} for x in countries
     ], multi=True, value=['Canada', 'United States']),

--- a/tutorial/tools.py
+++ b/tutorial/tools.py
@@ -51,16 +51,16 @@ def load_example(path):
         )
 
         # if there are lines that should be included in the syntax but
-        # not executed, simply put this comment at the end of the line.
-        no_run = '# no-run'
-        if no_run in _example:
+        # not executed, simply put a comment on that line starting "# no-exec"
+        no_exec = '# no-exec'
+        if no_exec in _example:
             _example = '\n'.join(
-                line for line in _example.splitlines() if no_run not in line
+                line for line in _example.splitlines() if no_exec not in line
             )
 
-            find_no_run = re.compile(r'\s+' + no_run + '.*')
+            find_no_exec = re.compile(r'\s+' + no_exec + '.*')
             _source = '\n'.join(
-                find_no_run.sub('', line) if no_run in line else line
+                find_no_exec.sub('', line) if no_exec in line else line
                 for line in _source.splitlines()
             )
 

--- a/tutorial/tools.py
+++ b/tutorial/tools.py
@@ -68,7 +68,7 @@ def load_example(path):
         exec(_example, scope)
 
     return (
-        _source.replace(no_run, ''),
+        _source,
         scope['layout']  # layout is a global created from the app
     )
 


### PR DESCRIPTION
... by extending `load_example` to ignore lines with "# no-run" comments. Stores are "special" components that can't (at least for now) be added outside the original layout, so we create them in the base `run.py`, and we have to strip them out of the examples before running them within the greater docs app. Would be nice to remove that restriction, but until then this at least keeps the two pieces in sync.

This is an updated version of #496 by @StefanTippelt 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [X] I understand
