### PR TITLE
add li for spacing style

### DIFF
--- a/dashr/components.R
+++ b/dashr/components.R
@@ -14,11 +14,13 @@ Header <- function(title) {
 }
 
 Chapter <- function(name, href = NA, caption = NA) {
-  divTitle <- htmlA( 
+  divTitle <- htmlLi(
+    htmlA(
       name,
       href = href,
       id = href,
       className = 'toc--chapter-link'
+    )
   )
   divCaption <- htmlSmall(
     className = 'toc--chapter-content',
@@ -90,4 +92,3 @@ Example <- function(example){
     )
   )
 }
-


### PR DESCRIPTION
@rpkyle can we try using this (`a` in an `li`) to keep the spacing style consistent w/ dash python docs (the links are working locally for me w/ this format)  this will resolve https://github.com/plotly/dash-docs/issues/578