### PR TITLE
Revert "Changed links to the datasets stored in master branch of `dashr`

### DIFF
--- a/dashr/chapters/dash-bio/alignment-chart/examples/colorscaleAlignmentChart.R
+++ b/dashr/chapters/dash-bio/alignment-chart/examples/colorscaleAlignmentChart.R
@@ -4,7 +4,7 @@ library(readr)
 app <- Dash$new()
 
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 app$layout(htmlDiv(list(
   dashbioAlignmentChart(

--- a/dashr/chapters/dash-bio/alignment-chart/examples/consensusAlignmentChart.R
+++ b/dashr/chapters/dash-bio/alignment-chart/examples/consensusAlignmentChart.R
@@ -4,7 +4,7 @@ library(readr)
 app <- Dash$new()
 
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 app$layout(htmlDiv(list(
   dashbioAlignmentChart(

--- a/dashr/chapters/dash-bio/alignment-chart/examples/defaultAlignmentChart.R
+++ b/dashr/chapters/dash-bio/alignment-chart/examples/defaultAlignmentChart.R
@@ -4,7 +4,7 @@ library(readr)
 app <- Dash$new()
 
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 app$layout(htmlDiv(list(
   dashbioAlignmentChart(

--- a/dashr/chapters/dash-bio/alignment-chart/examples/hideBarPlots.R
+++ b/dashr/chapters/dash-bio/alignment-chart/examples/hideBarPlots.R
@@ -4,7 +4,7 @@ library(readr)
 app <- Dash$new()
 
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 app$layout(htmlDiv(list(
   dashbioAlignmentChart(

--- a/dashr/chapters/dash-bio/alignment-chart/examples/tileAlignmentChart.R
+++ b/dashr/chapters/dash-bio/alignment-chart/examples/tileAlignmentChart.R
@@ -4,7 +4,7 @@ library(readr)
 app <- Dash$new()
 
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 app$layout(htmlDiv(list(
   dashbioAlignmentChart(

--- a/dashr/chapters/dash-bio/circos/circos.R
+++ b/dashr/chapters/dash-bio/circos/circos.R
@@ -44,7 +44,7 @@ library(dashBio)
 library(readr)
 library(jsonlite)
 
-data <- "https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/circos_graph_data.json"
+data <- "https://raw.githubusercontent.com/plotly/dash-bio/master/tests/dashbio_demos/sample_data/circos_graph_data.json"
 
 circos_graph_data = read_json(data)
 

--- a/dashr/chapters/dash-bio/circos/examples/defaultCircos.R
+++ b/dashr/chapters/dash-bio/circos/examples/defaultCircos.R
@@ -5,7 +5,7 @@ library(jsonlite)
 app <- Dash$new()
 
 
-data <- "https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/circos_graph_data.json"
+data <- "https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/circos_graph_data.json"
 
 circos_graph_data = read_json(data)
 

--- a/dashr/chapters/dash-bio/clustergram/clustergram.R
+++ b/dashr/chapters/dash-bio/clustergram/clustergram.R
@@ -47,7 +47,7 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 dccGraph(figure = heatmaply(df,
@@ -80,7 +80,7 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 # The following is a color palette.
@@ -117,7 +117,7 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 dccGraph(figure = heatmaply(df,
@@ -150,7 +150,7 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 dccGraph(figure = heatmaply(df,
@@ -181,7 +181,7 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 

--- a/dashr/chapters/dash-bio/clustergram/examples/defaultClustergram.R
+++ b/dashr/chapters/dash-bio/clustergram/examples/defaultClustergram.R
@@ -6,14 +6,10 @@ library(dashBio)
 library(heatmaply)
 library(data.table)
 
-
-
 app <- Dash$new()
 
-
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                         skip = 4, sep ="\t",  row.names = 1, header = TRUE)
-
 
 # The following lines generate the options list for the dropdown we will be using.
 all_options <- rownames(df)

--- a/dashr/chapters/dash-bio/index.R
+++ b/dashr/chapters/dash-bio/index.R
@@ -290,7 +290,7 @@ app$callback(
 library(dashBio)
 library(readr)
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 dashbioAlignmentChart(
 id = "my-dashbio-alignmentchart",
@@ -306,7 +306,7 @@ data = data
 library(dashBio)
 library(readr)
 
-data = read_file("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/alignment_viewer_p53.fasta")
+data = read_file("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/alignment_viewer_p53.fasta")
 
 dashbioAlignmentChart(
 id = "my-dashbio-alignmentchart",
@@ -339,7 +339,7 @@ library(dashBio)
 library(readr)
 library(jsonlite)
 
-data <- "https://raw.githubusercontent.com/plotly/dash-docs/dash_docs/master/dash_docs/assets/sample_data/circos_graph_data.json"
+data <- "https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/circos_graph_data.json"
 
 circos_graph_data = read_json(data)
 
@@ -378,7 +378,7 @@ library(dashBio)
 library(readr)
 library(jsonlite)
 
-data <- "https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/circos_graph_data.json"
+data <- "https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/circos_graph_data.json"
 
 circos_graph_data = read_json(data)
 
@@ -428,7 +428,7 @@ app$callback(
 library(dashBio)
 library(dashCoreComponents)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                   skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 dccGraph(figure = heatmaply(df,
@@ -453,7 +453,7 @@ dccGraph(figure = heatmaply(df,
 library(dashBio)
 library(dashCoreComponents)
 
-df = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/clustergram_mtcars.tsv",
+df = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/clustergram_mtcars.tsv",
                   skip = 4, sep ="\t",  row.names = 1, header = TRUE)
 
 dccGraph(figure = heatmaply(df,
@@ -533,7 +533,7 @@ app$callback(
           '
 library(dashBio)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/manhattan_data.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/manhattan_data.csv",
                      header = TRUE, sep = ",")
 
 dccGraph(figure = dashbioManhattan(
@@ -550,7 +550,7 @@ dccGraph(figure = dashbioManhattan(
           dccMarkdown('```r
 library(dashBio)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/manhattan_data.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/manhattan_data.csv",
                      header = TRUE, sep = ",")
 
 dccGraph(figure = dashbioManhattan(
@@ -681,7 +681,7 @@ app$callback(
 library(dashBio)
 library(jsonlite)
 
-mdata = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/needle_PIK3CA.json")
+mdata = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/needle_PIK3CA.json")
 
 dashbioNeedlePlot(
 id = "my-dashbio-needleplot",
@@ -699,7 +699,7 @@ mutationData = mdata
 library(dashBio)
 library(jsonlite)
 
-mdata = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/needle_PIK3CA.json")
+mdata = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/needle_PIK3CA.json")
 
 dashbioNeedlePlot(
 id = "my-dashbio-needleplot",
@@ -729,7 +729,7 @@ app$callback(
 library(dashBio)
 library(jsonlite)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 dashbioOncoPrint(
 id = "my-dashbio-oncoprint",
@@ -747,7 +747,7 @@ data = data
 library(dashBio)
 library(jsonlite)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 dashbioOncoPrint(
 id = "my-dashbio-oncoprint",
@@ -854,7 +854,7 @@ importSpeck <- function(filepath,
 }
 
 
-data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/speck_methane.xyz")
+data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/speck_methane.xyz")
 
 dashbioSpeck(
   id = "my-speck",
@@ -890,7 +890,7 @@ importSpeck <- function(filepath,
 }
 
 
-data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/speck_methane.xyz")
+data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/speck_methane.xyz")
 
 dashbioSpeck(
   id = "my-speck",
@@ -921,7 +921,7 @@ app$callback(
 library(dashBio)
 library(dashCoreComponents)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/volcano_data1.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/volcano_data1.csv",
                      header = TRUE, sep = ",")
 
 dccGraph(figure = dashbioVolcano(
@@ -941,7 +941,7 @@ dccGraph(figure = dashbioVolcano(
 library(dashBio)
 library(dashCoreComponents)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/volcano_data1.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/volcano_data1.csv",
                      header = TRUE, sep = ",")
 
 dccGraph(figure = dashbioVolcano(

--- a/dashr/chapters/dash-bio/manhattan/examples/defaultManhattan.R
+++ b/dashr/chapters/dash-bio/manhattan/examples/defaultManhattan.R
@@ -1,34 +1,22 @@
-
 library(dashBio)
 library(data.table)
 
 app <- Dash$new()
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/manhattan_data.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/manhattan_data.csv",
                   header = TRUE, sep = ",")
 
-
-
 genMark <- function(n){
-
   l <- list(sprintf('%s', n))
-
   names(l) <- 'label'
-
   return(l)
-
 }
 
 genMarks <- function(min, max, by){
-
   s <- seq(from=min, to=max, by)
-
   l <- lapply(s, genMark)
-
   names(l) <- s
-
   return(l)
-
 }
 
 app$layout(htmlDiv(list(

--- a/dashr/chapters/dash-bio/manhattan/manhattan.R
+++ b/dashr/chapters/dash-bio/manhattan/manhattan.R
@@ -41,7 +41,7 @@ lineColors <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/manhattan_data.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/manhattan_data.csv",
                   header = TRUE, sep = ",")
 
 dccGraph(
@@ -62,7 +62,7 @@ highlightedPoints <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read.table("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/manhattan_data.csv",
+data = read.table("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/manhattan_data.csv",
                   header = TRUE, sep = ",")
 
 dccGraph(

--- a/dashr/chapters/dash-bio/molecule2dviewer/examples/defaultMolecule2dViewer.R
+++ b/dashr/chapters/dash-bio/molecule2dviewer/examples/defaultMolecule2dViewer.R
@@ -5,7 +5,7 @@ library(dashCoreComponents)
 library(dashBio)
 library(jsonlite)
 
-model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/mol2d_buckminsterfullerene.json")
+model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/mol2d_buckminsterfullerene.json")
 
 
 app <- Dash$new()

--- a/dashr/chapters/dash-bio/molecule2dviewer/molecule2dviewer.R
+++ b/dashr/chapters/dash-bio/molecule2dviewer/molecule2dviewer.R
@@ -41,7 +41,7 @@ selectedAtom <- htmlDiv(list(
     '
 library(dashBio)
 
-model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/mol2d_buckminsterfullerene.json")
+model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/mol2d_buckminsterfullerene.json")
 
 dashbioMolecule2dViewer(
         modelData = model_data,
@@ -58,7 +58,7 @@ modelData <- htmlDiv(list(
     '
 library(dashBio)
 
-model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/mol2d_buckminsterfullerene.json")
+model_data <- read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/mol2d_buckminsterfullerene.json")
 
 for (node in model_data$nodes) {
     node$atom <- "N"

--- a/dashr/chapters/dash-bio/needleplot/examples/defaultNeedle.R
+++ b/dashr/chapters/dash-bio/needleplot/examples/defaultNeedle.R
@@ -5,7 +5,7 @@ library(data.table)
 
 app <- Dash$new()
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/needle_PIK3CA.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/needle_PIK3CA.json")
 
 
 app$layout(htmlDiv(list(

--- a/dashr/chapters/dash-bio/needleplot/needleplot.R
+++ b/dashr/chapters/dash-bio/needleplot/needleplot.R
@@ -41,7 +41,7 @@ needleStyle <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/needle_PIK3CA.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/needle_PIK3CA.json")
 
 dashbioNeedlePlot(
   mutationData = data,
@@ -64,7 +64,7 @@ domainStyle <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/needle_PIK3CA.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/needle_PIK3CA.json")
 
 dashbioNeedlePlot(
   mutationData = data,

--- a/dashr/chapters/dash-bio/oncoprint/examples/defaultOnco.R
+++ b/dashr/chapters/dash-bio/oncoprint/examples/defaultOnco.R
@@ -8,7 +8,7 @@ library(dashBio)
 app <- Dash$new()
 
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 
 app$layout(htmlDiv(list(

--- a/dashr/chapters/dash-bio/oncoprint/oncoprint.R
+++ b/dashr/chapters/dash-bio/oncoprint/oncoprint.R
@@ -41,7 +41,7 @@ oncoColors <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 dashbioOncoPrint(
   data = data,
@@ -63,7 +63,7 @@ oncoSize <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 dashbioOncoPrint(
   data = data,
@@ -82,7 +82,7 @@ oncoLegend <- htmlDiv(list(
     '
 library(dashBio)
 
-data = read_json("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/oncoprint_dataset3.json")
+data = read_json("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/oncoprint_dataset3.json")
 
 dashbioOncoPrint(
   data=data,

--- a/dashr/chapters/dash-bio/speck/examples/defaultSpeck.R
+++ b/dashr/chapters/dash-bio/speck/examples/defaultSpeck.R
@@ -23,7 +23,7 @@ importSpeck <- function(filepath,
 }
 
 
-data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/speck_methane.xyz")
+data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/speck_methane.xyz")
 
 app$layout(htmlDiv(list(
   dccDropdown(

--- a/dashr/chapters/dash-bio/speck/speck.R
+++ b/dashr/chapters/dash-bio/speck/speck.R
@@ -54,7 +54,7 @@ speckRender <- htmlDiv(list(
     '
 library(dashBio)
 
-data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/speck_methane.xyz")
+data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/speck_methane.xyz")
 
 dashbioSpeck(
   data = data,
@@ -78,7 +78,7 @@ scrollZoom <- htmlDiv(list(
     '
 library(dashBio)
 
-data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/speck_methane.xyz")
+data <- importSpeck("https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/speck_methane.xyz")
 
 dashbioSpeck(
   data = data,

--- a/dashr/chapters/dash-bio/volcanoplot/examples/colors.R
+++ b/dashr/chapters/dash-bio/volcanoplot/examples/colors.R
@@ -7,7 +7,7 @@ library(dashCoreComponents)
 app <- Dash$new()
 
 df <- read.csv(
-  file = 'https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/volcano_data1.csv',
+  file = 'https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/volcano_data1.csv',
   stringsAsFactors = FALSE
 )
 

--- a/dashr/chapters/dash-bio/volcanoplot/examples/default.R
+++ b/dashr/chapters/dash-bio/volcanoplot/examples/default.R
@@ -7,7 +7,7 @@ library(dashCoreComponents)
 app <- Dash$new()
 
 df <- read.csv(
-  file ='https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/volcano_data1.csv',
+  file ='https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/volcano_data1.csv',
   stringsAsFactors = FALSE
 )
 

--- a/dashr/chapters/dash-bio/volcanoplot/examples/pointSizesLineWidths.R
+++ b/dashr/chapters/dash-bio/volcanoplot/examples/pointSizesLineWidths.R
@@ -8,7 +8,7 @@ library(dashCoreComponents)
 app <- Dash$new()
 
 df <- read.csv(
-  file = 'https://raw.githubusercontent.com/plotly/dash-docs/master/dash_docs/assets/sample_data/volcano_data1.csv',
+  file = 'https://raw.githubusercontent.com/plotly/dash-bio-docs-files/master/volcano_data1.csv',
   stringsAsFactors = FALSE
 )
 


### PR DESCRIPTION
Points back to links in shared repo between DashR and Dash for Python docs. 

This reverts commit 5d8edf71d5e21b83a90c5bb896733a53470c3588.

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`
