### PR TITLE
Minor formatting fixes for dashr docs

### DIFF
--- a/dashr/chapters/dash-core-components/index.R
+++ b/dashr/chapters/dash-core-components/index.R
@@ -59,15 +59,15 @@ utils$LoadAndDisplayComponent(
   '
 library(dashCoreComponents)
 
-  dccDropdown(
-    options=list(
-      list(label = "New York City", value = "NYC"),
-      list(label = "Montréal", value = "MTL"),
-      list(label = "San Francisco", value = "SF")
-    ),
-    value = "MTL",
-    multi = TRUE
-  )
+dccDropdown(
+  options=list(
+    list(label = "New York City", value = "NYC"),
+    list(label = "Montréal", value = "MTL"),
+    list(label = "San Francisco", value = "SF")
+  ),
+  value = "MTL",
+  multi = TRUE
+)
   '
 ),
 htmlBr(),
@@ -112,26 +112,31 @@ htmlHr(),
 htmlDiv(titleLink('RangeSlider')),
 htmlDiv(list(utils$LoadAndDisplayComponent2(
   '
-  library(dashCoreComponents)
-  dccRangeSlider(
+library(dashCoreComponents)
+dccRangeSlider(
   count = 1,
   min = -5,
   max = 10,
   step = 0.5,
   value = list(-3, 7)
-  )
+)
   '
 ),
 
 htmlDiv(list(utils$LoadAndDisplayComponent2(
   '
-  library(dashCoreComponents)
-  dccRangeSlider(
-  marks = lapply(-5:7, function(x){paste("Label", x)}),
+library(dashCoreComponents)
+dccRangeSlider(
+  marks = as.list(
+    setNames(
+      lapply(-5:6, function(x) paste("Label", x)),
+      -5:6
+    )
+  ),
   min = -5,
   max = 6,
   value = list(-3,4)
-  )
+)
   '
 )),
 style = list('overflow' = 'hidden'))
@@ -145,12 +150,12 @@ htmlHr(),
 htmlDiv(titleLink('Input')),
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  dccInput(
+library(dashCoreComponents)
+dccInput(
   placeholder = "Enter a value...",
   type = "text",
   value = ""
-  )
+)
   '
 ))),
 
@@ -163,12 +168,12 @@ htmlDiv(titleLink('Textarea')),
 
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  dccTextarea(
+library(dashCoreComponents)
+dccTextarea(
   placeholder = "Enter a value...",
   value = "This is a TextArea component",
   style = list("width" = "100%")
-  )
+)
   '
 ))),
 htmlBr(),
@@ -182,9 +187,9 @@ htmlDiv(list(utils$LoadAndDisplayComponent(
 library(dashCoreComponents)
 dccChecklist(
   options=list(
-  list("label" = "New York City", "value" = "NYC"),
-  list("label" = "Montréal", "value" = "MTL"),
-  list("label" = "San Francisco", "value" = "SF")
+    list("label" = "New York City", "value" = "NYC"),
+    list("label" = "Montréal", "value" = "MTL"),
+    list("label" = "San Francisco", "value" = "SF")
   ),
   value=list("MTL", "SF")
 )
@@ -193,16 +198,16 @@ dccChecklist(
 
 utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
+library(dashCoreComponents)
 dccChecklist(
   options=list(
-  list("label" = "New York City", "value" = "NYC"),
-  list("label" = "Montréal", "value" = "MTL"),
-  list("label" = "San Francisco", "value" = "SF")
+    list("label" = "New York City", "value" = "NYC"),
+    list("label" = "Montréal", "value" = "MTL"),
+    list("label" = "San Francisco", "value" = "SF")
   ),
   value=list("MTL", "SF"),
   labelStyle = list("display" = "inline-block")
-  )
+)
   '
 )
 )),
@@ -214,30 +219,30 @@ htmlHr(),
 htmlDiv(titleLink('Radioitems')),
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  dccRadioItems(
+library(dashCoreComponents)
+dccRadioItems(
   options=list(
-  list("label" = "New York City", "value" = "NYC"),
-  list("label" = "Montréal", "value" = "MTL"),
-  list("label" = "San Francisco", "value" = "SF")
+    list("label" = "New York City", "value" = "NYC"),
+    list("label" = "Montréal", "value" = "MTL"),
+    list("label" = "San Francisco", "value" = "SF")
   ),
   value = "MTL"
-  )
+)
   '
 ),
 
 utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  dccRadioItems(
+library(dashCoreComponents)
+dccRadioItems(
   options=list(
-  list("label" = "New York City", "value" = "NYC"),
-  list("label" = "Montréal", "value" = "MTL"),
-  list("label" = "San Francisco", "value" = "SF")
+    list("label" = "New York City", "value" = "NYC"),
+    list("label" = "Montréal", "value" = "MTL"),
+    list("label" = "San Francisco", "value" = "SF")
   ),
   value = "MTL",
   labelStyle = list("display" = "inline-block")
-  )
+)
   '
 )
 )),
@@ -261,10 +266,9 @@ htmlDiv(list(utils$LoadAndDisplayComponent(
   '
 library(dashCoreComponents)
 dccDatePickerSingle(
-    id="date-picker-single",
-    date=as.Date("1997/5/10")
+  id="date-picker-single",
+  date=as.Date("1997/5/10")
 )
-
   '
 ))),
 
@@ -419,12 +423,11 @@ htmlHr(),
 htmlDiv(titleLink('ConfirmDialog')),
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  confirm = dccConfirmDialog(
+library(dashCoreComponents)
+confirm = dccConfirmDialog(
   id = "confirm",
   message = "Danger danger! Are you sure you want to continue?"
-  )
-
+)
   '
 ))),
 
@@ -443,13 +446,12 @@ dccMarkdown(
 
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  confirm = dccConfirmDialogProvider(
+library(dashCoreComponents)
+confirm = dccConfirmDialogProvider(
   children = htmlButton("Click Me"),
   id = "danger-danger",
   message = "Danger danger! Are you sure you want to continue?"
-  )
-
+)
   '
 ))),
 
@@ -473,8 +475,11 @@ dccMarkdown(
 
 htmlDiv(list(utils$LoadAndDisplayComponent(
   '
-  library(dashCoreComponents)
-  store = dccStore(id = "my-store", data = list("my-data" = "data"))
+library(dashCoreComponents)
+store = dccStore(
+  id = "my-store", 
+  data = list("my-data" = "data")
+)
   '
 ))),
 dccMarkdown('_The store must be used with callbacks_'),

--- a/dashr/chapters/graph-crossfiltering/index.R
+++ b/dashr/chapters/graph-crossfiltering/index.R
@@ -116,7 +116,7 @@ The next chapter of the Dash User Guide explains how to share data between callb
   "),
   dccLink(
     'Dash Tutorial Part 6. Sharing Data Between Callbacks',
-    href='/data-callbacks'
+    href='/sharing-data-between-callbacks'
   ),
   htmlHr(),
   dccMarkdown("

--- a/dashr/chapters/state/index.R
+++ b/dashr/chapters/state/index.R
@@ -71,7 +71,7 @@ respond to interactions with graphs on the page.
   
   dccLink(
     'Dash Tutorial Part 5. Interactive Graphing',
-    href='/graph-crossfiltering'
+    href='/interactive-graphing'
   ),
   
   htmlHr(),

--- a/dashr/utils.R
+++ b/dashr/utils.R
@@ -50,7 +50,7 @@ LoadExampleCode <- function(filename, wd = NULL) {
   list(
     layout=htmlDiv(
       className='example-container', children=layout,
-      style=list('margin-bottom' = '10px', 'overflow-x' = 'initial')
+      style=list('margin-bottom' = '10px')
     ),
     source_code=htmlDiv(
       children=dccMarkdown(sprintf("```r\n%s```", example.file.as.string)),


### PR DESCRIPTION
This PR proposes minor formatting fixes for the dashR docs:

- Fix the overflow issue on the `dashDataTable` example divs ([as seen on this page](https://dashr.plot.ly/datatable)): fixes #573
- Replace the non-existent hrefs to navigate properly from dash-state to interactive-graphing, and from interactive-graphing to sharing-data-between-callbacks
- Fix the indentation of the `dcc` examples, and the `marks` issue on `dccRangeSlider` in the [dash-core-components landing page](https://dashr.plot.ly/dash-core-components) 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [ ] I understand
