### PR TITLE
remove "s" in link: middlewares/ to middleware/

### DIFF
--- a/dash_docs/tutorial/integrating_dash.py
+++ b/dash_docs/tutorial/integrating_dash.py
@@ -84,7 +84,7 @@ layout = html.Div([
     ## Combining One or More Dash Apps with Existing WSGI Apps
 
     This approach uses Werkzeug's
-    [`DispatcherMiddleware`](http://werkzeug.pocoo.org/docs/latest/middlewares/)
+    [`DispatcherMiddleware`](http://werkzeug.pocoo.org/docs/latest/middleware/)
     to combine one or more Dash apps with existing WSGI apps (including
     Flask). It is useful when you want to combine multiple Dash apps or when
     your existing app is a non-Flask WSGI app.


### PR DESCRIPTION
Tiny update but found while reading through today. Looks like the `middlewares` endpoint moved to `middleware` at werkzeug documentation.

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.
