### PR TITLE
Minor fixes on graduated-bar/knob/numericinput/slider

### DIFF
--- a/tutorial/daq_component_examples.py
+++ b/tutorial/daq_component_examples.py
@@ -349,7 +349,7 @@ daq.GraduatedBar(
     html.Hr(),
     html.H3('Color Gradient'),
     dcc.Markdown("Set a color gradient with: \
-    \n `color={'gradient':{'<color>':[<value>, <value>],'<color>':[<value>, <value>],'<color>':[<value>, <value>]}}`"),
+    \n `color={'gradient':True,'ranges':{'<color>':[<value>, <value>],'<color>':[<value>, <value>],'<color>':[<value>, <value>]}}`"),
     ComponentBlock('''import dash_daq as daq
 
 daq.GraduatedBar(
@@ -517,7 +517,7 @@ daq.Knob(
     html.Hr(),
     html.H3('Color Gradient'),
     dcc.Markdown("Set up a color gradient with: \
-    \n `color={'ranges':{'gradient': True,'ranges' <color>':[<value>,<value>],'<color>':[<value>,<value>], '<color>':[<value>,<value>]}}`."),
+    \n `color={'gradient':True,'ranges':{'<color>':[<value>,<value>],'<color>':[<value>,<value>], '<color>':[<value>,<value>]}}`."),
     ComponentBlock('''import dash_daq as daq
 
 daq.Knob(
@@ -532,7 +532,7 @@ daq.Knob(
     ComponentBlock('''import dash_daq as daq
 
 daq.Knob(
-  label="Gradient Ranges",
+  label="Scale",
   value=7,
   max=18,
   scale={'start':0, 'labelInterval': 3, 'interval': 3}
@@ -643,7 +643,7 @@ daq.NumericInput(
 )''', style=styles.code_container),
     html.Hr(),
     html.H3('Max and Min'),
-    dcc.Markdown("Set the minimum and maximum bounds with `min` and max`."),
+    dcc.Markdown("Set the minimum and maximum bounds with `min` and `max`."),
     ComponentBlock('''import dash_daq as daq
 
 daq.NumericInput(

--- a/tutorial/examples/daq_components/slider.py
+++ b/tutorial/examples/daq_components/slider.py
@@ -8,7 +8,7 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 
 app.layout = html.Div([
     daq.Slider(
-        id='my-daq-slider',
+        id='my-daq-slider-ex',
         value=17
     ),
     html.Div(id='slider-output')
@@ -17,7 +17,7 @@ app.layout = html.Div([
 
 @app.callback(
     dash.dependencies.Output('slider-output', 'children'),
-    [dash.dependencies.Input('my-daq-slider', 'value')])
+    [dash.dependencies.Input('my-daq-slider-ex', 'value')])
 def update_output(value):
     return 'The slider is currently at {}.'.format(value)
 


### PR DESCRIPTION
- Fixed syntax for `color` attributes of `daq.GraduatedBar` & `daq.Knob` for the _Color Gradient_ examples

- Corrected the label for `daq.Knob` _Scale_ example

- Added missing tick to the daq.NumericInput _Max and Min_ example

- Edited `id` of default slider from `my-daq-slider` to `my-daq-slider-ex` (Previous name was causing a conflict and example was not functional)



Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
