### PR TITLE
Merge after 1.4.0 release - Add an example of serverside options filtering in Dropdown

### DIFF
--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -14,6 +14,7 @@ examples = {
     'date_picker_single': tools.load_example('tutorial/examples/core_components/date_picker_single.py'),
     'date_picker_range': tools.load_example('tutorial/examples/core_components/date_picker_range.py'),
     'dropdown': tools.load_example('tutorial/examples/core_components/dropdown.py'),
+    'dropdown-dynamic-options': tools.load_example('tutorial/examples/core_components/dropdown_dynamic_options.py'),
     'graph-config': tools.load_example('tutorial/examples/core_components/export_graph_to_chart_studio.py'),
     'input-all-types': tools.load_example('tutorial/examples/core_components/input_all_types.py'),
     'input-basic': tools.load_example('tutorial/examples/core_components/input-basic.py'),
@@ -151,6 +152,21 @@ dcc.Dropdown(
         {'label': 'San Francisco', 'value': 'SF', 'disabled': True}
     ],
 )''', style=styles.code_container),
+
+    html.H3('Dynamic Options'),
+    html.P("This is an example on how to update the options on the server \
+           depending on the search terms the user types. For example purpose \
+           the options are empty on first load, as soon as you start typing \
+           they will be loaded with the corresponding values."),
+    dcc.Markdown(
+        examples['dropdown-dynamic-options'][0],
+        style=styles.code_container
+    ),
+    html.Div(
+        examples['dropdown-dynamic-options'][1],
+        className='example-container',
+        style={'overflow-x': 'initial'}
+    ),
 
     html.Hr(),
     html.H3("Dropdown Properties"),

--- a/tutorial/examples/core_components/dropdown_dynamic_options.py
+++ b/tutorial/examples/core_components/dropdown_dynamic_options.py
@@ -3,27 +3,52 @@ from dash.exceptions import PreventUpdate
 import dash_html_components as html
 import dash_core_components as dcc
 
-external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 
-options=[
-    {'label': 'New York City', 'value': 'NYC'},
-    {'label': 'Montreal', 'value': 'MTL'},
-    {'label': 'San Francisco', 'value': 'SF'}
+options = [
+    {"label": "New York City", "value": "NYC"},
+    {"label": "Montreal", "value": "MTL"},
+    {"label": "San Francisco", "value": "SF"},
 ]
 
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-app.layout = dcc.Dropdown(id='my-dynamic-dropdown')
+app.layout = html.Div(
+    [
+        html.Label(["Single dynamic Dropdown", dcc.Dropdown(id="my-dynamic-dropdown")]),
+        html.Label(
+            [
+                "Multi dynamic Dropdown",
+                dcc.Dropdown(id="my-multi-dynamic-dropdown", multi=True),
+            ]
+        ),
+    ]
+)
 
 
 @app.callback(
-    dash.dependencies.Output('my-dynamic-dropdown', 'options'),
-    [dash.dependencies.Input('my-dynamic-dropdown', 'search_value')],
+    dash.dependencies.Output("my-dynamic-dropdown", "options"),
+    [dash.dependencies.Input("my-dynamic-dropdown", "search_value")],
 )
 def update_options(search_value):
     if not search_value:
         raise PreventUpdate
-    return [o for o in options if search_value in o['label']]
+    return [o for o in options if search_value in o["label"]]
 
 
-if __name__ == '__main__':
+@app.callback(
+    dash.dependencies.Output("my-multi-dynamic-dropdown", "options"),
+    [dash.dependencies.Input("my-multi-dynamic-dropdown", "search_value")],
+    [dash.dependencies.State("my-multi-dynamic-dropdown", "value")],
+)
+def update_multi_options(search_value, value):
+    if not search_value:
+        raise PreventUpdate
+    # Make sure that the set values are in the option list, else they will disappear
+    # from the shown select list, but still part of the `value`.
+    return [
+        o for o in options if search_value in o["label"] or o["value"] in (value or [])
+    ]
+
+
+if __name__ == "__main__":
     app.run_server(debug=True)

--- a/tutorial/examples/core_components/dropdown_dynamic_options.py
+++ b/tutorial/examples/core_components/dropdown_dynamic_options.py
@@ -1,4 +1,5 @@
 import dash
+from dash.exceptions import PreventUpdate
 import dash_html_components as html
 import dash_core_components as dcc
 
@@ -19,6 +20,8 @@ app.layout = dcc.Dropdown(id='my-dynamic-dropdown')
     [dash.dependencies.Input('my-dynamic-dropdown', 'search_value')],
 )
 def update_options(search_value):
+    if not search_value:
+        raise PreventUpdate
     return [o for o in options if search_value in o['label']]
 
 

--- a/tutorial/examples/core_components/dropdown_dynamic_options.py
+++ b/tutorial/examples/core_components/dropdown_dynamic_options.py
@@ -1,0 +1,26 @@
+import dash
+import dash_html_components as html
+import dash_core_components as dcc
+
+external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+options=[
+    {'label': 'New York City', 'value': 'NYC'},
+    {'label': 'Montreal', 'value': 'MTL'},
+    {'label': 'San Francisco', 'value': 'SF'}
+]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+app.layout = dcc.Dropdown(id='my-dynamic-dropdown')
+
+
+@app.callback(
+    dash.dependencies.Output('my-dynamic-dropdown', 'options'),
+    [dash.dependencies.Input('my-dynamic-dropdown', 'search_value')],
+)
+def update_options(search_value):
+    return [o for o in options if search_value in o['label']]
+
+
+if __name__ == '__main__':
+    app.run_server(debug=True)


### PR DESCRIPTION
Requires the `search_value` property in `Dropdown` as implemented in https://github.com/plotly/dash-core-components/pull/660

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [ ] I understand
