### PR TITLE
Update to dash==1.8.0

### DIFF
--- a/dash_docs/tutorial/auth.py
+++ b/dash_docs/tutorial/auth.py
@@ -283,7 +283,7 @@ layout = html.Div([
     '''.replace('    ', '')),
 
     reusable_components.Markdown('''
-    ```
+    ```py
     import dash
     import dash_auth
     import dash_core_components as dcc

--- a/dash_docs/tutorial/canvas.py
+++ b/dash_docs/tutorial/canvas.py
@@ -24,7 +24,7 @@ layout = html.Div([
 
     reusable_components.Markdown(
         '''
-        ```
+        ```shell
         pip install dash-canvas=={}
         ```
         '''.format(dash_canvas.__version__),

--- a/dash_docs/tutorial/core_components.py
+++ b/dash_docs/tutorial/core_components.py
@@ -28,7 +28,7 @@ layout = html.Div(className="gallery", children=[
     '''.replace('    ', '').format(dcc.__version__)),
 
     reusable_components.Markdown('''
-    ```
+    ```py
     >>> import dash_core_components as dcc
     >>> print(dcc.__version__)
     {}

--- a/dash_docs/tutorial/cytoscape/styling_chapter.py
+++ b/dash_docs/tutorial/cytoscape/styling_chapter.py
@@ -219,7 +219,7 @@ layout = html.Div([
     A nice property of the selector is that it can select elements by comparing
     a certain item of the data dictionaries with a given value. Say we have
     some nodes with `id` A to E declared this way:
-    ```
+    ```py
     {'data': {'source': 'A', 'target': 'B', 'weight': 1}}
     ```
     where the `'weight'` key indicates the weight of your edge. You can find
@@ -308,7 +308,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     Comparisons also work for string matching problems. Given the same graph
     as before, but with a data key `'firstname'` for each node:
-    ```
+    ```py
     {'data': {'id': 'A', 'firstname': 'Albert'}}
     ```
     We can select all the elements that match a specific pattern. For instance,

--- a/dash_docs/tutorial/daq.py
+++ b/dash_docs/tutorial/daq.py
@@ -25,7 +25,7 @@ daq_library_heading =  reusable_components.Markdown('''
 )
 
 daq_install_instructions = reusable_components.Markdown('''
-    ```
+    ```py
     >>> import dash_daq as daq
     >>> print(daq.__version__)
     {}

--- a/dash_docs/tutorial/dash_cytoscape_index.py
+++ b/dash_docs/tutorial/dash_cytoscape_index.py
@@ -44,7 +44,7 @@ preamble = html.Div([
     Section('Quickstart', [
         reusable_components.Markdown(
             '''
-            ```
+            ```shell
             pip install dash-cytoscape=={}
             ```
             '''.format(dash_cytoscape.__version__),

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -1043,7 +1043,7 @@ EnvVars = html.Div(children=[
 
     rc.Markdown(
     '''
-    ```
+    ```py
     database_password = os.environ.get('DATABASE_PASSWORD', 'my-default-database-password')
     ```
     ''',
@@ -1062,7 +1062,7 @@ EnvVars = html.Div(children=[
     this is to define the variables on-the-fly when you run `python app.py`.
     That is, instead of running `python app.py`, run:
 
-    ```
+    ```shell
     $ DATABASE_USER=chris DATABASE_PASSWORD=my-password python app.py
     ```
 
@@ -1399,7 +1399,7 @@ def display_instructions(platform):
 
         rc.Markdown(
         '''
-        ```
+        ```shell
         $ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
         ```
         ''',
@@ -1422,7 +1422,7 @@ def display_instructions(platform):
             ```
             ''' if platform == 'Windows' else
             '''
-            ```
+            ```shell
             $ eval "$(ssh-agent -s)"
             ```
             '''),
@@ -1446,7 +1446,7 @@ def display_instructions(platform):
             ```
             ''' if platform == 'Windows' else
             '''
-            ```
+            ```shell
             $ ssh-add -k ~/.ssh/id_rsa
             ```
             '''),
@@ -1865,7 +1865,7 @@ Cli = html.Div(children=[
 
             You can also retrieve a specific piece of service info via flags:
 
-            ```
+            ```shell
             ssh dokku@your-dash-enterprise -p PORT redis:info redis-db --config-dir
             ssh dokku@your-dash-enterprise -p PORT redis:info redis-db --data-dir
             ssh dokku@your-dash-enterprise -p PORT redis:info redis-db --dsn
@@ -3730,7 +3730,7 @@ Git = html.Div(children=[
 
     rc.Markdown(
     '''
-    ```
+    ```shell
     $ git checkout <branchname>
     ```
     ''',

--- a/dash_docs/tutorial/dash_table_index.py
+++ b/dash_docs/tutorial/dash_table_index.py
@@ -68,7 +68,7 @@ preamble = html.Div([
     Section('Quickstart', [
         reusable_components.Markdown(
             '''
-            ```
+            ```shell
             pip install dash=={}
             ```
             '''.format(dash.__version__),

--- a/dash_docs/tutorial/external_css_and_js.py
+++ b/dash_docs/tutorial/external_css_and_js.py
@@ -236,7 +236,7 @@ Starting with Dash 1.0.0, `serve_locally` defaults to `True`.
 
     reusable_components.Markdown(
     '''
-    ```
+    ```py
     import dash
     import dash_html_components as html
 
@@ -272,7 +272,7 @@ Starting with Dash 1.0.0, `serve_locally` defaults to `True`.
 
     reusable_components.Markdown(
     '''
-    ```
+    ```py
     import dash
     import dash_html_components as html
 

--- a/dash_docs/tutorial/live_updates.py
+++ b/dash_docs/tutorial/live_updates.py
@@ -134,7 +134,7 @@ on every page load.
 
 For example, if your `app.layout` looked like this:
 
-```
+```py
 import datetime
 
 import dash
@@ -151,7 +151,7 @@ then your app would display the time when the app was started.
 If you change this to a function, then a new `datetime` will get computed
 everytime you refresh the page. Give it a try:
 
-```
+```py
 import datetime
 
 import dash

--- a/dash_docs/tutorial/migration.py
+++ b/dash_docs/tutorial/migration.py
@@ -48,7 +48,7 @@ layout = html.Div([
     ```
     Now that's the default, and that syntax can still be used to disable it for
     each asset class, but if you want to use CDNs for both you can just do:
-    ```
+    ```py
     app = dash.Dash(serve_locally=False)
     ```
 

--- a/dash_docs/tutorial/react_for_python_developers.py
+++ b/dash_docs/tutorial/react_for_python_developers.py
@@ -200,7 +200,7 @@ render() {
 ##### Variable declaration
 
 In JavaScript, we have to declare our variables with `let` or `const`. `const` is used when the variable shouldn't change, `let` is used elsewhere:
-```
+```js
 const color = 'blue';
 let someText = 'Hello World';
 let myText;
@@ -210,7 +210,7 @@ myText = 'Hello Dash';
 ##### Comments
 
 Single line comments are prefixed with `//`. Multi-line comments are wrapped in `/* */`
-```
+```js
 /*
 * This is a multi-line comment
 * By convention, we use a `*` on each line, but it's
@@ -222,13 +222,13 @@ const color = 'blue'; // This is a single line comment
 ##### Strings
 
 Strings are defined the same way in JavaScript: single or double quotes:
-```
+```js
 const someString = 'Hello Dash';
 const anotherString = "Hello Dash";
 ```
 
 Instead of Python's `format`, JavaScript allows you to embed variables directly into strings by wrapping the variable in `${}` and wrapping the string in backticks:
-```
+```js
 const name = 'Dash';
 const someString = `Hello ${name}`;
 ```
@@ -236,19 +236,19 @@ const someString = `Hello ${name}`;
 ##### Dictionaries
 
 In Python, we use dictionaries for key-value pairs. In JavaScript, we use "objects" and they are instantiated and accessed very similarly:
-```
+```js
 const myObject = {"color": "blue", "size": 20};
 myObject['color']; // is blue
 myObject.color;  // another way to access the color variable
 ```
 
 In Python, the keys of a dictionary can be any type. But in JavaScript, the keys can only be strings. JavaScript allows you to omit the quotes around the strings and we frequently do:
-```
+```js
 const myObject = {color: "blue"}; // notice how there are no strings around color
 ```
 
 So if you want to set a dynamic key in an object, you have to wrap it in square brackets:
-```
+```js
 const styleProperty = "color";
 const myObject = {[styleProperty]: "blue"};
 myObject.color;
@@ -257,7 +257,7 @@ myObject.color;
 ##### Lists
 
 In JavaScript, lists are called "arrays" and they're instantiated and accessed the same way:
-```
+```js
 const myList = ["Hello", "Dash", "!"];
 myList[0];  // Hello
 myList[1];  // Dash
@@ -272,7 +272,7 @@ In JavaScript, the convention is to end each line in a semicolon. It's not stric
 
 In JavaScript, we use `console.log` to print statements into the "console":
 
-```
+```js
 console.log("Hello Dash");
 ```
 
@@ -293,7 +293,7 @@ Like Python, error messages and exceptions will also appear inside this console.
 ##### If, For, While
 
 `if`
-```
+```js
 if (color === 'red') {
   console.log("the color is red");
 } else if (color === 'blue') {
@@ -304,14 +304,14 @@ if (color === 'red') {
 ```
 
 `for`
-```
+```js
 for (let i = 0; i < 10; i++) {
   console.log(i);
 }
 ```
 
 `while`
-```
+```js
 let i = 0;
 while (i < 10) {
   i += 1;
@@ -323,7 +323,7 @@ while (i < 10) {
 In JavaScript, you'll see functions defined in two ways:
 
 The new style way:
-```
+```js
 const add = (a, b) => {
   // The inside of the function
   const c = a + b;
@@ -334,7 +334,7 @@ console.log(add(4, 6)); // 10
 ```
 
 The traditional way:
-```
+```js
 function (a, b) {
   // The inside of the function
   const c = a + b;
@@ -379,20 +379,20 @@ In Python, we can import any variable from any file. In JavaScript, we have to e
 If we only want to export a single variable, we'll write `export default`:
 
 `some_file.js`
-```
+```js
 const text = 'hello world';
 export default text;
 ```
 
 `another_file.js`
-```
+```js
 import text from './some_file.js';
 ```
 
 If we want to export multiple variables, we'll just write `export`:
 
 `some_file.js`
-```
+```js
 const text = 'hello world';
 const color = 'blue';
 const size = '12px';
@@ -402,7 +402,7 @@ export color;
 ```
 
 `another_file.js`
-```
+```js
 import {text, color} from './some_file.js';
 /*
 * note that we can't import size

--- a/dash_docs/tutorial/utils/convert_props_to_list.py
+++ b/dash_docs/tutorial/utils/convert_props_to_list.py
@@ -15,7 +15,7 @@ def generate_prop_info(component_name, lib=dcc):
         reusable_components.Markdown(dedent(
             '''
             > Access this documentation in your Python terminal with:
-            > ```
+            > ```shell
             > >>> help({}.{})
             > ```
             '''.format(lib.__name__, component_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2018.4.16
 chardet==3.0.4
 click==6.7
 configparser==3.5.0
-dash[testing]==1.7.0
+dash[testing]==1.8.0
 dash-auth==1.2.0
 dash_bio==0.4.5
 dash-bio-utils==0.0.3rc3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ chardet==3.0.4
 click==6.7
 configparser==3.5.0
 dash[testing]==1.8.0
-
 dash-auth==1.2.0
 dash_bio==0.4.5
 dash-bio-utils==0.0.3rc3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ chardet==3.0.4
 click==6.7
 configparser==3.5.0
 dash[testing]==1.8.0
+
 dash-auth==1.2.0
 dash_bio==0.4.5
 dash-bio-utils==0.0.3rc3


### PR DESCRIPTION
- Update to `dash==1.8.0`
- Update markdown codeblock usage to include more language hints; updating `hilightjs` version in dcc (and possibly other factors?) caused language discovery to change and for certain `shell` scripts to be evaluated as `ruby`