### PR TITLE
document dev_tools_prune_errors

### DIFF
--- a/tutorial/devtools.py
+++ b/tutorial/devtools.py
@@ -57,7 +57,7 @@ layout = html.Div([
     The full set of dev tools parameters are included in `app.run_server` or `app.enable_dev_tools`:
 
     - `debug`, bool, activate all the dev tools.
-    - `dev_tools_ui`, bool, set to `False` to explicitly disable dev tools UI in debugger mode (defualt=True)
+    - `dev_tools_ui`, bool, set to `False` to explicitly disable dev tools UI in debugger mode (default=True)
     - `dev_tools_props_check`, bool, set to `False` to explicitly disable component props validation (default=True)
     - `dev_tools_hot_reload`, bool, set to `True` to enable hot reload (default=False).
     - `dev_tools_hot_reload_interval`, int, interval in millisecond at which the renderer will request the reload hash (default=3000).
@@ -65,6 +65,7 @@ layout = html.Div([
     - `dev_tools_hot_reload_max_retry`, int, number of times the reloader is allowed to fail before stopping and sending an alert. (default=8)
     - `dev_tools_silence_routes_logging`, bool, remove the routes access logging from the console.
     - `dev_tools_serve_dev_bundles`, bool, serve the dev bundles.
+    - `dev_tools_prune_errors`, bool, simplify tracebacks to just user code, omitting stack frames from Dash and Flask internals. (default=True)
 
     ### Settings with environment variables
 


### PR DESCRIPTION
adds `dev_tools_prune_errors` https://github.com/plotly/dash/pull/860 to the dev tools page. To be merged after dash 1.2 is released.