### PR TITLE
Bump dash to v1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2018.4.16
 chardet==3.0.4
 click==6.7
 configparser==3.5.0
-dash==1.1.0
+dash==1.1.1
 dash-auth==1.2.0
 dash-bio==0.1.3rc4
 dash-bio-utils==0.0.3rc3


### PR DESCRIPTION
The problematic page: https://dash-docs-pr-620.herokuapp.com/datatable/editable
Now seems to load correctly now!

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand
