### PR TITLE
exclude datepickers from base css td/th overrides

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -310,16 +310,16 @@ li {
 
 /* Tables
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-th,
-td {
+th:not(.CalendarDay),
+td:not(.CalendarDay) {
   padding: 12px 15px;
   text-align: left;
   border-bottom: 1px solid #E1E1E1; }
-th:first-child,
-td:first-child {
+th:first-child:not(.CalendarDay),
+td:first-child:not(.CalendarDay) {
   padding-left: 0; }
-th:last-child,
-td:last-child {
+th:last-child:not(.CalendarDay),
+td:last-child:not(.CalendarDay) {
   padding-right: 0; }
 
 


### PR DESCRIPTION
The docs portion of https://github.com/plotly/dash-core-components/issues/658 