### PR TITLE
add return before example code in dcc markdown

### DIFF
--- a/dashr/utils.R
+++ b/dashr/utils.R
@@ -51,7 +51,7 @@ LoadExampleCode <- function(filename, wd = NULL) {
     layout=htmlDiv(className='example-container', children=layout,
                    style=list('overflow-x' = 'initial')),
     source_code=htmlDiv(
-      children=dccMarkdown(sprintf("```r %s```", example.file.as.string)),
+      children=dccMarkdown(sprintf("```r\n%s```", example.file.as.string)),
       className='code-container'
     )
   )


### PR DESCRIPTION
resolves #575 by adding a return in example code gen function so that the first line doesn't always get ignored by dcc markdown. cc @cldougl, @rpkyle 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
