### PR TITLE
remove google analytics tags as we have the google tag manager

### DIFF
--- a/assets/plotly_ga.js
+++ b/assets/plotly_ga.js
@@ -1,7 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-39373211-1', 'auto');
-ga('send', 'pageview');


### PR DESCRIPTION
relates to: https://github.com/plotly/marketing-team/issues/118

having both google analytics and [google tag manager](https://github.com/plotly/dash-docs/blob/b10701c8514b87d86645f6edeb808ccdcfa4143d/run.py#L283) double counts pageviews