### PR TITLE
Fix usage for implicit pixels style strings

### DIFF
--- a/tutorial/dashbio.py
+++ b/tutorial/dashbio.py
@@ -98,8 +98,8 @@ DASHBIO_COMPONENTS = {
             'column_labels': 'list(df.columns.values)',
             'row_labels': 'list(df.index)',
             'hidden_labels': '[\'row\']',
-            'height': '800',
-            'width': '600'
+            'height': 800,
+            'width': 600
         },
         'component_wrap': 'dcc.Graph(figure=_[0])',
         'setup_code': '''df = pd.read_csv(
@@ -137,7 +137,7 @@ data = df.values
     'Ideogram': {
         'description': '''A visual representation and analysis tool for chromosome bands.''',
         'params': {
-            'chrHeight': '250'
+            'chrHeight': 250
         },
         'iframe_info': {
             'location': 'https://dash-gallery.plotly.host/docs-demos-dashbio/ideogram'

--- a/tutorial/table/filtering_chapter.py
+++ b/tutorial/table/filtering_chapter.py
@@ -61,7 +61,7 @@ layout = html.Div(
             html.Td([
                 html.H4(
                     html.P([html.Code('='), ' ', html.Code('eq')]),
-                    style={'margin': '0'}),
+                    style={'margin': '0px'}),
                 dcc.Markdown('Default operator for `number` columns')]),
             html.Td(dcc.Markdown(dedent("""
             Are the two numbers equal? Regardless of type, will first try to
@@ -70,7 +70,7 @@ layout = html.Div(
             """)))
         ]), html.Tr([
             html.Td([
-                html.H4(html.P(html.Code('contains')), style={'margin': '0'}),
+                html.H4(html.P(html.Code('contains')), style={'margin': '0px'}),
                 dcc.Markdown('Default operator for `text` and `any` columns')
             ]),
             html.Td(dcc.Markdown(dedent("""
@@ -82,7 +82,7 @@ layout = html.Div(
             html.Td([
                 html.H4(
                     html.P(html.Code('datestartswith')),
-                    style={'margin': '0'}),
+                    style={'margin': '0px'}),
                 dcc.Markdown('Default operator for `datetime` columns')]),
             html.Td(dcc.Markdown(dedent("""
             Does the datetime start with the given parts? Enter a partial
@@ -99,7 +99,7 @@ layout = html.Div(
                 html.Code('>='), ' ', html.Code('ge'), u' \u00a0 ',
                 html.Code('<='), ' ', html.Code('le'), html.Br(),
                 html.Code('!='), ' ', html.Code('ne')
-            ]), style={'margin': '0'})),
+            ]), style={'margin': '0px'})),
             html.Td(dcc.Markdown(dedent("""
             Comparison: greater than, less than, greater or equal, less or
             equal, and not equal. Two strings compare by their dictionary

--- a/tutorial/table/sizing_chapter.py
+++ b/tutorial/table/sizing_chapter.py
@@ -506,7 +506,7 @@ layout = html.Div(
             data=df_long.to_dict('records'),
             columns=[{'id': c, 'name': c} for c in df.columns],
             style_table={
-                'maxHeight': '300',
+                'maxHeight': '300px',
                 'overflowY': 'scroll'
             },
         )


### PR DESCRIPTION
React accepts `margin: '0'` as `0px` but ignores `margin: '10'`, need to add 'px' for it to be picked up..

Searching through the docs with `['"]\w+['"]: ['"]\d+['"]`, found these examples are that can be updated. The non-zero usages were incorrect / broken.

As discussed with @alexcjohnson 

React allows `'0'` to be treated as `0` but does not allow non-zero unit-less strings to be treated as `px`. It will treat numbers as `px` though.

We will probably never want to validate/transform all props on `style_**` props in the future so that `'10'` becomes `'10px'`.