### PR TITLE
Update version of dash-bio dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ click==6.7
 configparser==3.5.0
 dash==1.0.2
 dash-auth==1.2.0
-dash-bio==0.1.2rc3
-dash-bio-utils==0.0.3rc2
+dash-bio==0.1.3rc4
+dash-bio-utils==0.0.3rc3
 dash-cytoscape==0.0.5
 dash-daq==0.1.0
 dash-canvas>=0.0.10

--- a/tutorial/dashbio.py
+++ b/tutorial/dashbio.py
@@ -235,7 +235,7 @@ styles_data = json.loads(styles_data)
         'datafile': {
             'name': 'sequence_viewer_P01308.fasta'
         },
-        'setup_code': '''seq = protein_reader.read_fasta(data_string=data)[0]['sequence']''',
+        'setup_code': '''seq = protein_reader.read_fasta(data, is_datafile=False)[0]['sequence']''',
         'params': {
             'sequence': 'seq'
         },

--- a/tutorial/dashbio_component_examples.py
+++ b/tutorial/dashbio_component_examples.py
@@ -781,7 +781,7 @@ data = urlreq.urlopen("https://raw.githubusercontent.com/plotly/dash-bio/master/
 if PY3:
     data = data.decode('utf-8')
 
-data = xyz_reader.read_xyz(data_string=data)
+data = xyz_reader.read_xyz(data, is_datafile=False)
 
 dashbio.Speck(
     data=data,
@@ -811,7 +811,7 @@ data = urlreq.urlopen("https://raw.githubusercontent.com/plotly/dash-bio/master/
 if PY3:
     data = data.decode('utf-8')
 
-data = xyz_reader.read_xyz(data_string=data)
+data = xyz_reader.read_xyz(data, is_datafile=False)
 
 dashbio.Speck(
     data=data,

--- a/tutorial/dashbio_component_examples.py
+++ b/tutorial/dashbio_component_examples.py
@@ -672,7 +672,7 @@ fasta_str = urlreq.urlopen(
 if PY3:
     fasta_str = fasta_str.decode('utf-8')
 
-seq = protein_reader.read_fasta(data_string=fasta_str)[0]['sequence']
+seq = protein_reader.read_fasta(fasta_str, is_datafile=False)[0]['sequence']
 
 dashbio.SequenceViewer(
     id='sequence-viewer-lines',
@@ -698,7 +698,7 @@ fasta_str = urlreq.urlopen(
 if PY3:
     fasta_str = fasta_str.decode('utf-8')
 
-seq = protein_reader.read_fasta(data_string=fasta_str)[0]['sequence']
+seq = protein_reader.read_fasta(fasta_str, is_datafile=False)[0]['sequence']
 
 dashbio.SequenceViewer(
     id='sequence-viewer-selection',
@@ -723,7 +723,7 @@ fasta_str = urlreq.urlopen(
 if PY3:
     fasta_str = fasta_str.decode('utf-8')
 
-seq = protein_reader.read_fasta(data_string=fasta_str)[0]['sequence']
+seq = protein_reader.read_fasta(fasta_str, is_datafile=False)[0]['sequence']
 
 dashbio.SequenceViewer(
     id='sequence-viewer-toolbar',
@@ -749,7 +749,7 @@ fasta_str = urlreq.urlopen(
 if PY3:
     fasta_str = fasta_str.decode('utf-8')
 
-seq = protein_reader.read_fasta(data_string=fasta_str)[0]['sequence']
+seq = protein_reader.read_fasta(fasta_str, is_datafile=False)[0]['sequence']
 
 dashbio.SequenceViewer(
     id='sequence-viewer-titlebadge',

--- a/tutorial/examples/dashbio_components/sequence_viewer.py
+++ b/tutorial/examples/dashbio_components/sequence_viewer.py
@@ -17,7 +17,7 @@ fasta_str = urlreq.urlopen(
 if PY3:
     fasta_str = fasta_str.decode('utf-8')
 
-seq = protein_reader.read_fasta(data_string=fasta_str)[0]['sequence']
+seq = protein_reader.read_fasta(fasta_str, is_datafile=False)[0]['sequence']
 
 app.layout = html.Div([
     dashbio.SequenceViewer(

--- a/tutorial/examples/dashbio_components/speck.py
+++ b/tutorial/examples/dashbio_components/speck.py
@@ -19,7 +19,7 @@ data = urlreq.urlopen(
 if PY3:
     data = data.decode('utf-8')
 
-data = xyz_reader.read_xyz(data_string=data)
+data = xyz_reader.read_xyz(data, is_datafile=False)
 
 app.layout = html.Div([
     dcc.Dropdown(


### PR DESCRIPTION
With this PR, we're checking the third box in https://github.com/plotly/dash-docs/issues/598#issuecomment-513207278. It should suffice in the end, since `pip` does use the dependency's `setup.py`:  
```
Found existing installation: dash-bio 0.1.2rc3
    Uninstalling dash-bio-0.1.2rc3:
      Successfully uninstalled dash-bio-0.1.2rc3
  Running setup.py install for dash-bio ... done
```
*phew* ;)

We're also updating the `dash-bio` examples and docs following the standardization of data parsers (the same way we update the demo apps: https://github.com/plotly/dash-bio/pull/375).

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
