### PR TITLE
add migration note about dcc & html version.py

### DIFF
--- a/tutorial/migration.py
+++ b/tutorial/migration.py
@@ -121,6 +121,21 @@ layout = html.Div([
     ### Renamed `Checklist.values` prop to `value`
     To match all the other input components.
 
+    ### Removed `version.py`
+    The simple way to get version info has always been `dcc.__version__`.
+    Previously there was a `dash_core_components.version` module you could
+    look in as well, but that has been removed.
+
+    ---
+
+    ## `dash_html_components`
+
+    ### Removed `version.py`
+    Same as in `dash_core_components`.
+    The simple way to get version info has always been `html.__version__`.
+    Previously there was a `dash_html_components.version` module you could
+    look in as well, but that has been removed.
+
     ---
 
     ## `dash_table`


### PR DESCRIPTION
Closes https://github.com/plotly/dash-html-components/issues/120 (along with changes I've already made to the dcc and html changelogs) - notes about the removed `version.py` files in the Dash 1.0 migration guide.

We briefly considered bringing back auto-generated version.py files, and removing `package-info.json` - but the even better solution will be to auto-generate the whole `__init__.py` based on some info about js and css dist files that can also be used by the R codegen system.

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [X] I understand