### PR TITLE
Add useful reusable components for DashR docs

### DIFF
--- a/dashr/components.R
+++ b/dashr/components.R
@@ -1,12 +1,26 @@
 source('dashr/styles.R')
 
-Syntax = function(children, language='R', style=styles$code_container, summary=''){
+# Added Reuseable Components
+
+Header <- function(title) {
+  return (
+    htmlDiv(
+      htmlH2(
+        list(htmlDiv(title)),
+        style = list('borderBottom' = 'thin lightgrey solid', 'marginRight' = 20)
+      ),
+    )
+  )
+}
+
+# Existing Components (may need to edit)
+
+Syntax <- function(children, language='R', style=styles$code_container, summary=''){
   if (!(summary == '')){
   return(htmlDetails(list(
     htmlSummary(summary),
     htmlDiv(children)
-    )
-  , 
+    ),
     open=TRUE))}
 else{
   return(dccSyntaxHighlighter(
@@ -16,5 +30,6 @@ else{
   ))
 }}
 
-Example = function(example){
+Example <- function(example){
   return(htmlDiv(example, className='example-container'))}
+

--- a/dashr/components.R
+++ b/dashr/components.R
@@ -37,6 +37,20 @@ Chapter <- function(name, href = NA, caption = NA) {
   }
 }
 
+Section <- function(title, links, description = NA, headerStyle = list()) {
+  #ifelse(is.na(description), )
+  return(
+    htmlDiv(
+      className = 'toc--section',
+      children = list(
+        htmlH2(title, style = c(list('borderBottom' = 'thin lightgrey solid', 'marginTop' = 50), headerStyle)),
+        htmlDiv(description),
+        htmlUl(links, className = 'toc--chapters')
+      )
+    )
+  )
+}
+
 # Existing Components (may need to edit)
 
 Syntax <- function(children, language='R', style=styles$code_container, summary=''){

--- a/dashr/components.R
+++ b/dashr/components.R
@@ -13,6 +13,30 @@ Header <- function(title) {
   )
 }
 
+Chapter <- function(name, href = NA, caption = NA) {
+  divTitle <- htmlLi(
+    dccLink(
+      name,
+      href = href,
+      id = href,
+      className = 'toc--chapter-link'
+    ),
+  )
+  divCaption <- htmlSmall(
+    className = 'toc--chapter-content',
+    children = dccMarkdown(caption),
+    style = list(
+      'display' = 'block',
+      'marginTop' = '-8px'
+    )
+  )
+  if (!is.na(caption)) {
+    return (htmlDiv(className = 'toc--chapter', children = list(divTitle, divCaption)))
+  } else {
+    return (htmlDiv(className = 'toc--chapter', children = list(divTitle)))
+  }
+}
+
 # Existing Components (may need to edit)
 
 Syntax <- function(children, language='R', style=styles$code_container, summary=''){

--- a/dashr/components.R
+++ b/dashr/components.R
@@ -25,10 +25,7 @@ Chapter <- function(name, href = NA, caption = NA) {
   divCaption <- htmlSmall(
     className = 'toc--chapter-content',
     children = dccMarkdown(caption),
-    style = list(
-      'display' = 'block',
-      'marginTop' = '-8px'
-    )
+    style = list('display' = 'block', 'marginTop' = '-8px')
   )
   # return (
   #   htmlDiv(

--- a/dashr/components.R
+++ b/dashr/components.R
@@ -6,9 +6,9 @@ Header <- function(title) {
   return (
     htmlDiv(
       htmlH2(
-        list(htmlDiv(title)),
+        title,
         style = list('borderBottom' = 'thin lightgrey solid', 'marginRight' = 20)
-      ),
+      )
     )
   )
 }
@@ -30,6 +30,12 @@ Chapter <- function(name, href = NA, caption = NA) {
       'marginTop' = '-8px'
     )
   )
+  # return (
+  #   htmlDiv(
+  #     className = 'toc--chapter',
+  #     children = ifelse(!is.na(caption), list(divTitle, divCaption), list(divTitle))
+  #   )
+  # )
   if (!is.na(caption)) {
     return (htmlDiv(className = 'toc--chapter', children = list(divTitle, divCaption)))
   } else {
@@ -43,9 +49,15 @@ Section <- function(title, links, description = NA, headerStyle = list()) {
     htmlDiv(
       className = 'toc--section',
       children = list(
-        htmlH2(title, style = c(list('borderBottom' = 'thin lightgrey solid', 'marginTop' = 50), headerStyle)),
+        htmlH2(
+          title,
+          style = c(list('borderBottom' = 'thin lightgrey solid', 'marginTop' = 50), headerStyle)
+        ),
         htmlDiv(description),
-        htmlUl(links, className = 'toc--chapters')
+        htmlUl(
+          links,
+          className = 'toc--chapters'
+        )
       )
     )
   )
@@ -53,21 +65,34 @@ Section <- function(title, links, description = NA, headerStyle = list()) {
 
 # Existing Components (may need to edit)
 
-Syntax <- function(children, language='R', style=styles$code_container, summary=''){
-  if (!(summary == '')){
-  return(htmlDetails(list(
-    htmlSummary(summary),
-    htmlDiv(children)
-    ),
-    open=TRUE))}
-else{
-  return(dccSyntaxHighlighter(
-    children,
-    'language'=language,
-    'customStyle'=style
-  ))
-}}
+Syntax <- function(children, language = 'R', style = styles$code_container, summary = ''){
+  if (!(summary == '')) {
+    return(
+      htmlDetails(
+        list(
+          htmlSummary(summary),
+          htmlDiv(children)
+        ),
+        open=TRUE
+      )
+    )
+  } else {
+    return(
+      dccSyntaxHighlighter(
+        children,
+        'language' = language,
+        'customStyle' = style
+      )
+    )
+  }
+}
 
 Example <- function(example){
-  return(htmlDiv(example, className='example-container'))}
+  return(
+    htmlDiv(
+      example,
+      className = 'example-container'
+    )
+  )
+}
 

--- a/run.R
+++ b/run.R
@@ -120,188 +120,188 @@ app$callback(
   output=list(id='chapter', property='children'),
   params=list(input('url', 'pathname')),
   function(pathname) {
-   switch(
-     pathname,
-     "/Whats_dash" = return(chapters.Whats_dash$layout),
-     "/installation" = return(chapters.installation$layout),
-     "/getting-started" = return(chapters.getting_started$layout),
-     "/getting-started-part-2" = return(chapters.callbacks$layout),
-     "/state" = return(chapters.state$layout),
-     "/graph-crossfiltering" = return(chapters.graph_crossfiltering$layout),
-     #"/data-callbacks" = return(chapters.data_callbacks$layout),
-     "/faq-gotchas" = return(chapters.faq_gotchas$layout),
-     '/dash-core-components' = return(chapters.dashCoreComponents$layout),
-     '/dash-core-components/Dropdown' = return(chapters.dccDropdown$layout),
-     '/dash-core-components/Slider' = return(chapters.dccSlider$layout),
-     '/dash-core-components/RangeSlider' = return(chapters.RangeSlider$layout),
-     '/dash-core-components/Input' = return(chapters.Input$layout),
-     '/dash-core-components/Textarea' = return(chapters.TextArea$layout),
-     '/dash-core-components/Checklist' = return(chapters.Checklist$layout),
-     '/dash-core-components/Radioitems' = return(chapters.RadioItems$layout),
-     '/dash-core-components/Button' = return(chapters.Button$layout),
-     '/dash-core-components/DatePickerSingle' = return(chapters.DatePickerSingle$layout),
-     '/dash-core-components/DatePickerRange' = return(chapters.DatePickerRange$layout),
-     '/dash-core-components/Markdown' = return(chapters.Markdown$layout),
-     '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
-     '/dash-core-components/ConfirmDialog' = return(chapters.ConfirmDialog$layout),
-     '/dash-core-components/ConfirmDialogProvider' = return(chapters.ConfirmDialogProvider$layout),
-     '/dash-core-components/Store' = return(chapters.Store$layout),
-     '/dash-core-components/Location' = return(chapters.Location$layout),
-     '/dash-core-components/LoadingComponent' = return(chapters.LoadingComponent$layout),
-     '/dash-core-components/Graph' = return(chapters.Graph$layout),
-     '/dash-core-components/Tabs' = return(chapters.Tabs$layout),
-     '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
-     '/dash-html-components' = return(chapters.dashHtmlComponents$layout),
-     '/dashDataTable' = return(chapters.dashDataTable$layout),
-     '/dashDataTable/Part1' = return(chapters.dashDataTablePart1$layout),
-     '/external-resources' = return(chapters.external_resources$layout),
-     {
-       htmlDiv(
-         list(
-           htmlH1('DashR User Guide'),
+    switch(
+      pathname,
+      "/Whats_dash" = return(chapters.Whats_dash$layout),
+      "/installation" = return(chapters.installation$layout),
+      "/getting-started" = return(chapters.getting_started$layout),
+      "/getting-started-part-2" = return(chapters.callbacks$layout),
+      "/state" = return(chapters.state$layout),
+      "/graph-crossfiltering" = return(chapters.graph_crossfiltering$layout),
+      #"/data-callbacks" = return(chapters.data_callbacks$layout),
+      "/faq-gotchas" = return(chapters.faq_gotchas$layout),
+      '/dash-core-components' = return(chapters.dashCoreComponents$layout),
+      '/dash-core-components/Dropdown' = return(chapters.dccDropdown$layout),
+      '/dash-core-components/Slider' = return(chapters.dccSlider$layout),
+      '/dash-core-components/RangeSlider' = return(chapters.RangeSlider$layout),
+      '/dash-core-components/Input' = return(chapters.Input$layout),
+      '/dash-core-components/Textarea' = return(chapters.TextArea$layout),
+      '/dash-core-components/Checklist' = return(chapters.Checklist$layout),
+      '/dash-core-components/Radioitems' = return(chapters.RadioItems$layout),
+      '/dash-core-components/Button' = return(chapters.Button$layout),
+      '/dash-core-components/DatePickerSingle' = return(chapters.DatePickerSingle$layout),
+      '/dash-core-components/DatePickerRange' = return(chapters.DatePickerRange$layout),
+      '/dash-core-components/Markdown' = return(chapters.Markdown$layout),
+      '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
+      '/dash-core-components/ConfirmDialog' = return(chapters.ConfirmDialog$layout),
+      '/dash-core-components/ConfirmDialogProvider' = return(chapters.ConfirmDialogProvider$layout),
+      '/dash-core-components/Store' = return(chapters.Store$layout),
+      '/dash-core-components/Location' = return(chapters.Location$layout),
+      '/dash-core-components/LoadingComponent' = return(chapters.LoadingComponent$layout),
+      '/dash-core-components/Graph' = return(chapters.Graph$layout),
+      '/dash-core-components/Tabs' = return(chapters.Tabs$layout),
+      '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
+      '/dash-html-components' = return(chapters.dashHtmlComponents$layout),
+      '/dashDataTable' = return(chapters.dashDataTable$layout),
+      '/dashDataTable/Part1' = return(chapters.dashDataTablePart1$layout),
+      '/external-resources' = return(chapters.external_resources$layout),
+      {
+        htmlDiv(
+          list(
+            htmlH1('DashR User Guide'),
 
 
-           components$Header('What\'s Dash?'),
-           htmlA(
-             'Introduction',
-             href='https://dash.plot.ly/introduction'
-           ),
-           htmlBr(),
-           dccMarkdown("A quick paragraph about Dash and a link to the talk at Plotcon that started it all."),
-           htmlA(
-             'Announcement Essay',
-             href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503'
-           ),
-           htmlBr(),
-           dccMarkdown("Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."),
-           htmlA(
-             'Dash App Gallery',
-             href='https://dash.plot.ly/gallery'
-           ),
-           htmlBr(),
-           dccMarkdown("A glimpse into what's possible with Dash."),
-           htmlA(
-             'Dash Club',
-             href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7'
-           ),
-           htmlBr(),
-           dccMarkdown("A fortnightly email newsletter by chriddyp, the creator of Dash."),
+            components$Header('What\'s Dash?'),
+            components$Chapter(
+              'Introduction',
+              href='https://dash.plot.ly/introduction',
+              caption="A quick paragraph about Dash and a link to the talk at Plotcon that started it all."
+            ),
+            components$Chapter(
+              'Announcement Essay',
+              href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503',
+              caption="Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."
+            ),
+            components$Chapter(
+              'Dash App Gallery',
+              href='https://dash.plot.ly/gallery',
+              caption="A glimpse into what's possible with Dash."
+            ),
+            components$Chapter(
+              'Dash Club',
+              href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7',
+              caption="A fortnightly email newsletter by chriddyp, the creator of Dash."
+            ),
 
 
-           components$Header("Dash Tutorial"),
-           dccLink(
-             'Part 1. Installation',
-             href='/installation'
-           ),
-           htmlBr(),
-           dccLink(
-             'Part 2. The Dash Layout',
-             href='/getting-started'
-           ),
-           dccMarkdown("The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."),
-           htmlBr(),
-           dccLink(
-             'Part 3. Basic Callbacks',
-             href='/getting-started-part-2'
-           ),
-           dccMarkdown("Dash apps are made interactive through Dash Callbacks:
-R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
-allowing one update in the UI to trigger several updates across the app."),
-           htmlBr(),
-           dccLink(
-             'Part 4. Callbacks With State',
-             href='/state'
-           ),
-           dccMarkdown("Basic callbacks are fired whenever the values change.
-Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
-`state` is useful for UIs that contain forms or buttons."),
-           htmlBr(),
-           dccLink(
-            'Part 5. Interactive Graphing and Crossfiltering',
-            href='/graph-crossfiltering'
-           ),
-           dccMarkdown("Bind interactivity to the Dash `Graph` component whenever you hover, click, or
-           select points on your chart."),
-           htmlBr(),
-           dccLink(
-             'Part 6. Sharing Data Between Callbacks',
-             href='/data-callbacks'
-           ),
-           dccMarkdown("`global` variables will break your Dash apps.
-However, there are other ways to share data between callbacks.
-This chapter is useful for callbacks that run expensive data processing tasks or process large data."),
-           htmlBr(),
-           dccLink(
-             'Part 7. FAQs and Gotchas',
-             href='/faq-gotchas'
-           ),
-           dccMarkdown("If you have read through the rest of the tutorial and still have questions
-or are encountering unexpected behaviour,this chapter may be useful."),
+            components$Header("Dash Tutorial"),
+            components$Chapter(
+              'Part 1. Installation',
+              href='/installation'
+            ),
+            components$Chapter(
+              'Part 2. The Dash Layout',
+              href='/getting-started',
+              caption="The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."
+            ),
+            components$Chapter(
+              'Part 3. Basic Callbacks',
+              href='/getting-started-part-2',
+              caption="Dash apps are made interactive through Dash Callbacks:
+              R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
+              allowing one update in the UI to trigger several updates across the app."
+            ),
+            components$Chapter(
+              'Part 4. Callbacks With State',
+              href='/state',
+              caption="Basic callbacks are fired whenever the values change.
+              Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
+              `state` is useful for UIs that contain forms or buttons."
+            ),
+            components$Chapter(
+              'Part 5. Interactive Graphing and Crossfiltering',
+              href='/graph-crossfiltering',
+              caption="Bind interactivity to the Dash `Graph` component whenever you hover, click, or
+              select points on your chart."
+            ),
+            components$Chapter(
+              'Part 6. Sharing Data Between Callbacks',
+              href='/data-callbacks',
+              caption="`global` variables will break your Dash apps.
+              However, there are other ways to share data between callbacks.
+              This chapter is useful for callbacks that run expensive data processing tasks or process large data."
+            ),
+            components$Chapter(
+              'Part 7. FAQs and Gotchas',
+              href='/faq-gotchas',
+              caption="If you have read through the rest of the tutorial and still have questions
+              or are encountering unexpected behaviour,this chapter may be useful."
+            ),
 
 
-           components$Header('Component Libraries'),
-           dccLink(
-             'Dash Core Components',
-             href='/dash-core-components'
-           ),
-           htmlBr(),
-           dccMarkdown("The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."),
-           dccLink(
-             'Dash HTML Components',
-             href='/dash-html-components'
-           ),
-           htmlBr(),
-           dccMarkdown("Dash provides all of the available HTML tags as user-friendly Python classes.
-This chapter explains how this works and the few important key differences between Dash HTML components and standard html.
-        "),
-           dccLink(
-             'Dash DataTable',
-             href='/dashDataTable'
-           ),
-           htmlBr(),
-           dccMarkdown("(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component.
-It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."),
+            components$Header('Component Libraries'),
+            components$Chapter(
+              'Dash Core Components',
+              href='/dash-core-components',
+              caption="The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."
+            ),
+            components$Chapter(
+              'Dash HTML Components',
+              href='/dash-html-components',
+              caption="Dash provides all of the available HTML tags as user-friendly Python classes.
+              This chapter explains how this works and the few important key differences between Dash HTML components and standard html."
+            ),
+            components$Chapter(
+              'Dash DataTable',
+              href='/dashDataTable',
+              caption="(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component.
+              It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."
+            ),
 
 
-           components$Header('Creating Your Own Components'),
-           dccMarkdown("IN PROGRESS..."),
+            components$Header('Creating Your Own Components'),
+            dccMarkdown("IN PROGRESS..."),
+            components$Chapter(
+              '',
+              href='',
+              caption=
+            ),
 
 
-           components$Header('Beyond the Basics'),
-           dccLink(
-             'Adding CSS & JS and Overriding the Page-Load Template',
-             href='/external-resources'
-           ),
-           htmlBr(),
-           dccMarkdown("Learn how to add custom CSS and JS to your application with the `assets` directory.
-Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."),
+            components$Header('Beyond the Basics'),
+            components$Chapter(
+              'Adding CSS & JS and Overriding the Page-Load Template',
+              href='/external-resources',
+              caption="Learn how to add custom CSS and JS to your application with the `assets` directory.
+              Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."
+            ),
 
 
-           components$Header('Production'),
-           dccMarkdown("IN PROGRESS..."),
+            components$Header('Production'),
+            dccMarkdown("IN PROGRESS..."),
+            components$Chapter(
+              '',
+              href='',
+              caption=
+            ),
 
 
-           components$Header('Getting Help'),
-           dccMarkdown("IN PROGRESS..."),
+            components$Header('Getting Help'),
+            dccMarkdown("IN PROGRESS..."),
+            components$Chapter(
+              '',
+              href='',
+              caption=
+            ),
 
 
-           htmlH2('Dash Deployment Server',
-                  style = list(color = "rgb(13, 118, 191)")),
-           dccMarkdown("Dash Deployment Server is Plotly's commercial offering for hosting and sharing
-Dash apps on-premises or in the cloud."),
-           dccLink(
-             'About Dash Deployment Server',
-             href='/faq-gotchas'
-           ),
-           htmlBr(),
-           dccLink(
-             'Dash Deployment Server Documentation',
-             href='/faq-gotchas'
-           )
-         )
-       )
-     }
-   )
- })
+            htmlH2('Dash Deployment Server',
+            style = list(color = "rgb(13, 118, 191)")),
+            dccMarkdown("Dash Deployment Server is Plotly's commercial offering for hosting and sharing
+            Dash apps on-premises or in the cloud."),
+            components$Chapter(
+              'About Dash Deployment Server',
+              href='/faq-gotchas'
+            ),
+            components$Chapter(
+              'Dash Deployment Server Documentation',
+              href='/faq-gotchas'
+            )
+          )
+        )
+      }
+    )
+  }
+)
 
 app$run_server(host = "0.0.0.0", port = Sys.getenv('PORT', 8050))

--- a/run.R
+++ b/run.R
@@ -161,141 +161,155 @@ app$callback(
             htmlH1('DashR User Guide'),
 
 
-            components$Header('What\'s Dash?'),
-            components$Chapter(
-              'Introduction',
-              href='https://dash.plot.ly/introduction',
-              caption="A quick paragraph about Dash and a link to the talk at Plotcon that started it all."
-            ),
-            components$Chapter(
-              'Announcement Essay',
-              href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503',
-              caption="Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."
-            ),
-            components$Chapter(
-              'Dash App Gallery',
-              href='https://dash.plot.ly/gallery',
-              caption="A glimpse into what's possible with Dash."
-            ),
-            components$Chapter(
-              'Dash Club',
-              href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7',
-              caption="A fortnightly email newsletter by chriddyp, the creator of Dash."
-            ),
-
-
-            components$Header("Dash Tutorial"),
-            components$Chapter(
-              'Part 1. Installation',
-              href='/installation'
-            ),
-            components$Chapter(
-              'Part 2. The Dash Layout',
-              href='/getting-started',
-              caption="The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."
-            ),
-            components$Chapter(
-              'Part 3. Basic Callbacks',
-              href='/getting-started-part-2',
-              caption="Dash apps are made interactive through Dash Callbacks:
-              R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
-              allowing one update in the UI to trigger several updates across the app."
-            ),
-            components$Chapter(
-              'Part 4. Callbacks With State',
-              href='/state',
-              caption="Basic callbacks are fired whenever the values change.
-              Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
-              `state` is useful for UIs that contain forms or buttons."
-            ),
-            components$Chapter(
-              'Part 5. Interactive Graphing and Crossfiltering',
-              href='/graph-crossfiltering',
-              caption="Bind interactivity to the Dash `Graph` component whenever you hover, click, or
-              select points on your chart."
-            ),
-            components$Chapter(
-              'Part 6. Sharing Data Between Callbacks',
-              href='/data-callbacks',
-              caption="`global` variables will break your Dash apps.
-              However, there are other ways to share data between callbacks.
-              This chapter is useful for callbacks that run expensive data processing tasks or process large data."
-            ),
-            components$Chapter(
-              'Part 7. FAQs and Gotchas',
-              href='/faq-gotchas',
-              caption="If you have read through the rest of the tutorial and still have questions
-              or are encountering unexpected behaviour,this chapter may be useful."
+            components$Section(
+              'What\'s Dash?',
+              list(
+                components$Chapter(
+                  'Introduction',
+                  href='https://dash.plot.ly/introduction',
+                  caption="A quick paragraph about Dash and a link to the talk at Plotcon that started it all."
+                ),
+                components$Chapter(
+                  'Announcement Essay',
+                  href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503',
+                  caption="Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."
+                ),
+                components$Chapter(
+                  'Dash App Gallery',
+                  href='https://dash.plot.ly/gallery',
+                  caption="A glimpse into what's possible with Dash."
+                ),
+                components$Chapter(
+                  'Dash Club',
+                  href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7',
+                  caption="A fortnightly email newsletter by chriddyp, the creator of Dash."
+                )
+              )
             ),
 
 
-            components$Header('Component Libraries'),
-            components$Chapter(
-              'Dash Core Components',
-              href='/dash-core-components',
-              caption="The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."
-            ),
-            components$Chapter(
-              'Dash HTML Components',
-              href='/dash-html-components',
-              caption="Dash provides all of the available HTML tags as user-friendly Python classes.
-              This chapter explains how this works and the few important key differences between Dash HTML components and standard html."
-            ),
-            components$Chapter(
-              'Dash DataTable',
-              href='/dashDataTable',
-              caption="(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component.
-              It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."
-            ),
-
-
-            components$Header('Creating Your Own Components'),
-            dccMarkdown("IN PROGRESS..."),
-            components$Chapter(
-              '',
-              href='',
-              caption=
-            ),
-
-
-            components$Header('Beyond the Basics'),
-            components$Chapter(
-              'Adding CSS & JS and Overriding the Page-Load Template',
-              href='/external-resources',
-              caption="Learn how to add custom CSS and JS to your application with the `assets` directory.
-              Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."
-            ),
-
-
-            components$Header('Production'),
-            dccMarkdown("IN PROGRESS..."),
-            components$Chapter(
-              '',
-              href='',
-              caption=
-            ),
-
-
-            components$Header('Getting Help'),
-            dccMarkdown("IN PROGRESS..."),
-            components$Chapter(
-              '',
-              href='',
-              caption=
+            components$Section(
+              'Dash Tutorial',
+              list(
+                components$Chapter(
+                  'Part 1. Installation',
+                  href='/installation'
+                ),
+                components$Chapter(
+                  'Part 2. The Dash Layout',
+                  href='/getting-started',
+                  caption="The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."
+                ),
+                components$Chapter(
+                  'Part 3. Basic Callbacks',
+                  href='/getting-started-part-2',
+                  caption="Dash apps are made interactive through Dash Callbacks:
+                  R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
+                  allowing one update in the UI to trigger several updates across the app."
+                ),
+                components$Chapter(
+                  'Part 4. Callbacks With State',
+                  href='/state',
+                  caption="Basic callbacks are fired whenever the values change.
+                  Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
+                  `state` is useful for UIs that contain forms or buttons."
+                ),
+                components$Chapter(
+                  'Part 5. Interactive Graphing and Crossfiltering',
+                  href='/graph-crossfiltering',
+                  caption="Bind interactivity to the Dash `Graph` component whenever you hover, click, or
+                  select points on your chart."
+                ),
+                components$Chapter(
+                  'Part 6. Sharing Data Between Callbacks',
+                  href='/data-callbacks',
+                  caption="`global` variables will break your Dash apps.
+                  However, there are other ways to share data between callbacks.
+                  This chapter is useful for callbacks that run expensive data processing tasks or process large data."
+                ),
+                components$Chapter(
+                  'Part 7. FAQs and Gotchas',
+                  href='/faq-gotchas',
+                  caption="If you have read through the rest of the tutorial and still have questions
+                  or are encountering unexpected behaviour,this chapter may be useful."
+                )
+              )
             ),
 
 
-            htmlH2('Dash Deployment Server',
-            style = list(color = "rgb(13, 118, 191)")),
-            dccMarkdown("Dash Deployment Server is Plotly's commercial offering for hosting and sharing
-            Dash apps on-premises or in the cloud."),
-            components$Chapter(
-              'About Dash Deployment Server',
-              href='/faq-gotchas'
+            components$Section(
+              'Component Libraries',
+              list(
+                components$Chapter(
+                  'Dash Core Components',
+                  href='/dash-core-components',
+                  caption="The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."
+                ),
+                components$Chapter(
+                  'Dash HTML Components',
+                  href='/dash-html-components',
+                  caption="Dash provides all of the available HTML tags as user-friendly Python classes.
+                  This chapter explains how this works and the few important key differences between Dash HTML components and standard html."
+                ),
+                components$Chapter(
+                  'Dash DataTable',
+                  href='/dashDataTable',
+                  caption="(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component.
+                  It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."
+                )
+              )
             ),
-            components$Chapter(
-              'Dash Deployment Server Documentation',
-              href='/faq-gotchas'
+
+
+            components$Section(
+              'Creating Your Own Components',
+              list(),
+              description="IN PROGRESS..."
+            ),
+
+
+            components$Section(
+              'Beyond the Basics',
+              list(
+                components$Chapter(
+                  'Adding CSS & JS and Overriding the Page-Load Template',
+                  href='/external-resources',
+                  caption="Learn how to add custom CSS and JS to your application with the `assets` directory.
+                  Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."
+                )
+              )
+            ),
+
+
+            components$Section(
+              'Production',
+              list(),
+              description="IN PROGRESS..."
+            ),
+
+
+            components$Section(
+              'Getting Help',
+              list(),
+              description="IN PROGRESS..."
+            ),
+
+
+            components$Section(
+              'Dash Deployment Server',
+              list(
+                components$Chapter(
+                  'About Dash Deployment Server',
+                  href='/faq-gotchas'
+                ),
+                components$Chapter(
+                  'Dash Deployment Server Documentation',
+                  href='/faq-gotchas'
+                )
+              ),
+              description="Dash Deployment Server is Plotly's commercial offering for hosting and sharing
+              Dash apps on-premises or in the cloud.",
+              headerStyle=list('color'='#0D76BF')
             )
           )
         )

--- a/run.R
+++ b/run.R
@@ -1,305 +1,307 @@
-  setwd('/Users/kevinphan/Desktop/dash-docs')
-  
-  source('app.R')
-  library(dash)
-  library(dashCoreComponents)
-  library(dashHtmlComponents)
-  library(jsonlite)
-  
-  chapters.installation <- new.env()
-  source('dashr/chapters/installation/index.R', local=chapters.installation)
-  chapters.getting_started <- new.env()
-  source('dashr/chapters/getting-started/index.R', local=chapters.getting_started)
-  chapters.callbacks <- new.env()
-  source('dashr/chapters/callbacks/index.R', local=chapters.callbacks)
-  chapters.state <- new.env()
-  source('dashr/chapters/state/index.R', local=chapters.state)
-  chapters.graph_crossfiltering <- new.env()
-  source('dashr/chapters/graph-crossfiltering/index.R', local=chapters.graph_crossfiltering)
-  #chapters.data_callbacks <- new.env()
-  #source('dashr/chapters/data-callbacks/index.R', local=chapters.data_callbacks)
-  chapters.faq_gotchas <- new.env()
-  source('dashr/chapters/faq-gotchas/index.R', local=chapters.faq_gotchas)
-  chapters.dashCoreComponents <- new.env()
-  source('dashr/chapters/dash-core-components/index.R', local=chapters.dashCoreComponents)
-  chapters.dccDropdown <- new.env()
-  source('dashr/chapters/dash-core-components/dropdown/index.R', local=chapters.dccDropdown)
-  chapters.dccSlider <- new.env()
-  source('dashr/chapters/dash-core-components/slider/index.R', local=chapters.dccSlider)
-  chapters.RangeSlider <- new.env()
-  source('dashr/chapters/dash-core-components/RangeSlider/index.R', local=chapters.RangeSlider)
-  chapters.Input <- new.env()
-  source('dashr/chapters/dash-core-components/Input/index.R', local=chapters.Input)
-  chapters.TextArea <- new.env()
-  source('dashr/chapters/dash-core-components/Textarea/index.R', local=chapters.TextArea)
-  chapters.Checklist <- new.env()
-  source('dashr/chapters/dash-core-components/Checklist/index.R', local=chapters.Checklist)
-  chapters.RadioItems  <- new.env()
-  source('dashr/chapters/dash-core-components/Radioitems/index.R', local=chapters.RadioItems)
-  chapters.Button  <- new.env()
-  source('dashr/chapters/dash-core-components/Button/index.R', local=chapters.Button)
-  chapters.DatePickerSingle  <- new.env()
-  source('dashr/chapters/dash-core-components/Datepickersingle/index.R', local=chapters.DatePickerSingle)
-  chapters.DatePickerRange  <- new.env()
-  source('dashr/chapters/dash-core-components/DatePickerRange/index.R', local=chapters.DatePickerRange)
-  chapters.Markdown  <- new.env()
-  source('dashr/chapters/dash-core-components/Markdown/index.R', local=chapters.Markdown)
-  chapters.UploadComponent  <- new.env()
-  source('dashr/chapters/dash-core-components/UploadComponent/index.R', local=chapters.UploadComponent)
-  chapters.ConfirmDialog  <- new.env()
-  source('dashr/chapters/dash-core-components/ConfirmDialog/index.R', local=chapters.ConfirmDialog)
-  chapters.ConfirmDialogProvider  <- new.env()
-  source('dashr/chapters/dash-core-components/ConfirmDialogProvider/index.R', local=chapters.ConfirmDialogProvider)
-  chapters.Store  <- new.env()
-  source('dashr/chapters/dash-core-components/Store/index.R', local=chapters.Store)
-  chapters.Location  <- new.env()
-  source('dashr/chapters/dash-core-components/Location/index.R', local=chapters.Location)
-  chapters.LoadingComponent  <- new.env()
-  source('dashr/chapters/dash-core-components/LoadingComponent/index.R', local=chapters.LoadingComponent)
-  chapters.Graph  <- new.env()
-  source('dashr/chapters/dash-core-components/Graph/index.R', local=chapters.Graph)
-  chapters.Tabs  <- new.env()
-  source('dashr/chapters/dash-core-components/Tabs/index.R', local=chapters.Tabs)
-  chapters.UploadComponent  <- new.env()
-  source('dashr/chapters/dash-core-components/UploadComponent/index.R', local=chapters.UploadComponent )
-  chapters.dashHtmlComponents <- new.env()
-  source('dashr/chapters/dash-html-components/index.R', local=chapters.dashHtmlComponents)
-  chapters.external_resources <- new.env()
-  source('dashr/chapters/external-resources/index.R', local=chapters.external_resources)
-  #chapters.dashDataTable <- new.env()
-  #source('dashr/chapters/dashDataTable/index.R', local=chapters.dashDataTable)
-  chapters.dashDataTablePart1 <- new.env()
-  #source('dashr/chapters/dashDataTable/part1/index.R', local=chapters.dashDataTablePart1)
-  chapters.Whats_dash <- new.env()
-  source('dashr/chapters/Whats_dash/introduction.R', local=chapters.Whats_dash)
-  
-  header <- htmlDiv(
-    className = 'header',
-    list(
-      htmlDiv(
-        style = list(height = '95%'),
-        className = 'container-width',
-        children = list(
-          htmlA(htmlImg(
-            style = list(height = '100%'),
-            src = 'https://user-images.githubusercontent.com/1865834/50180824-abcc5f80-02d8-11e9-8319-8842909c3f8e.png'
-          ), href = 'https://plot.ly/products/dash', className='logo-link'),
-          htmlDiv(className='links', children = list(
-            htmlA('pricing', className='link', href = 'https://plot.ly/dash/pricing'),
-            htmlA('user guide', className='link', href = '/'),
-            htmlA('plotly', className='link', href = 'https://plot.ly/'),
-            htmlA(children=list(htmlI(className="fa fa-search")), className='link', href='https://dash.plot.ly/search')
-          ))
-        ))
-    ))
-  
-  app$layout(
-    header,
+source('app.R')
+library(dash)
+library(dashCoreComponents)
+library(dashHtmlComponents)
+library(jsonlite)
+
+components <- new.env()
+source('dashr/components.R', local=components)
+
+chapters.installation <- new.env()
+source('dashr/chapters/installation/index.R', local=chapters.installation)
+chapters.getting_started <- new.env()
+source('dashr/chapters/getting-started/index.R', local=chapters.getting_started)
+chapters.callbacks <- new.env()
+source('dashr/chapters/callbacks/index.R', local=chapters.callbacks)
+chapters.state <- new.env()
+source('dashr/chapters/state/index.R', local=chapters.state)
+chapters.graph_crossfiltering <- new.env()
+source('dashr/chapters/graph-crossfiltering/index.R', local=chapters.graph_crossfiltering)
+#chapters.data_callbacks <- new.env()
+#source('dashr/chapters/data-callbacks/index.R', local=chapters.data_callbacks)
+chapters.faq_gotchas <- new.env()
+source('dashr/chapters/faq-gotchas/index.R', local=chapters.faq_gotchas)
+chapters.dashCoreComponents <- new.env()
+source('dashr/chapters/dash-core-components/index.R', local=chapters.dashCoreComponents)
+chapters.dccDropdown <- new.env()
+source('dashr/chapters/dash-core-components/dropdown/index.R', local=chapters.dccDropdown)
+chapters.dccSlider <- new.env()
+source('dashr/chapters/dash-core-components/slider/index.R', local=chapters.dccSlider)
+chapters.RangeSlider <- new.env()
+source('dashr/chapters/dash-core-components/RangeSlider/index.R', local=chapters.RangeSlider)
+chapters.Input <- new.env()
+source('dashr/chapters/dash-core-components/Input/index.R', local=chapters.Input)
+chapters.TextArea <- new.env()
+source('dashr/chapters/dash-core-components/Textarea/index.R', local=chapters.TextArea)
+chapters.Checklist <- new.env()
+source('dashr/chapters/dash-core-components/Checklist/index.R', local=chapters.Checklist)
+chapters.RadioItems  <- new.env()
+source('dashr/chapters/dash-core-components/Radioitems/index.R', local=chapters.RadioItems)
+chapters.Button  <- new.env()
+source('dashr/chapters/dash-core-components/Button/index.R', local=chapters.Button)
+chapters.DatePickerSingle  <- new.env()
+source('dashr/chapters/dash-core-components/Datepickersingle/index.R', local=chapters.DatePickerSingle)
+chapters.DatePickerRange  <- new.env()
+source('dashr/chapters/dash-core-components/DatePickerRange/index.R', local=chapters.DatePickerRange)
+chapters.Markdown  <- new.env()
+source('dashr/chapters/dash-core-components/Markdown/index.R', local=chapters.Markdown)
+chapters.UploadComponent  <- new.env()
+source('dashr/chapters/dash-core-components/UploadComponent/index.R', local=chapters.UploadComponent)
+chapters.ConfirmDialog  <- new.env()
+source('dashr/chapters/dash-core-components/ConfirmDialog/index.R', local=chapters.ConfirmDialog)
+chapters.ConfirmDialogProvider  <- new.env()
+source('dashr/chapters/dash-core-components/ConfirmDialogProvider/index.R', local=chapters.ConfirmDialogProvider)
+chapters.Store  <- new.env()
+source('dashr/chapters/dash-core-components/Store/index.R', local=chapters.Store)
+chapters.Location  <- new.env()
+source('dashr/chapters/dash-core-components/Location/index.R', local=chapters.Location)
+chapters.LoadingComponent  <- new.env()
+source('dashr/chapters/dash-core-components/LoadingComponent/index.R', local=chapters.LoadingComponent)
+chapters.Graph  <- new.env()
+source('dashr/chapters/dash-core-components/Graph/index.R', local=chapters.Graph)
+chapters.Tabs  <- new.env()
+source('dashr/chapters/dash-core-components/Tabs/index.R', local=chapters.Tabs)
+chapters.UploadComponent  <- new.env()
+source('dashr/chapters/dash-core-components/UploadComponent/index.R', local=chapters.UploadComponent )
+chapters.dashHtmlComponents <- new.env()
+source('dashr/chapters/dash-html-components/index.R', local=chapters.dashHtmlComponents)
+chapters.external_resources <- new.env()
+source('dashr/chapters/external-resources/index.R', local=chapters.external_resources)
+#chapters.dashDataTable <- new.env()
+#source('dashr/chapters/dashDataTable/index.R', local=chapters.dashDataTable)
+chapters.dashDataTablePart1 <- new.env()
+#source('dashr/chapters/dashDataTable/part1/index.R', local=chapters.dashDataTablePart1)
+chapters.Whats_dash <- new.env()
+source('dashr/chapters/Whats_dash/introduction.R', local=chapters.Whats_dash)
+
+header <- htmlDiv(
+  className = 'header',
+  list(
     htmlDiv(
-      list(
-        dccLocation(id='url'),
-        htmlDiv(
-          className='background',
-          children=list(
-            htmlDiv(id='wait-for-layout'),
-            htmlDiv(
-              className='container-width',
-              children=htmlDiv(
-                htmlDiv(id='chapter', className='content'),
-                className='content-container'
-              )
+      style = list(height = '95%'),
+      className = 'container-width',
+      children = list(
+        htmlA(htmlImg(
+          style = list(height = '100%'),
+          src = 'https://user-images.githubusercontent.com/1865834/50180824-abcc5f80-02d8-11e9-8319-8842909c3f8e.png'
+        ), href = 'https://plot.ly/products/dash', className='logo-link'),
+        htmlDiv(className='links', children = list(
+          htmlA('pricing', className='link', href = 'https://plot.ly/dash/pricing'),
+          htmlA('user guide', className='link', href = '/'),
+          htmlA('plotly', className='link', href = 'https://plot.ly/'),
+          htmlA(children=list(htmlI(className="fa fa-search")), className='link', href='https://dash.plot.ly/search')
+        ))
+      ))
+  ))
+
+app$layout(
+  header,
+  htmlDiv(
+    list(
+      dccLocation(id='url'),
+      htmlDiv(
+        className='background',
+        children=list(
+          htmlDiv(id='wait-for-layout'),
+          htmlDiv(
+            className='container-width',
+            children=htmlDiv(
+              htmlDiv(id='chapter', className='content'),
+              className='content-container'
             )
           )
         )
       )
     )
   )
-  
-  app$callback(output=list(id='chapter', property='children'),
-               params=list(input('url', 'pathname')),
-               function(pathname) {
-                 switch(
-                   pathname,
-                   "/Whats_dash" = return(chapters.Whats_dash$layout),
-                   "/installation" = return(chapters.installation$layout),
-                   "/getting-started" = return(chapters.getting_started$layout),
-                   "/getting-started-part-2" = return(chapters.callbacks$layout),
-                   "/state" = return(chapters.state$layout),
-                   "/graph-crossfiltering" = return(chapters.graph_crossfiltering$layout),
-                   #"/data-callbacks" = return(chapters.data_callbacks$layout),
-                   "/faq-gotchas" = return(chapters.faq_gotchas$layout),
-                   '/dash-core-components' = return(chapters.dashCoreComponents$layout),
-                   '/dash-core-components/Dropdown' = return(chapters.dccDropdown$layout),
-                   '/dash-core-components/Slider' = return(chapters.dccSlider$layout),
-                   '/dash-core-components/RangeSlider' = return(chapters.RangeSlider$layout),
-                   '/dash-core-components/Input' = return(chapters.Input$layout),
-                   '/dash-core-components/Textarea' = return(chapters.TextArea$layout),
-                   '/dash-core-components/Checklist' = return(chapters.Checklist$layout),
-                   '/dash-core-components/Radioitems' = return(chapters.RadioItems$layout),
-                   '/dash-core-components/Button' = return(chapters.Button$layout),
-                   '/dash-core-components/DatePickerSingle' = return(chapters.DatePickerSingle$layout),
-                   '/dash-core-components/DatePickerRange' = return(chapters.DatePickerRange$layout),
-                   '/dash-core-components/Markdown' = return(chapters.Markdown$layout),
-                   '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
-                   '/dash-core-components/ConfirmDialog' = return(chapters.ConfirmDialog$layout),
-                   '/dash-core-components/ConfirmDialogProvider' = return(chapters.ConfirmDialogProvider$layout),
-                   '/dash-core-components/Store' = return(chapters.Store$layout),
-                   '/dash-core-components/Location' = return(chapters.Location$layout),
-                   '/dash-core-components/LoadingComponent' = return(chapters.LoadingComponent$layout),
-                   '/dash-core-components/Graph' = return(chapters.Graph$layout),
-                   '/dash-core-components/Tabs' = return(chapters.Tabs$layout),
-                   '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
-                   '/dash-html-components' = return(chapters.dashHtmlComponents$layout),
-                   '/dashDataTable' = return(chapters.dashDataTable$layout),
-                   '/dashDataTable/Part1' = return(chapters.dashDataTablePart1$layout),
-                   '/external-resources' = return(chapters.external_resources$layout),
-                   {
-                     
-                     htmlDiv(
-                       list(
-                         htmlH1('DashR User Guide'),
-                         htmlH2('What\'s Dash?'),
-                         htmlHr(),
-                         htmlA('Introduction', href='https://dash.plot.ly/introduction'),
-                         htmlBr(),
-                         dccMarkdown("A quick paragraph about Dash and a link to the talk at Plotcon that started it all."),
-                         
-                         htmlA(
-                           'Announcement Essay',
-                           href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."),
-                         
-                         htmlA(
-                           'Dash App Gallery',
-                           href='https://dash.plot.ly/gallery'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("A glimpse into what's possible with Dash."),
-                         htmlA(
-                           'Dash Club',
-                           href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("A fortnightly email newsletter by chriddyp, the creator of Dash."),
-                         
-                         htmlH2("Dash Tutorial"),
-                         htmlHr(),
-                         dccLink(
-                           'Part 1. Installation',
-                           href='/installation'
-                         ),
-                         htmlBr(),
-                         dccLink(
-                           'Part 2. The Dash Layout',
-                           href='/getting-started'
-                         ),
-                         dccMarkdown("The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."),
-                         htmlBr(),
-                         dccLink(
-                           'Part 3. Basic Callbacks',
-                           href='/getting-started-part-2'
-                         ),
-                         dccMarkdown("Dash apps are made interactive through Dash Callbacks:
-  R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
-  allowing one update in the UI to trigger several updates across the app."),
-                         htmlBr(),
-                         dccLink(
-                           'Part 4. Callbacks With State',
-                           href='/state'
-                         ),
-                         dccMarkdown("Basic callbacks are fired whenever the values change.
-  Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
-  `state` is useful for UIs that contain forms or buttons."),
-                         htmlBr(),
-                         dccLink(
-                          'Part 5. Interactive Graphing and Crossfiltering',
-                          href='/graph-crossfiltering'
-                         ),
-                         dccMarkdown("Bind interactivity to the Dash `Graph` component whenever you hover, click, or
-                         select points on your chart."),
-                         htmlBr(),
-                         dccLink(
-                           'Part 6. Sharing Data Between Callbacks',
-                           href='/data-callbacks'
-                         ),
-                         dccMarkdown("`global` variables will break your Dash apps. 
-  However, there are other ways to share data between callbacks.
-  This chapter is useful for callbacks that run expensive data processing tasks or process large data.
-                                     "),
-                         htmlBr(),
-                         dccLink(
-                           'Part 7. FAQs and Gotchas',
-                           href='/faq-gotchas'
-                         ),
-                         dccMarkdown("If you have read through the rest of the tutorial and still have questions 
-  or are encountering unexpected behaviour,this chapter may be useful."),
-                         
-                         htmlH2('Component Libraries'),
-                         htmlHr(),
-                         dccLink(
-                           'Dash Core Components',
-                           href='/dash-core-components'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."),
-                         dccLink(
-                           'Dash HTML Components',
-                           href='/dash-html-components'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("Dash provides all of the available HTML tags as user-friendly Python classes.
-  This chapter explains how this works and the few important key differences between Dash HTML components and standard html.
-                      "),
-                         dccLink(
-                           'Dash DataTable',
-                           href='/dashDataTable'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component. 
-  It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."),
-                         htmlH2('Creating Your Own Components'),
-                         htmlHr(),
-                         dccMarkdown("IN PROGRESS..."),
-                         
-                         htmlH2('Beyond the Basics'),
-                         htmlHr(),
-                         dccLink(
-                           'Adding CSS & JS and Overriding the Page-Load Template',
-                           href='/external-resources'
-                         ),
-                         htmlBr(),
-                         dccMarkdown("
-  Learn how to add custom CSS and JS to your application with the `assets` directory. 
-  Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more.
-                                     "),
-                         htmlH2('Creating Your Own Components'),
-                         htmlHr(),
-                         
-                         htmlH2('Getting Help'),
-                         htmlHr(),
-                         dccMarkdown("IN PROGRESS..."),
-                         
-                         htmlH2('Dash Deployment Server',
-                                style = list(color = "rgb(13, 118, 191)")),
-                         htmlHr(),
-                         dccMarkdown("Dash Deployment Server is Plotly's commercial offering for hosting and sharing 
-  Dash apps on-premises or in the cloud."),
-                         dccLink(
-                           'About Dash Deployment Server',
-                           href='/faq-gotchas'
-                         ),
-                         htmlBr(),
-                         dccLink(
-                           'Dash Deployment Server Documentation',
-                           href='/faq-gotchas'
-                         )
-                         
-                       )
-                     )
-                   }
-                 )
-               })
-  
-  app$run_server(host = "0.0.0.0", port = Sys.getenv('PORT', 8050))
+)
+
+app$callback(
+  output=list(id='chapter', property='children'),
+  params=list(input('url', 'pathname')),
+  function(pathname) {
+   switch(
+     pathname,
+     "/Whats_dash" = return(chapters.Whats_dash$layout),
+     "/installation" = return(chapters.installation$layout),
+     "/getting-started" = return(chapters.getting_started$layout),
+     "/getting-started-part-2" = return(chapters.callbacks$layout),
+     "/state" = return(chapters.state$layout),
+     "/graph-crossfiltering" = return(chapters.graph_crossfiltering$layout),
+     #"/data-callbacks" = return(chapters.data_callbacks$layout),
+     "/faq-gotchas" = return(chapters.faq_gotchas$layout),
+     '/dash-core-components' = return(chapters.dashCoreComponents$layout),
+     '/dash-core-components/Dropdown' = return(chapters.dccDropdown$layout),
+     '/dash-core-components/Slider' = return(chapters.dccSlider$layout),
+     '/dash-core-components/RangeSlider' = return(chapters.RangeSlider$layout),
+     '/dash-core-components/Input' = return(chapters.Input$layout),
+     '/dash-core-components/Textarea' = return(chapters.TextArea$layout),
+     '/dash-core-components/Checklist' = return(chapters.Checklist$layout),
+     '/dash-core-components/Radioitems' = return(chapters.RadioItems$layout),
+     '/dash-core-components/Button' = return(chapters.Button$layout),
+     '/dash-core-components/DatePickerSingle' = return(chapters.DatePickerSingle$layout),
+     '/dash-core-components/DatePickerRange' = return(chapters.DatePickerRange$layout),
+     '/dash-core-components/Markdown' = return(chapters.Markdown$layout),
+     '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
+     '/dash-core-components/ConfirmDialog' = return(chapters.ConfirmDialog$layout),
+     '/dash-core-components/ConfirmDialogProvider' = return(chapters.ConfirmDialogProvider$layout),
+     '/dash-core-components/Store' = return(chapters.Store$layout),
+     '/dash-core-components/Location' = return(chapters.Location$layout),
+     '/dash-core-components/LoadingComponent' = return(chapters.LoadingComponent$layout),
+     '/dash-core-components/Graph' = return(chapters.Graph$layout),
+     '/dash-core-components/Tabs' = return(chapters.Tabs$layout),
+     '/dash-core-components/UploadComponent' = return(chapters.UploadComponent$layout),
+     '/dash-html-components' = return(chapters.dashHtmlComponents$layout),
+     '/dashDataTable' = return(chapters.dashDataTable$layout),
+     '/dashDataTable/Part1' = return(chapters.dashDataTablePart1$layout),
+     '/external-resources' = return(chapters.external_resources$layout),
+     {
+       htmlDiv(
+         list(
+           htmlH1('DashR User Guide'),
+
+
+           htmlH2('What\'s Dash?'),
+           htmlA(
+             'Introduction',
+             href='https://dash.plot.ly/introduction'
+           ),
+           htmlBr(),
+           dccMarkdown("A quick paragraph about Dash and a link to the talk at Plotcon that started it all."),
+           htmlA(
+             'Announcement Essay',
+             href='https://medium.com/@plotlygraphs/introducing-dash-5ecf7191b503'
+           ),
+           htmlBr(),
+           dccMarkdown("Our extended essay on Dash. An extended discussion of Dash's architecture and our motivation behind the project."),
+           htmlA(
+             'Dash App Gallery',
+             href='https://dash.plot.ly/gallery'
+           ),
+           htmlBr(),
+           dccMarkdown("A glimpse into what's possible with Dash."),
+           htmlA(
+             'Dash Club',
+             href='https://plot.us12.list-manage.com/subscribe?u=28d7f8f0685d044fb51f0d4ee&id=0c1cb734d7'
+           ),
+           htmlBr(),
+           dccMarkdown("A fortnightly email newsletter by chriddyp, the creator of Dash."),
+
+
+           htmlH2("Dash Tutorial"),
+           dccLink(
+             'Part 1. Installation',
+             href='/installation'
+           ),
+           htmlBr(),
+           dccLink(
+             'Part 2. The Dash Layout',
+             href='/getting-started'
+           ),
+           dccMarkdown("The Dash `layout` describes what your app will look like and is composed of a set of declarative Dash components."),
+           htmlBr(),
+           dccLink(
+             'Part 3. Basic Callbacks',
+             href='/getting-started-part-2'
+           ),
+           dccMarkdown("Dash apps are made interactive through Dash Callbacks:
+R functions that are automatically called whenever an input component's property changes. Callbacks can be chained,
+allowing one update in the UI to trigger several updates across the app."),
+           htmlBr(),
+           dccLink(
+             'Part 4. Callbacks With State',
+             href='/state'
+           ),
+           dccMarkdown("Basic callbacks are fired whenever the values change.
+Use Dash `state` with Dash `inputs` to pass in extra values whenever the `inputs` change.
+`state` is useful for UIs that contain forms or buttons."),
+           htmlBr(),
+           dccLink(
+            'Part 5. Interactive Graphing and Crossfiltering',
+            href='/graph-crossfiltering'
+           ),
+           dccMarkdown("Bind interactivity to the Dash `Graph` component whenever you hover, click, or
+           select points on your chart."),
+           htmlBr(),
+           dccLink(
+             'Part 6. Sharing Data Between Callbacks',
+             href='/data-callbacks'
+           ),
+           dccMarkdown("`global` variables will break your Dash apps.
+However, there are other ways to share data between callbacks.
+This chapter is useful for callbacks that run expensive data processing tasks or process large data."),
+           htmlBr(),
+           dccLink(
+             'Part 7. FAQs and Gotchas',
+             href='/faq-gotchas'
+           ),
+           dccMarkdown("If you have read through the rest of the tutorial and still have questions
+or are encountering unexpected behaviour,this chapter may be useful."),
+
+
+           htmlH2('Component Libraries'),
+           dccLink(
+             'Dash Core Components',
+             href='/dash-core-components'
+           ),
+           htmlBr(),
+           dccMarkdown("The Dash Core Component library contains a set of higher-level components like sliders, graphs, dropdowns, tables, and more."),
+           dccLink(
+             'Dash HTML Components',
+             href='/dash-html-components'
+           ),
+           htmlBr(),
+           dccMarkdown("Dash provides all of the available HTML tags as user-friendly Python classes.
+This chapter explains how this works and the few important key differences between Dash HTML components and standard html.
+        "),
+           dccLink(
+             'Dash DataTable',
+             href='/dashDataTable'
+           ),
+           htmlBr(),
+           dccMarkdown("(New! Released Nov 2, 2018) The Dash DataTable is our latest and most advanced component.
+It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."),
+
+
+           htmlH2('Creating Your Own Components'),
+           dccMarkdown("IN PROGRESS..."),
+
+
+           htmlH2('Beyond the Basics'),
+           dccLink(
+             'Adding CSS & JS and Overriding the Page-Load Template',
+             href='/external-resources'
+           ),
+           htmlBr(),
+           dccMarkdown("Learn how to add custom CSS and JS to your application with the `assets` directory.
+Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."),
+
+
+           htmlH2('Production'),
+           dccMarkdown("IN PROGRESS..."),
+
+
+           htmlH2('Getting Help'),
+           dccMarkdown("IN PROGRESS..."),
+
+
+           htmlH2('Dash Deployment Server',
+                  style = list(color = "rgb(13, 118, 191)")),
+           dccMarkdown("Dash Deployment Server is Plotly's commercial offering for hosting and sharing
+Dash apps on-premises or in the cloud."),
+           dccLink(
+             'About Dash Deployment Server',
+             href='/faq-gotchas'
+           ),
+           htmlBr(),
+           dccLink(
+             'Dash Deployment Server Documentation',
+             href='/faq-gotchas'
+           )
+         )
+       )
+     }
+   )
+ })
+
+app$run_server(host = "0.0.0.0", port = Sys.getenv('PORT', 8050))

--- a/run.R
+++ b/run.R
@@ -161,7 +161,7 @@ app$callback(
            htmlH1('DashR User Guide'),
 
 
-           htmlH2('What\'s Dash?'),
+           components$Header('What\'s Dash?'),
            htmlA(
              'Introduction',
              href='https://dash.plot.ly/introduction'
@@ -188,7 +188,7 @@ app$callback(
            dccMarkdown("A fortnightly email newsletter by chriddyp, the creator of Dash."),
 
 
-           htmlH2("Dash Tutorial"),
+           components$Header("Dash Tutorial"),
            dccLink(
              'Part 1. Installation',
              href='/installation'
@@ -239,7 +239,7 @@ This chapter is useful for callbacks that run expensive data processing tasks or
 or are encountering unexpected behaviour,this chapter may be useful."),
 
 
-           htmlH2('Component Libraries'),
+           components$Header('Component Libraries'),
            dccLink(
              'Dash Core Components',
              href='/dash-core-components'
@@ -263,11 +263,11 @@ This chapter explains how this works and the few important key differences betwe
 It is an interactive table that supports rich styling, conditional formatting, editing, sorting, filtering, and more."),
 
 
-           htmlH2('Creating Your Own Components'),
+           components$Header('Creating Your Own Components'),
            dccMarkdown("IN PROGRESS..."),
 
 
-           htmlH2('Beyond the Basics'),
+           components$Header('Beyond the Basics'),
            dccLink(
              'Adding CSS & JS and Overriding the Page-Load Template',
              href='/external-resources'
@@ -277,11 +277,11 @@ It is an interactive table that supports rich styling, conditional formatting, e
 Also, learn how to customize the HTML template that Dash serves on page load in order to add custom meta tags, customize the page's title, and more."),
 
 
-           htmlH2('Production'),
+           components$Header('Production'),
            dccMarkdown("IN PROGRESS..."),
 
 
-           htmlH2('Getting Help'),
+           components$Header('Getting Help'),
            dccMarkdown("IN PROGRESS..."),
 
 


### PR DESCRIPTION
In the process of adding some reusable components for DashR docs to standardize styling and reflect the look of the Python version of Dash docs as noted in issue #567, but not sure if remaining components (mentioned below) are needed.

Add the following components:
- [x] Chapter
- [x] Section
- [x] Header (to be used for dash-cytoscape docs)

Implement the following components in [run.R](https://github.com/plotly/dash-docs/blob/styling-dashr-docs/run.R):
- [x] Chapter
- [x] Section

Decide if the following components are needed:
- Column
- Blockquote
- Notebox
- Row

# Example

Note the example mentioned in issue #567. Given the components `Section` and `Chapter` added [here](https://github.com/plotly/dash-docs/blob/styling-dashr-docs/dashr/components.R) and implemented [here](https://github.com/plotly/dash-docs/blob/styling-dashr-docs/run.R), the home page for DashR docs can look like this:

<img width="860" alt="Screen Shot 2019-07-02 at 07 42 04" src="https://user-images.githubusercontent.com/23238764/60510228-edcd5980-9c9c-11e9-8a34-a566f0f4725c.png">

Closes #567.