### PR TITLE
:knife: temporarily remove search link

### DIFF
--- a/run.R
+++ b/run.R
@@ -124,8 +124,7 @@ header <- htmlDiv(
         htmlDiv(className='links', children = list(
           htmlA('pricing', className='link', href = 'https://plot.ly/dash/pricing'),
           htmlA('user guide', className='link', href = '/'),
-          htmlA('plotly', className='link', href = 'https://plot.ly/'),
-          htmlA('🔎', className='link', href='https://dash.plot.ly/search')
+          htmlA('plotly', className='link', href = 'https://plot.ly/')
         ))
       ))
   ))


### PR DESCRIPTION
temporarily remove search link from R docs as it's going to the python search (todo issue logged: https://github.com/plotly/dash-docs/issues/570)

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
