### PR TITLE
let python env not be necessarily 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Dash Userguide is hosted online at: [https://plot.ly/dash](https://plot.ly/d
 
 To run an app locally:
 
-1. (optional) create and activate new virtualenv or conda env (Python 2.7):
+1. (optional) create and activate new virtualenv or conda env:
 
 ```
 pip install virtualenv
@@ -18,7 +18,7 @@ source venv/bin/activate
 
 or, with conda:
 ```
-conda create --yes -n dash_docs python=2.7
+conda create --yes -n dash_docs
 source activate dash_docs
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 algoliasearch==1.15.3
-biopython==1.73
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7


### PR DESCRIPTION
Change 9926897 is not actually (explicitly) porting the docs to py3, we're only dropping the instruction of activating a py2.7 conda env.

Change fb39272 matches https://github.com/plotly/dash-bio/commit/316b1e284ffca99f95e54dce614044be7d5836e6 now that `dash-bio>=0.1.0` (https://github.com/plotly/dash-bio/blob/master/CHANGELOG.md#010---2019-05-27).

The `biopython` dependency comes into play when using `dash-cytoscape` as well (https://github.com/plotly/dash-cytoscape/blob/e1f25c14aaa4900685876dfbcddcfe5516ae7ebe/requirements.txt#L1: it's a dependency of dependency so it shouldn't need to be in the top-level requirements).

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
