### PR TITLE
Use dcc.Link in markdown sections for faster navigation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,6 @@ If this PR includes a new dataset available at a remote URL:
 - [ ] I have added this dataset to the `datasets/` folder
 - [ ] I have added a mapping between the remote URL and the filename in the
 `datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`
+
+If I introduced a new relative link inside `dcc.Markdown`:
+- [ ] I used e.g. `<dccLink href="/getting-started" children="the first chapter"/>` instead of `[the first chapter](/getting-started)`.

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -714,14 +714,14 @@ URLS = [
                     {
                         'url': '/dash-enterprise/initialize',
                         'content': tutorial.dds_examples.Initialize,
-                        'name': 'Part 1. Initialize Dash Apps on Dash Enterprise',
+                        'name': 'Part 1. Initialize Dash Apps on Dash Deployment Server',
                         'description': 'Initialize Dash Apps on Plotly Enterprise'
                     },
                     {
                         'url': '/dash-enterprise/deployment',
                         'content': tutorial.dds_examples.Deploy,
-                        'name': 'Part 2. Deploy Dash Apps on Dash Enterprise',
-                        'description': 'Deploy Dash Apps on Dash Enterprise'
+                        'name': 'Part 2. Deploy Dash Apps on Dash Deployment Server',
+                        'description': 'Deploy Dash Apps on Dash Deployment Server'
                     },
                     {
                         'url': '/dash-enterprise/application-structure',
@@ -778,12 +778,12 @@ URLS = [
                         'content': tutorial.dds_examples.LocalDir,
                         'name': 'Mapping Local Directories',
                         'description': 'Directory mappings allow you to make directories '
-                        'on the Dash Enterprise available to your app.'
+                        'on the Dash Deployment Server available to your app.'
                     },
                     {
                         'url': '/dash-enterprise/ssh',
                         'content': tutorial.dds_examples.Ssh,
-                        'name': 'Authenticating to Dash Enterprise with SSH',
+                        'name': 'Authenticating to Dash Deployment Server with SSH',
                         'description': "There are two methods to deploy Dash Apps: HTTPS and SSH "
                         "and we recommend getting started with the HTTPS method."
                     },
@@ -803,7 +803,7 @@ URLS = [
                     {
                         'url': '/dash-enterprise/checks',
                         'content': tutorial.dds_examples.Checks,
-                        'name': 'Dash Enterprise App Health Checks',
+                        'name': 'Dash Deployment Health Checks',
                         'description': 'Create custom checks to ensure that a newly deployed app can serve traffic.'
                     },
                     {
@@ -828,8 +828,8 @@ URLS = [
                     {
                         'url': '/dash-enterprise/pdf-service',
                         'content': tutorial.dds_examples.pdfService,
-                        'name': 'Dash Enterprise PDF Service',
-                        'description': 'Utilize the Dash Enterprise API endpoint for '
+                        'name': 'Dash Deployment Server PDF Service',
+                        'description': 'Utilize the Dash Deployment Server API endpoint for '
                         'creating PDF exports of your Dash applications'
                     },
                     {
@@ -844,7 +844,7 @@ URLS = [
                         'content': tutorial.dds_examples.Logs,
                         'name': 'App Logs',
                         'description': """Check your Dash App's logs via the Dash
-                        Enterprise UI or via the command line."""
+                        Deployment Server UI or via the command line."""
                     },
                     {
                         'url': '/dash-enterprise/troubleshooting',
@@ -864,7 +864,7 @@ URLS = [
                         'content': tutorial.dds_examples.Git,
                         'name': 'Advanced Git',
                         'description': 'A reference for git commands and how they are used '
-                        'with Dash Enterprise.'
+                        'with Dash Deployment Server.'
                     },
                 ]
             }

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -710,14 +710,14 @@ URLS = [
                     {
                         'url': '/dash-enterprise/initialize',
                         'content': tutorial.dds_examples.Initialize,
-                        'name': 'Part 1. Initialize Dash Apps on Dash Deployment Server',
+                        'name': 'Part 1. Initialize Dash Apps on Dash Enterprise',
                         'description': 'Initialize Dash Apps on Plotly Enterprise'
                     },
                     {
                         'url': '/dash-enterprise/deployment',
                         'content': tutorial.dds_examples.Deploy,
-                        'name': 'Part 2. Deploy Dash Apps on Dash Deployment Server',
-                        'description': 'Deploy Dash Apps on Dash Deployment Server'
+                        'name': 'Part 2. Deploy Dash Apps on Dash Enterprise',
+                        'description': 'Deploy Dash Apps on Dash Enterprise'
                     },
                     {
                         'url': '/dash-enterprise/application-structure',
@@ -774,12 +774,12 @@ URLS = [
                         'content': tutorial.dds_examples.LocalDir,
                         'name': 'Mapping Local Directories',
                         'description': 'Directory mappings allow you to make directories '
-                        'on the Dash Deployment Server available to your app.'
+                        'on the Dash Enterprise available to your app.'
                     },
                     {
                         'url': '/dash-enterprise/ssh',
                         'content': tutorial.dds_examples.Ssh,
-                        'name': 'Authenticating to Dash Deployment Server with SSH',
+                        'name': 'Authenticating to Dash Enterprise with SSH',
                         'description': "There are two methods to deploy Dash Apps: HTTPS and SSH "
                         "and we recommend getting started with the HTTPS method."
                     },
@@ -799,7 +799,7 @@ URLS = [
                     {
                         'url': '/dash-enterprise/checks',
                         'content': tutorial.dds_examples.Checks,
-                        'name': 'Dash Deployment Health Checks',
+                        'name': 'Dash Enterprise App Health Checks',
                         'description': 'Create custom checks to ensure that a newly deployed app can serve traffic.'
                     },
                     {
@@ -824,8 +824,8 @@ URLS = [
                     {
                         'url': '/dash-enterprise/pdf-service',
                         'content': tutorial.dds_examples.pdfService,
-                        'name': 'Dash Deployment Server PDF Service',
-                        'description': 'Utilize the Dash Deployment Server API endpoint for '
+                        'name': 'Dash Enterprise PDF Service',
+                        'description': 'Utilize the Dash Enterprise API endpoint for '
                         'creating PDF exports of your Dash applications'
                     },
                     {
@@ -840,7 +840,7 @@ URLS = [
                         'content': tutorial.dds_examples.Logs,
                         'name': 'App Logs',
                         'description': """Check your Dash App's logs via the Dash
-                        Deployment Server UI or via the command line."""
+                        Enterprise UI or via the command line."""
                     },
                     {
                         'url': '/dash-enterprise/troubleshooting',
@@ -860,7 +860,7 @@ URLS = [
                         'content': tutorial.dds_examples.Git,
                         'name': 'Advanced Git',
                         'description': 'A reference for git commands and how they are used '
-                        'with Dash Deployment Server.'
+                        'with Dash Enterprise.'
                     },
                 ]
             }

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -16,7 +16,7 @@ from .reusable_components import TOC, TOCChapters
 ## in the root of this repo.
 
 
-def component_list(package, content_module, base_url, import_alias):
+def component_list(package, content_module, base_url, import_alias, escape_tags=False):
     return [
         {
             'url': tools.relpath('/{}/{}'.format(base_url, component.lower())),
@@ -31,7 +31,10 @@ def component_list(package, content_module, base_url, import_alias):
                         component
                     ))),
                     html.H2('Reference & Documentation'),
-                    reusable_components.Markdown(getattr(package, component).__doc__),
+                    reusable_components.Markdown(
+                        getattr(package, component).__doc__,
+                        escape_tags=escape_tags
+                    ),
                 ])
             )
         } for component in sorted(dir(package))
@@ -206,7 +209,8 @@ URLS = [
                     html,
                     None,
                     'dash-html-components',
-                    'html'
+                    'html',
+                    escape_tags=True
                 )
             },
 

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -2,14 +2,23 @@ import dash_core_components as dcc
 from dash_docs import tools
 import re
 
-# Use our own Markdown function so that we can
-# use `relpath` for the embedded URLs
-def Markdown(children='', **kwargs):
+def replace_relative_links(children):
     children = re.sub(
         ']\((\/\S*)\)',
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
+    children = re.sub(
+        'href="(/\S*)"',
+        lambda match: 'href="{}"'.format(tools.relpath(match.groups()[0])),
+        children
+    )
+    return children
+
+# Use our own Markdown function so that we can
+# use `relpath` for the embedded URLs
+def Markdown(children='', **kwargs):
+    children = replace_relative_links(children)
     if kwargs.pop('escape_tags', False) and 'dccLink' in children:
         # escape the HTML tags presented in the html component docstrings
         # note that if these tags are within `backticks`, then we don't need

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -12,10 +12,10 @@ def Markdown(children='', **kwargs):
     )
     # escape the HTML tags presented in the html component docstrings
     children = re.sub(
-        'is a wrapper for the \<(\w+)\> ',
+        '\<(\w+)\> ',
         # for some reason, if we do `\<{}\>`, the first slash is shown in the
         # rendered text.
-        lambda match: 'is a wrapper for the <{}\> '.format(match.groups()[0]),
+        lambda match: '<{}\> '.format(match.groups()[0]),
         children
     )
     return dcc.Markdown(

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -18,6 +18,12 @@ def Markdown(children='', **kwargs):
         lambda match: '<{}\> '.format(match.groups()[0]),
         children
     )
+    # except when we talk about <template> in the context of dash-table
+    # (and likely other workarounds in the future, too!)
+    children = children.replace(
+        'FormatTemplate.<template\>',
+        'FormatTemplate.<template>'
+    )
     return dcc.Markdown(
         children=children,
         dangerously_allow_html=True,

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -24,6 +24,6 @@ def Markdown(children='', **kwargs):
         )
     return dcc.Markdown(
         children=children,
-        dangerously_allow_html=True,
+        dangerously_allow_html=('dccLink' in children),
         **kwargs
     )

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -10,20 +10,18 @@ def Markdown(children='', **kwargs):
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
-    # escape the HTML tags presented in the html component docstrings
-    children = re.sub(
-        '\<(\w+)\>',
-        # for some reason, if we do `\<{}\>`, the first slash is shown in the
-        # rendered text.
-        lambda match: '<{}\> '.format(match.groups()[0]),
-        children
-    )
-    # except when we talk about <template> in the context of dash-table
-    # (and likely other workarounds in the future, too!)
-    children = children.replace(
-        'FormatTemplate.<template\>',
-        'FormatTemplate.<template>'
-    )
+    if kwargs.pop('escape_tags', False):
+        # escape the HTML tags presented in the html component docstrings
+        # note that if these tags are within `backticks`, then we don't need
+        # to escape. so, let the caller determine whether or not to escape a
+        # section.
+        children = re.sub(
+            '\<(\w+)\>',
+            # for some reason, if we do `\<{}\>`, the first slash is shown in the
+            # rendered text.
+            lambda match: '<{}\> '.format(match.groups()[0]),
+            children
+        )
     return dcc.Markdown(
         children=children,
         dangerously_allow_html=True,

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -10,6 +10,14 @@ def Markdown(children='', **kwargs):
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
+    # escape the HTML tags presented in the html component docstrings
+    children = re.sub(
+        'is a wrapper for the \<(\w+)\> ',
+        # for some reason, if we do `\<{}\>`, the first slash is shown in the
+        # rendered text.
+        lambda match: 'is a wrapper for the <{}\> '.format(match.groups()[0]),
+        children
+    )
     return dcc.Markdown(
         children=children,
         dangerously_allow_html=True,

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -10,4 +10,8 @@ def Markdown(children='', **kwargs):
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
-    return dcc.Markdown(children=children, **kwargs)
+    return dcc.Markdown(
+        children=children,
+        dangerously_allow_html=True,
+        **kwargs
+    )

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -10,7 +10,7 @@ def Markdown(children='', **kwargs):
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
-    if kwargs.pop('escape_tags', False):
+    if 'dccLink' in children and kwargs.pop('escape_tags', False):
         # escape the HTML tags presented in the html component docstrings
         # note that if these tags are within `backticks`, then we don't need
         # to escape. so, let the caller determine whether or not to escape a

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -12,7 +12,7 @@ def Markdown(children='', **kwargs):
     )
     # escape the HTML tags presented in the html component docstrings
     children = re.sub(
-        '\<(\w+)\> ',
+        '\<(\w+)\>',
         # for some reason, if we do `\<{}\>`, the first slash is shown in the
         # rendered text.
         lambda match: '<{}\> '.format(match.groups()[0]),

--- a/dash_docs/reusable_components/Markdown.py
+++ b/dash_docs/reusable_components/Markdown.py
@@ -10,7 +10,7 @@ def Markdown(children='', **kwargs):
         lambda match: ']({})'.format(tools.relpath(match.groups()[0])),
         children
     )
-    if 'dccLink' in children and kwargs.pop('escape_tags', False):
+    if kwargs.pop('escape_tags', False) and 'dccLink' in children:
         # escape the HTML tags presented in the html component docstrings
         # note that if these tags are within `backticks`, then we don't need
         # to escape. so, let the caller determine whether or not to escape a

--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -11,7 +11,7 @@ def relpath(path):
     if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ:
         # In enterprise docs, all assets are under `/Docs`
         return '{}{}'.format(
-            os.environ['DASH_DOCS_URL_PREFIX'],
+            os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),
             path
         )
     return path

--- a/dash_docs/tutorial/auth.py
+++ b/dash_docs/tutorial/auth.py
@@ -252,7 +252,11 @@ layout = html.Div([
         style=styles.code_container),
 
     reusable_components.Markdown('''
-    or, if you are using [Dash Enterprise, you can keep your environment variables secret (view the docs)](/dash-enterprise/environment-variables).
+    or, if you are using
+    <dccLink
+        children="Dash Enterprise, you can keep your environment variables secret (view the docs)"
+        href="/dash-enterprise/environment-variables"
+    </dccLink>.
 
     '''.replace('   ', '')),
 

--- a/dash_docs/tutorial/auth.py
+++ b/dash_docs/tutorial/auth.py
@@ -255,8 +255,7 @@ layout = html.Div([
     or, if you are using
     <dccLink
         children="Dash Enterprise, you can keep your environment variables secret (view the docs)"
-        href="/dash-enterprise/environment-variables"
-    </dccLink>.
+        href="/dash-enterprise/environment-variables"/>.
 
     '''.replace('   ', '')),
 

--- a/dash_docs/tutorial/canvas.py
+++ b/dash_docs/tutorial/canvas.py
@@ -88,7 +88,7 @@ layout = html.Div([
 
     Like any Dash component, the properties of a ``DashCanvas`` can be
     modified by other components, via callbacks. Please be sure to have
-    read first through the [Dash tutorial](/) to
+    read first through the <dccLink children="Dash tutorial" href="/"/> to
     know how to write callbacks.
 
     ''')),
@@ -101,8 +101,9 @@ layout = html.Div([
     In the example above, a slider ``dcc.Slider`` and a color picker
     ``daq.ColorPicker`` are used to adjust the width and color of the drawing
     brush. We just created an image coloring tool in a few lines of code! You
-    can learn more about available components in the [component
-    libraries](/) section of the Dash documentation. Also
+    can learn more about available components in the
+    <dccLink children="component libraries" href="/"/> section of the
+    Dash documentation. Also
     note that the set of available buttons has been restricted through the
     ``hide_buttons`` properties, in order to keep the app design simple.
 

--- a/dash_docs/tutorial/core_component_examples.py
+++ b/dash_docs/tutorial/core_component_examples.py
@@ -1210,7 +1210,7 @@ Tabs = html.Div(children=[
     reusable_components.Markdown('''
     In the example above, our callback contains all of the content. In practice,
     we'll keep the tab's content in separate files and import the data.
-    For an example, see the [URLs and Multi-Page App Tutorial](/urls).
+    For an example, see the <dccLink children="URLs and Multi-Page App Tutorial" href="/urls"/>.
     '''),
 
     html.H2('Method 2. Content as Tab Children'),
@@ -1249,7 +1249,13 @@ Tabs = html.Div(children=[
     Notice how the container of the Tabs can be styled as well by supplying a class to the `parent_className` prop, which we use here to draw a border below it, positioning the actual Tabs (with padding) more in the center.
     We also added `display: flex` and `justify-content: center` to the regular `Tab` components, so that labels with multiple lines will not break the flow of the text.
 
-    The corresponding CSS file (`assets/tabs.css`) looks like this. Save the file in an `assets` folder (it can be named anything you want). Dash will automatically include this CSS when the app is loaded. [Learn more about including CSS in your app here.](/external-resources)
+    The corresponding CSS file (`assets/tabs.css`) looks like this.
+    Save the file in an `assets` folder (it can be named anything you want).
+    Dash will automatically include this CSS when the app is loaded.
+    <dccLink
+        children="Learn more about including CSS in your app"
+        href="/external-resources"
+    />.
     '''),
 
     reusable_components.Markdown(

--- a/dash_docs/tutorial/core_component_examples.py
+++ b/dash_docs/tutorial/core_component_examples.py
@@ -244,7 +244,7 @@ dcc.Graph(
 
     html.H2('Interactive Graphing'),
     reusable_components.Markdown("""
-    The [Interactive Visualizations](/interactive-graphing) tutorial explains how
+    The <dccLink href="/interactive-graphing" children="Interactive Visualizations"/> tutorial explains how
     to capture user interaction events with a `dcc.Graph`, and how to update the
     `figure` property in callbacks.
 
@@ -1168,7 +1168,7 @@ dcc.DatePickerSingle(
 # Link
 Link = html.Div(children=[
     html.H3('Link Example'),
-    reusable_components.Markdown('To learn more about links, see the chapter on [Dash URLs](/urls)'),
+    reusable_components.Markdown('To learn more about links, see the chapter on <dccLink href="/urls" children="Dash URLs"/>'),
     html.H3('Link Properties'),
     generate_prop_info('Link')
 ])
@@ -1373,7 +1373,7 @@ ConfirmDialog = html.Div([
 ConfirmDialogProvider = html.Div([
     html.H1('ConfirmDialogProvider component'),
     reusable_components.Markdown('''
-    Send a [ConfirmDialog](/dash-core-components/confirmdialog) when the user
+    Send a <dccLink href="/dash-core-components/confirmdialog" children="ConfirmDialog"/> when the user
     clicks the children of this component, usually a button.
     '''),
     Syntax(examples['confirm-provider'][0]),
@@ -1472,7 +1472,7 @@ LoadingComponent = html.Div([
     Syntax(examples['loading_component'][0]),
     Example(examples['loading_component'][1]),
     reusable_components.Markdown('''
-    Please also check out [this section on loading states](/loading-states) if you want a more customizable experience.
+    Please also check out <dccLink href="/loading-states" children="this section on loading states"/> if you want a more customizable experience.
     '''),
     generate_prop_info('Loading')
 ])

--- a/dash_docs/tutorial/core_components.py
+++ b/dash_docs/tutorial/core_components.py
@@ -283,7 +283,7 @@ dcc.DatePickerRange(
     reusable_components.Markdown('''
     The `dash_html_components` library exposes all of the HTML tags.
     This includes the `Table`, `Tr`, and `Tbody` tags that can be used
-    to create an HTML table. See [Dash Layout](/getting-started)
+    to create an HTML table. See <dccLink href="/getting-started" children="Dash Layout"/>
     for an example.
 
     Dash provides an interactive `DataTable` as part of the `data-table`
@@ -303,7 +303,7 @@ dcc.DatePickerRange(
 
 
     reusable_components.Markdown('''
-    [View the docs](/datatable) or [View the source](https://github.com/plotly/dash-table)
+    <dccLink href="/datatable" children="View the docs"/> or [View the source](https://github.com/plotly/dash-table)
 
     ***
     '''.replace('    ', '')),

--- a/dash_docs/tutorial/cytoscape/callbacks_chapter.py
+++ b/dash_docs/tutorial/cytoscape/callbacks_chapter.py
@@ -82,7 +82,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Dash Callbacks for Cytoscape
 
-    [Dash callbacks](/getting-started-part-2) allow you to update your
+    <dccLink href="/getting-started-part-2" children="Dash callbacks"/> allow you to update your
     Cytoscape graph via other components like dropdowns, buttons, and sliders.
     If you have used Cytoscape.js before, you have probably used event handlers
     to interactively update your graph; with Dash Cytoscape, we will instead

--- a/dash_docs/tutorial/cytoscape/elements_chapter.py
+++ b/dash_docs/tutorial/cytoscape/elements_chapter.py
@@ -98,7 +98,7 @@ layout = html.Div([
     of Cytoscape. The `id` parameter is needed for assigning callbacks,
     `style` lets you specify the CSS style of the component (similarly to core
     components), and layout tells you how to arrange your graph. It is
-    described in depth in [part 2](/cytoscape/layout), so all you need to know is that `'preset'`
+    described in depth in <dccLink href="/cytoscape/layout" children="part 2"/>, so all you need to know is that `'preset'`
     will organize the nodes according to the positions you specified.
 
     The official Cytoscape.js documentation nicely outlines the [JSON format
@@ -149,7 +149,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     > Note that those boolean properties can be overwritten by certain Cytoscape
     > parameters such as `autoungrabify` or `autounselectify`. Please refer to
-    > [the reference](/cytoscape/reference) for more information.
+    > <dccLink href="/cytoscape/reference" children="the reference"/> for more information.
 
     ## Classes
 
@@ -194,7 +194,7 @@ layout = html.Div([
     '''),
 
     reusable_components.Markdown('''
-    > The stylesheet parameter will be described in depth in [part 3](/cytoscape/styling)
+    > The stylesheet parameter will be described in depth in <dccLink href="/cytoscape/styling" children="part 3"/>
     > of this guide. We will show extensive examples of using selectors to
     > style groups, classes, and data values. Expand below if you still
     > want to take a look at the stylesheet used previously.

--- a/dash_docs/tutorial/cytoscape/events_chapter.py
+++ b/dash_docs/tutorial/cytoscape/events_chapter.py
@@ -81,7 +81,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Cytoscape Event Callbacks
 
-    In [part 4](/cytoscape/callbacks), we showed how to update Cytoscape with
+    In <dccLink href="/cytoscape/callbacks" children="part 4"/>, we showed how to update Cytoscape with
     other components by assigning callbacks that output to `'elements',
     'stylesheet', 'layout'`. Moreover, it is also possible to use properties
     of Cytoscape as an input to callbacks, which can be used to update other
@@ -91,7 +91,7 @@ layout = html.Div([
     `tapNode`, which returns a complete description of the node object when
     the user clicks or taps on a node, `mouseoverEdgeData`, which returns only
     the data dictionary of the edge that was most recently hovered by the user.
-    The complete list can be found in the [Dash Cytoscape Reference](/cytoscape/reference).
+    The complete list can be found in the <dccLink href="/cytoscape/reference" children="Dash Cytoscape Reference"/>.
 
     ## Simple callback construction
 
@@ -465,7 +465,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     To see more examples of events, check out the [event callbacks demo](https://dash-gallery.plotly.host/cytoscape-events)
     (the source file is available as [`usage-events.py`](https://github.com/plotly/dash-cytoscape/blob/master/usage-events.py) on the project repo)
-    and the [Cytoscape references](/cytoscape/reference).
+    and the <dccLink href="/cytoscape/reference" children="Cytoscape references"/>.
     ''')
 
 ])

--- a/dash_docs/tutorial/cytoscape/layout_chapter.py
+++ b/dash_docs/tutorial/cytoscape/layout_chapter.py
@@ -256,7 +256,7 @@ layout = html.Div([
     > Notice here that we are not giving the ID of the nodes to the `roots`
     > key, but instead using a specific syntax to select the desired elements.
     > This concept of [selector is extensively documented in Cytoscape.js](http://js.cytoscape.org/#selectors),
-    > and will be further explored in [part 3](/cytoscape/styling).
+    > and will be further explored in <dccLink href="/cytoscape/styling" children="part 3"/>.
     > We follow the same syntax as the Javascript library.
 
     For preset layouts, you can also specify the positions for which you would like to render each

--- a/dash_docs/tutorial/dash_deployment_server.py
+++ b/dash_docs/tutorial/dash_deployment_server.py
@@ -120,7 +120,7 @@ reusable_components.Section("User Interface", [
                 'with Dash Enterprise.'),
         reusable_components.Chapter('Dash Enterprise API',
                 'https://github.com/plotly/dds-api-docs',
-                'Reference documentation for DDS\'s GraphQL API. '
+                'Reference documentation for Dash Enterprise\'s GraphQL API. '
                 'Use this to programmatically add collaborators, '
                 'initialize dash apps and more.')
     ])

--- a/dash_docs/tutorial/dash_deployment_server.py
+++ b/dash_docs/tutorial/dash_deployment_server.py
@@ -120,7 +120,7 @@ reusable_components.Section("User Interface", [
                 'with Dash Enterprise.'),
         reusable_components.Chapter('Dash Enterprise API',
                 'https://github.com/plotly/dds-api-docs',
-                'Reference documentation for Dash Enterprise\'s GraphQL API. '
+                'Reference documentation for DDS\'s GraphQL API. '
                 'Use this to programmatically add collaborators, '
                 'initialize dash apps and more.')
     ])

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -116,8 +116,16 @@ Initialize = html.Div(children=[
         &nbsp;
 
         If you have successfully initialized an app, advance to
-        [**Part 2. Deploy Dash Apps on Dash Enterprise**](/dash-enterprise/deployment).
-        If you have encountered any issues, see [**Troubleshooting**](/dash-enterprise)
+        <b><dccLink
+            children="Part 2. Deploy Dash Apps on Dash Enterprise"
+            href="/dash-enterprise/deployment"/>
+        </b>.
+        If you have encountered any issues, see
+        <b><dccLink
+            children="Troubleshooting"
+            href="/dash-enterprise"
+            />
+        </b>
         for help.
 
     '''),
@@ -830,7 +838,7 @@ Requirements = html.Div(children=[
     `app.R`
 
     This is the entry point to your application, it contains your Dash app code.
-    This file must contain a line that includes ```app$run_server()```, or which 
+    This file must contain a line that includes ```app$run_server()```, or which
     loads an R script that does.
 
     ***
@@ -867,12 +875,12 @@ Requirements = html.Div(children=[
     r <- getOption('repos')
     r['CRAN'] <- 'http://cloud.r-project.org'
     options(repos=r)
-    
+
     # ======================================================================
 
     # packages go here
     install.packages('remotes')
-    
+
     remotes::install_github('plotly/dashR', upgrade=TRUE)
     ```
 
@@ -883,9 +891,9 @@ Requirements = html.Div(children=[
     Specifies the buildpack used by the R application to provide a base environment
     for deployment. This file should contain a URL to the buildpack and the relevant
     branch, unless the buildpack is stored within `master`.
-    
+
     We recommend using Plotly's customized buildpack for R deployments:
-    
+
     ```
     https://github.com/plotly/heroku-buildpack-r#heroku-18
     ```
@@ -1685,7 +1693,12 @@ def display_instructions(platform):
         ***
 
         If you have successfully added your SSH Key, advance to
-        [**Part 1. Initialize Dash Apps on Dash Enterprise**](/dash-enterprise/initialize).
+        <b>
+            <dccLink
+                children="Part 1. Initialize Dash Apps on Dash Enterprise"
+                href="/dash-enterprise/initialize"
+            />
+        </b>.
         ''')
     ]
 
@@ -2115,7 +2128,8 @@ Authentication = html.Div(children=[
 
     rc.Markdown('''
     DDS will automatically implement user authentication if your
-    [Dash app's privacy](/dash-enterprise/privacy) is set to *Restricted* (the default setting)
+    <dccLink children="Dash app's privacy" href="/dash-enterprise/privacy"/>
+    is set to *Restricted* (the default setting)
     or *Authorized* but not if is set to *Unauthorized*. You can access the authentication data within your app
     using the [`dash-enterprise-auth`](https://github.com/plotly/dash-enterprise-auth/) package.
 
@@ -2524,7 +2538,10 @@ Redis = html.Div(children=[
     &nbsp;
 
     Next, navigate to **Apps** and create a new app (for more info see
-    ['Part 1. Initialize Dash Apps on Dash Enterprise'](/dash-enterprise/initialize)),
+    <dccLink
+        children="Part 1. Initialize Dash Apps on Dash Enterprise"
+        href="/dash-enterprise/initialize"
+    />,
     in the 'Create App' modal you have the option of linking a database.
     Here, use the dropdown to select the database that you created previously
     (see image below).
@@ -2757,7 +2774,10 @@ pdfService = html.Div(children=[
         of your Dash applications. The API is simple: pass in the URL of your
         Dash app and the sizing parameters and get back a PDF print out. You can
         automate PDF generation with
-        [Dash Enterprise's Celery task queues](/dash-enterprise/celery-process)
+        <dccLink
+            children="Dash Enterprise's Celery task queues"
+            href="/dash-enterprise/celery-process"
+        />
         or you can generate these PDFs on-the-fly.
 
         This API endpoint is used by the Dash Enterprise Snapshot Engine library.

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -830,7 +830,7 @@ Requirements = html.Div(children=[
     `app.R`
 
     This is the entry point to your application, it contains your Dash app code.
-    This file must contain a line that includes ```app$run_server()```, or which
+    This file must contain a line that includes ```app$run_server()```, or which 
     loads an R script that does.
 
     ***
@@ -867,12 +867,12 @@ Requirements = html.Div(children=[
     r <- getOption('repos')
     r['CRAN'] <- 'http://cloud.r-project.org'
     options(repos=r)
-
+    
     # ======================================================================
 
     # packages go here
     install.packages('remotes')
-
+    
     remotes::install_github('plotly/dashR', upgrade=TRUE)
     ```
 
@@ -883,9 +883,9 @@ Requirements = html.Div(children=[
     Specifies the buildpack used by the R application to provide a base environment
     for deployment. This file should contain a URL to the buildpack and the relevant
     branch, unless the buildpack is stored within `master`.
-
+    
     We recommend using Plotly's customized buildpack for R deployments:
-
+    
     ```
     https://github.com/plotly/heroku-buildpack-r#heroku-18
     ```
@@ -1461,8 +1461,8 @@ Ssh = html.Div(children=[
 
     If you already have an SSH key that you've used in other
     services, you can use that key instead of generating a new one.
-    For instructions on how to add an existing SSH Key to Dash Enterprise,
-    scroll down to **Copy and Add SSH Key**.
+    For instructions on how to add an existing SSH Key to the Dash Deployment
+    Server, scroll down to **Copy and Add SSH Key**.
 
     ***
 
@@ -1702,10 +1702,10 @@ Cli = html.Div(children=[
     be able to use the commands below to help manage your apps from the command line.
 
     All commands are performed using `ssh dokku@your-dash-enterprise -p PORT command flags appname` where
-    `PORT` is the ssh port for Dash Enterprise (usually 3022). Dash Enterprise will compare the private key supplied to the ssh command
-    and the public key uploaded to Dash Enterprise in order to authenticate the user initiating the request.
+    `PORT` is the ssh port for DDS (usually 3022). DDS will compare the private key supplied to the ssh command
+    and the public key uploaded to DDS in order to authenticate the user initiating the request.
 
-    > Note that using the same public key for multiple users on Dash Enterprise isn't supported and will likely prevent it
+    > Note that using the same public key for multiple users on DDS isn't supported and will likely prevent it
     > from authenticating to the correct user.
 
     ***
@@ -1714,7 +1714,7 @@ Cli = html.Div(children=[
 
     rc.Markdown('''
 
-    ### List of exposed Dash Enterprise commands:
+    ### List of exposed DDS commands:
 
 
     #### App-related Commands:
@@ -1889,8 +1889,8 @@ Cli = html.Div(children=[
         rc.Markdown('''
         &nbsp;
 
-        Dash Enterprise can also manage scaling applications (increase the number of containers for processes defined
-        in the Procfile) via the `ps:scale` command. Dash Enterprise only scales the web process by default so if you
+        DDS can also manage scaling applications (increase the number of containers for processes defined
+        in the Procfile) via the `ps:scale` command. DDS only scales the web process by default so if you
         define others you will need to scale them.
 
         **Example:**
@@ -2114,7 +2114,7 @@ Authentication = html.Div(children=[
     Blockquote(),
 
     rc.Markdown('''
-    Dash Enterprise will automatically implement user authentication if your
+    DDS will automatically implement user authentication if your
     [Dash app's privacy](/dash-enterprise/privacy) is set to *Restricted* (the default setting)
     or *Authorized* but not if is set to *Unauthorized*. You can access the authentication data within your app
     using the [`dash-enterprise-auth`](https://github.com/plotly/dash-enterprise-auth/) package.
@@ -2127,8 +2127,8 @@ Authentication = html.Div(children=[
 
     ## Using `dash-enterprise-auth` in an Existing Dash App
 
-    If you have previously deployed your Dash app to your Dash Enterprise,
-    simply add `dash-enterprise-auth` to your `requirements.txt` file.
+    If you have previously deployed your Dash app to your Dash Deployment
+    Server, simply add `dash-enterprise-auth` to your `requirements.txt` file.
 
     `dash-enterprise-auth` includes the method `create_logout_button` which allows you to
     add a logout button to your app's layout and it also includes three other methods,
@@ -2249,7 +2249,7 @@ AppPrivacy = html.Div(children=[
     '''),
 
     html.Img(
-        alt='Dash Enterprise Apps List',
+        alt='DDS Apps List',
         src=tools.relpath('/assets/images/dds/manager-apps-list.png'),
         style={
             'width': '100%', 'border': 'thin lightgrey solid',
@@ -2281,10 +2281,10 @@ AppPrivacy = html.Div(children=[
 
 
 # # # # # # #
-# Dash Enterprise - App Health Checks
+# Dash Deployment Health Checks
 # # # # # # #
 Checks = html.Div(children=[
-    html.H1('Dash Enterprise - App Health Checks'),
+    html.H1('Dash Deployment Health Checks'),
 
     Blockquote(),
 
@@ -2296,8 +2296,8 @@ Checks = html.Div(children=[
     in the first 10 seconds of running.
 
     It is possible to customize the health checks performed on your app by adding a file named `CHECKS` to
-    the root directory of your app. In this file you can specify **Checks Settings** to instruct Dash Enterprise when
-    and how to perform the checks. You can also configure **Checks Instructions** to tell Dash Enterprise what endpoints to
+    the root directory of your app. In this file you can specify **Checks Settings** to instruct DDS when
+    and how to perform the checks. You can also configure **Checks Instructions** to tell DDS what endpoints to
     test and what content it should find there.
 
     &nbsp;
@@ -2308,10 +2308,10 @@ Checks = html.Div(children=[
     rc.Markdown('''
 
     You can specify values for `WAIT`, `TIMEOUT`, and `ATTEMPTS` to set the period of time
-    that Dash Enterprise waits before performing the check, the amount of time before it times out, and the number of times
+    that DDS waits before performing the check, the amount of time before it times out, and the number of times
     it will run them before determining that the deployment failed.
 
-    In the example `CHECKS` file below, Dash Enterprise will wait 15 seconds before performing the check, allow up to 10 seconds
+    In the example `CHECKS` file below, DDS will wait 15 seconds before performing the check, allow up to 10 seconds
     for a response from the app and perform the check 3 times before marking it as a failure.
 
     '''),
@@ -2332,7 +2332,7 @@ Checks = html.Div(children=[
 
     rc.Markdown('''
 
-   The instructions are specified in the format of a relative link followed by content that Dash Enterprise
+   The instructions are specified in the format of a relative link followed by content that DDS
    should find in the response. The expected content can be omitted if text content doesn't make sense (e.g if
    you want to check whether an image can be served). The example below checks the layout for the text `Sample App`,
    that `_dash-undo-redo` is included in the dash.css file and that dash-logo.png is being served by the app.
@@ -2693,15 +2693,15 @@ StagingApp = html.Div(children=[
     separate applications: one for "production" consumption and another one
     for testing. You will share the URL of the "production" app to your
     end-users and you will use your "testing" app to try out different changes
-    before you send them to your production app. With Dash Enterprise,
-    creating a separate testing app is easy:
+    before you send them to your production app. With Dash Deployment
+    Server, creating a separate testing app is easy:
 
     ***
 
     ### Initialize a New Dash App
 
-    <dccLink href="/dash-enterprise/initialize" children="Initialize a new app"/> in the
-    Dash Enterprise UI. We recommend giving it the same name as your
+    <dccLink href="/dash-enterprise/initialize" children="Initialize a new app"/> in the Dash
+    Deployment Server UI. We recommend giving it the same name as your
     other app but appending `-stage` to it (e.g. `analytics-stage`).
 
     ***
@@ -2834,8 +2834,8 @@ pdfService = html.Div(children=[
         #### Basic Example
 
         This example provides a simple UI around the PDF API. You can run this
-        example locally or you can deploy this example to Dash Enterprise.
-        A few things to note:
+        example locally or you can deploy this example to Dash
+        Deployment Server. A few things to note:
 
          - If you're testing locally, you will have to specify default values for your
         DASH_DOMAIN_BASE, DASH_APP_NAME and DASH_SECRET_KEY. You can find them in the list of your app's
@@ -3204,8 +3204,8 @@ Troubleshooting = html.Div(children=[
             under the "Modify SSH Config" heading.
 
             The next two emphasized lines show the public keys that were offered (and
-            in this case rejected) by the server. If the RSA key that you added to
-            Dash Enterprise is not among those offered you will need to add it to your `ssh-agent`
+            in this case rejected) by the server. If the RSA key that you added to Dash Deployment
+            Server is not among those offered you will need to add it to your `ssh-agent`
             with `ssh-add ~/path/to/your/key`. More details on `ssh-agent` are included in the
             <dccLink href="/dash-enterprise/ssh" children="ssh chapter"/>.
             ''')
@@ -3321,7 +3321,7 @@ Portal = html.Div(children=[
 
     In order for your app to appear on the Dash App Portal, you need
     enable the *Show in Portal* Toggle in your app's settings from
-    within the Dash Enterprise app manager and then edit your app's metadata to
+    within the DDS app manager and then edit your app's metadata to
     make it easier to find/customize its appearance.
 
     > Note that only users with access to your app will be able
@@ -3346,7 +3346,7 @@ Portal = html.Div(children=[
 
     ### Customize the Portal
 
-    From the Dash Enterprise app Manager, access the *Portal* tab
+    From the DDS app Manager, access the *Portal* tab
     to see its settings (or go to `/Manager/settings/portal/general`).
 
     &nbsp;
@@ -3400,7 +3400,7 @@ AdminPanel = html.Div(children=[
     '''),
 
     html.Img(
-        alt='Dash Enterprise admin panel link',
+        alt='DDS admin panel link',
         src=tools.relpath('/assets/images/dds/dash-enterprise-admin-panel-link.png'),
         style={
             'width': '100%', 'border': 'thin lightgrey solid',
@@ -3472,8 +3472,8 @@ Analytics = html.Div(children=[
     rc.Markdown('''
     #### Dash App Analytics
 
-    After you have successfully deployed a Dash App to Dash Enterprise,
-    you can monitor app performance via the app analytics and logs.
+    After you have successfully deployed a Dash App to the Dash Deployment
+    Server, you can monitor app performance via the app analytics and logs.
     Here, navigate to the Dash Enterprise UI and select the app to
     display analytics.
 
@@ -3501,7 +3501,7 @@ Logs = html.Div(children=[
     ***
 
     Dash apps create a log of usage data as well as any `print` statements
-    called from your app. These logs can be accessed via the Dash Enterprise UI or from the
+    called from your app. These logs can be accessed via the DDS UI or from the
     command line. Note that they will be cleared each time you re-deploy
     your app.
 
@@ -3509,8 +3509,8 @@ Logs = html.Div(children=[
 
     #### Dash App Logs (via UI)
 
-    If you have successfully deployed a Dash App to the Dash Enterprise,
-    you can view the app's logs via the Dash Enterprise UI.
+    If you have successfully deployed a Dash App to the Dash Deployment
+    Server, you can view the app's logs via the Dash Enterprise UI.
     From your list of apps, open the app and then select **Logs**. This will
     display the most recent 500 log entries for your app. For the complete list,
     use the command line method outlined below.
@@ -3633,8 +3633,8 @@ Git = html.Div(children=[
 
     If you have created a new folder for your Dash App, or have an existing
     folder on your local machine, you need to initialize a local Git
-    repository before you can deploy your Dash App to the Dash Enterprise.
-    You need to initialize the local Git repository from your app's
+    repository before you can deploy your Dash App to the Dash Deployment
+    Server. You need to initialize the local Git repository from your app's
     root folder, thus:
 
     '''),
@@ -3862,8 +3862,8 @@ Git = html.Div(children=[
 
     If you have created a new branch and are happy with the changes, you can
     add and commit these changes using the common `git add . ` and
-    `git commit -m "description"` commands. To deploy these to Dash Enterprise,
-    you will need to deploy the branch into master:
+    `git commit -m "description"` commands. To deploy these to Dash Deployment
+    Server, you will need to deploy the branch into master:
 
     '''),
 

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -23,7 +23,7 @@ def Blockquote():
         > This documentation is for [Dash Enterprise](https://plot.ly/dash),
         Plotly's commercial platform for managing and improving
         Dash applications in your organization.
-        [View the docs](/dash-enterprise) or
+        <dccLink href="/dash-enterprise" children="View the docs"/> or
         [request a trial](https://go.plot.ly/dash-doc).
     ''')
 
@@ -37,8 +37,8 @@ Initialize = html.Div(children=[
     Blockquote(),
 
     rc.Markdown('''
-        > This is the *1st* deployment chapter of the [Dash Enterprise Documentation](/dash-enterprise).
-        > The [next chapter](/dash-enterprise/deployment) covers deploying a Dash App on Dash Enterprise.
+        > This is the *1st* deployment chapter of the <dccLink href="/dash-enterprise" children="Dash Enterprise Documentation"/>.
+        > The <dccLink href="/dash-enterprise/deployment" children="next chapter"/> covers deploying a Dash App on Dash Enterprise.
 
         Before creating or deploying a dash app locally, you need to initialize
         an app on Dash Enterprise.
@@ -135,8 +135,8 @@ Deploy = html.Div(children=[
 
     rc.Markdown(
     '''
-    > This is the *2nd* deployment chapter of the [Dash Enterprise Documentation](/dash-enterprise).
-    > The [previous chapter](/dash-enterprise/initialize) covered initializing a Dash App on Dash Enterprise.
+    > This is the *2nd* deployment chapter of the <dccLink href="/dash-enterprise" children="Dash Enterprise Documentation"/>.
+    > The <dccLink href="/dash-enterprise/initialize" children="previous chapter"/> covered initializing a Dash App on Dash Enterprise.
 
 
     To deploy an app to your Dash Enterprise, you can either choose
@@ -249,7 +249,7 @@ def display_instructions2(platform):
                     doesn't require any extra configuration. However, if
                     you are using self-signed certificates or if your server
                     has SAML enabled, then you should deploy with SSH.
-                    [Configure SSH Authentication](/dash-enterprise/ssh).
+                    <dccLink href="/dash-enterprise/ssh" children="Configure SSH Authentication"/>.
 
                     &nbsp;
 
@@ -514,7 +514,7 @@ def display_instructions2(platform):
                     doesn't require any extra configuration. However, if
                     you are using self-signed certificates or if your server
                     has SAML enabled, then you should deploy with SSH.
-                    [Configure SSH Authentication](/dash-enterprise/ssh).
+                    <dccLink href="/dash-enterprise/ssh" children="Configure SSH Authentication"/>.
 
                     &nbsp;
 
@@ -566,7 +566,7 @@ def display_instructions2(platform):
                     doesn't require any extra configuration. However, if
                     you are using self-signed certificates or if your server
                     has SAML enabled, then you should deploy with SSH.
-                    [Configure SSH Authentication](/dash-enterprise/ssh).
+                    <dccLink href="/dash-enterprise/ssh" children="Configure SSH Authentication"/>.
 
                     &nbsp;
 
@@ -673,9 +673,9 @@ def display_instructions_deploy(method):
         #### Deploy Failed?
 
         If your depoly has been unsuccesful, you can check that you have the
-        [necessary files required for deployment](/dash-enterprise/application-structure),
+        <dccLink href="/dash-enterprise/application-structure" children="necessary files required for deployment"/>,
         or if you have a specific error, take a look at
-        [Common Errors](/dash-enterprise/troubleshooting).
+        <dccLink href="/dash-enterprise/troubleshooting" children="Common Errors"/>.
 
         ''')
     ]
@@ -735,7 +735,7 @@ Requirements = html.Div(children=[
     `CHECKS`
 
     This optional file allows you to define custom checks to be performed on your app upon deployment.
-     [Learn more about the CHECKS file](/dash-enterprise/checks).
+     <dccLink href="/dash-enterprise/checks" children="Learn more about the CHECKS file"/>.
 
     ***
 
@@ -800,7 +800,7 @@ Requirements = html.Div(children=[
     `assets`
 
     An optional folder that contains CSS stylesheets, images, or
-    custom JavaScript files. [Learn more about assets](/external-resources).
+    custom JavaScript files. <dccLink href="/external-resources" children="Learn more about assets"/>.
     '''),
     ])
       ]),
@@ -838,7 +838,7 @@ Requirements = html.Div(children=[
     `CHECKS`
 
     This optional file allows you to define custom checks to be performed on your app upon deployment.
-     [Learn more about the CHECKS file](/dash-enterprise/checks).
+     <dccLink href="/dash-enterprise/checks" children="Learn more about the CHECKS file"/>.
 
     ***
 
@@ -915,7 +915,7 @@ Requirements = html.Div(children=[
     `assets`
 
     An optional folder that contains CSS stylesheets, images, or
-    custom JavaScript files. [Learn more about assets](/external-resources).
+    custom JavaScript files. <dccLink href="/external-resources" children="Learn more about assets"/>.
     '''),
     ])
     ])
@@ -943,7 +943,7 @@ staticAssets = html.Div(children=[
 
     For more information about custom CSS, JavaScripts, HTML index template,
     meta tags, or serving Dash's component libaries locally, see
-    [Dash Docs](/external-resources).
+    <dccLink href="/external-resources" children="Dash Docs"/>.
 
     ***
 
@@ -1001,7 +1001,7 @@ ConfigSys = html.Div(children=[
     &nbsp;
 
     If you need help configuring complex system level dependencies, please
-    reach out to our [support](/dash-enterprise/support) team.
+    reach out to our <dccLink href="/dash-enterprise/support" children="support"/> team.
 
     ***
 
@@ -1389,7 +1389,7 @@ rc.Markdown('''
     [RHEL7 and CentOS documentation on CIFS and NFS](https://www.certdepot.net/rhel7-mount-unmount-cifs-nfs-network-file-systems/)
     , the official [Ubuntu NFS documentation](https://help.ubuntu.com/lts/serverguide/network-file-system.html.en),
     the official [Ubuntu CIFS documentation](https://wiki.ubuntu.com/MountWindowsSharesPermanently)
-    or [contact our support team](/dash-enterprise/support).
+    or <dccLink href="/dash-enterprise/support" children="contact our support team"/>.
 
     ***
 
@@ -1427,7 +1427,7 @@ Ssh = html.Div(children=[
     either HTTPS or SSH. If you are deploying with HTTPS, then you do not
     need to set up an SSH key. Thus, you can skip this tutorial and go
     straight to
-    [Initialize Dash Apps on Dash Enterprise](/dash-enterprise/initialize).
+    <dccLink href="/dash-enterprise/initialize" children="Initialize Dash Apps on Dash Enterprise"/>.
 
     &nbsp;
 
@@ -1698,7 +1698,7 @@ Cli = html.Div(children=[
     Blockquote(),
 
     rc.Markdown('''
-    After setting up SSH authentication (see our [ssh doc](/dash-enterprise/ssh)), you will
+    After setting up SSH authentication (see our <dccLink href="/dash-enterprise/ssh" children="ssh doc"/>), you will
     be able to use the commands below to help manage your apps from the command line.
 
     All commands are performed using `ssh dokku@your-dash-enterprise -p PORT command flags appname` where
@@ -1923,7 +1923,7 @@ Cli = html.Div(children=[
             &nbsp;
 
             List bind mounts for an app's container(s) (host:container).
-            See our doc on [mapping local directories](/dash-enterprise/map-local-directories) for more info on
+            See our doc on <dccLink href="/dash-enterprise/map-local-directories" children="mapping local directories"/> for more info on
             how to set these up.
 
             **Example:**
@@ -2239,7 +2239,7 @@ AppPrivacy = html.Div(children=[
     Starting in Version 3.0.0 of Dash Enterprise, you can restrict
     who is able to view your app from the app's management page.
      This will also restrict who will be able to see it in the
-    [Dash App Portal](/dash-enterprise/portal).
+    <dccLink href="/dash-enterprise/portal" children="Dash App Portal"/>.
 
     Find a list of links to these pages for your apps at
     `https://<your-dash-enterprise>.com/Manager/apps`. Contact support
@@ -2420,7 +2420,7 @@ PrivatePackages = html.Div(children=[
     `AUTH_USER` and `AUTH_PASSWORD` variables can be added to your Dash App via
     the Dash Enterprise UI. For more information about adding
     environment variables to your Dash Apps, see
-    [Setting Environment Variables](/dash-enterprise/environment-variables)
+    <dccLink href="/dash-enterprise/environment-variables" children="Setting Environment Variables"/>
 
     ''')
 ])
@@ -2442,7 +2442,7 @@ Redis = html.Div(children=[
     - Enable queued and background processes with Celery.
     [Redis and Celery Demo App](https://github.com/plotly/dash-redis-demo)
     - Cache data from your callbacks across processes.
-    [Caching in Dash with Redis](/performance)
+    <dccLink href="/performance" children="Caching in Dash with Redis"/>
 
     &nbsp;
 
@@ -2700,7 +2700,7 @@ StagingApp = html.Div(children=[
 
     ### Initialize a New Dash App
 
-    [Initialize a new app](/dash-enterprise/initialize) in the Dash
+    <dccLink href="/dash-enterprise/initialize" children="Initialize a new app"/> in the Dash
     Deployment Server UI. We recommend giving it the same name as your
     other app but appending `-stage` to it (e.g. `analytics-stage`).
 
@@ -2839,7 +2839,7 @@ pdfService = html.Div(children=[
 
          - If you're testing locally, you will have to specify default values for your
         DASH_DOMAIN_BASE, DASH_APP_NAME and DASH_SECRET_KEY. You can find them in the list of your app's
-        environment variables. See [our doc on environment variables](/dash-enterprise/environment-variables)
+        environment variables. See <dccLink href="/dash-enterprise/environment-variables" children="our doc on environment variables"/>
         for more details.
         '''),
 
@@ -2962,7 +2962,7 @@ Troubleshooting = html.Div(children=[
     This section describes some of the common errors you may encounter when
     trying to deploy to the Dash Enterprise, and provides information
     about how to resolve these errors. If you can't find the information
-    you're looking for, or need help, [contact our support team](/dash-enterprise/support).
+    you're looking for, or need help, <dccLink href="/dash-enterprise/support" children="contact our support team"/>.
 
     ***
 
@@ -3102,7 +3102,7 @@ Troubleshooting = html.Div(children=[
         '''
         &nbsp;
 
-        For more information see [Application Structure](/dash-enterprise/application-structure).
+        For more information see <dccLink href="/dash-enterprise/application-structure" children="Application Structure"/>.
 
         &nbsp;
         ''')
@@ -3137,7 +3137,7 @@ Troubleshooting = html.Div(children=[
         &nbsp;
 
         For more information see
-        [Application Structure](/dash-enterprise/application-structure).
+        <dccLink href="/dash-enterprise/application-structure" children="Application Structure"/>.
 
         &nbsp;
         ''')
@@ -3200,14 +3200,14 @@ Troubleshooting = html.Div(children=[
             have been commented out or omitted. Check the first uncommented out line in the sample
             output above to ensure that the domain is your Dash server's domain and that port is 3022.
             If it isn't, you will need to update your `~/.ssh/config` file to set the
-            correct port. You can see how to do that in our [ssh chapter](/dash-enterprise/ssh)
+            correct port. You can see how to do that in our <dccLink href="/dash-enterprise/ssh" children="ssh chapter"/>
             under the "Modify SSH Config" heading.
 
             The next two emphasized lines show the public keys that were offered (and
             in this case rejected) by the server. If the RSA key that you added to Dash Deployment
             Server is not among those offered you will need to add it to your `ssh-agent`
             with `ssh-add ~/path/to/your/key`. More details on `ssh-agent` are included in the
-            [ssh chapter](/dash-enterprise/ssh).
+            <dccLink href="/dash-enterprise/ssh" children="ssh chapter"/>.
             ''')
     ]),
 
@@ -3227,7 +3227,7 @@ Troubleshooting = html.Div(children=[
         &nbsp;
 
         If you're receiving the above user permission error, please
-        [contact support](/dash-enterprise/support).
+        <dccLink href="/dash-enterprise/support" children="contact support"/>.
         ''')
     ]),
 
@@ -3326,7 +3326,7 @@ Portal = html.Div(children=[
 
     > Note that only users with access to your app will be able
     to see it in the portal. For more information about setting app pricacy
-    see [Dash App Privacy](/dash-enterprise/privacy).
+    see <dccLink href="/dash-enterprise/privacy" children="Dash App Privacy"/>.
 
     &nbsp;
 
@@ -3550,7 +3550,7 @@ Logs = html.Div(children=[
 
     This will work for any application that you own. This command
     authenticates with the server with ssh.
-    [Configure SSH Authentication](/dash-enterprise/ssh).
+    <dccLink href="/dash-enterprise/ssh" children="Configure SSH Authentication"/>.
 
     &nbsp;
 
@@ -3580,7 +3580,7 @@ Support = html.Div(children=[
 
     If you encounter any issues deploying your app, you can email
     `onpremise.support@plot.ly`. It is helpful to include any error
-    messages you encounter, as well as available logs. See [App Logs](/dash-enterprise/logs) on how
+    messages you encounter, as well as available logs. See <dccLink href="/dash-enterprise/logs" children="App Logs"/> on how
     to obtain Dash App logs. Additionally, see below for the Plotly Enterprise support
     bundle.
     '''),

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -830,7 +830,7 @@ Requirements = html.Div(children=[
     `app.R`
 
     This is the entry point to your application, it contains your Dash app code.
-    This file must contain a line that includes ```app$run_server()```, or which 
+    This file must contain a line that includes ```app$run_server()```, or which
     loads an R script that does.
 
     ***
@@ -867,12 +867,12 @@ Requirements = html.Div(children=[
     r <- getOption('repos')
     r['CRAN'] <- 'http://cloud.r-project.org'
     options(repos=r)
-    
+
     # ======================================================================
 
     # packages go here
     install.packages('remotes')
-    
+
     remotes::install_github('plotly/dashR', upgrade=TRUE)
     ```
 
@@ -883,9 +883,9 @@ Requirements = html.Div(children=[
     Specifies the buildpack used by the R application to provide a base environment
     for deployment. This file should contain a URL to the buildpack and the relevant
     branch, unless the buildpack is stored within `master`.
-    
+
     We recommend using Plotly's customized buildpack for R deployments:
-    
+
     ```
     https://github.com/plotly/heroku-buildpack-r#heroku-18
     ```
@@ -1461,8 +1461,8 @@ Ssh = html.Div(children=[
 
     If you already have an SSH key that you've used in other
     services, you can use that key instead of generating a new one.
-    For instructions on how to add an existing SSH Key to the Dash Deployment
-    Server, scroll down to **Copy and Add SSH Key**.
+    For instructions on how to add an existing SSH Key to Dash Enterprise,
+    scroll down to **Copy and Add SSH Key**.
 
     ***
 
@@ -1702,10 +1702,10 @@ Cli = html.Div(children=[
     be able to use the commands below to help manage your apps from the command line.
 
     All commands are performed using `ssh dokku@your-dash-enterprise -p PORT command flags appname` where
-    `PORT` is the ssh port for DDS (usually 3022). DDS will compare the private key supplied to the ssh command
-    and the public key uploaded to DDS in order to authenticate the user initiating the request.
+    `PORT` is the ssh port for Dash Enterprise (usually 3022). Dash Enterprise will compare the private key supplied to the ssh command
+    and the public key uploaded to Dash Enterprise in order to authenticate the user initiating the request.
 
-    > Note that using the same public key for multiple users on DDS isn't supported and will likely prevent it
+    > Note that using the same public key for multiple users on Dash Enterprise isn't supported and will likely prevent it
     > from authenticating to the correct user.
 
     ***
@@ -1714,7 +1714,7 @@ Cli = html.Div(children=[
 
     rc.Markdown('''
 
-    ### List of exposed DDS commands:
+    ### List of exposed Dash Enterprise commands:
 
 
     #### App-related Commands:
@@ -1889,8 +1889,8 @@ Cli = html.Div(children=[
         rc.Markdown('''
         &nbsp;
 
-        DDS can also manage scaling applications (increase the number of containers for processes defined
-        in the Procfile) via the `ps:scale` command. DDS only scales the web process by default so if you
+        Dash Enterprise can also manage scaling applications (increase the number of containers for processes defined
+        in the Procfile) via the `ps:scale` command. Dash Enterprise only scales the web process by default so if you
         define others you will need to scale them.
 
         **Example:**
@@ -2114,7 +2114,7 @@ Authentication = html.Div(children=[
     Blockquote(),
 
     rc.Markdown('''
-    DDS will automatically implement user authentication if your
+    Dash Enterprise will automatically implement user authentication if your
     [Dash app's privacy](/dash-enterprise/privacy) is set to *Restricted* (the default setting)
     or *Authorized* but not if is set to *Unauthorized*. You can access the authentication data within your app
     using the [`dash-enterprise-auth`](https://github.com/plotly/dash-enterprise-auth/) package.
@@ -2127,8 +2127,8 @@ Authentication = html.Div(children=[
 
     ## Using `dash-enterprise-auth` in an Existing Dash App
 
-    If you have previously deployed your Dash app to your Dash Deployment
-    Server, simply add `dash-enterprise-auth` to your `requirements.txt` file.
+    If you have previously deployed your Dash app to your Dash Enterprise,
+    simply add `dash-enterprise-auth` to your `requirements.txt` file.
 
     `dash-enterprise-auth` includes the method `create_logout_button` which allows you to
     add a logout button to your app's layout and it also includes three other methods,
@@ -2249,7 +2249,7 @@ AppPrivacy = html.Div(children=[
     '''),
 
     html.Img(
-        alt='DDS Apps List',
+        alt='Dash Enterprise Apps List',
         src=tools.relpath('/assets/images/dds/manager-apps-list.png'),
         style={
             'width': '100%', 'border': 'thin lightgrey solid',
@@ -2281,10 +2281,10 @@ AppPrivacy = html.Div(children=[
 
 
 # # # # # # #
-# Dash Deployment Health Checks
+# Dash Enterprise - App Health Checks
 # # # # # # #
 Checks = html.Div(children=[
-    html.H1('Dash Deployment Health Checks'),
+    html.H1('Dash Enterprise - App Health Checks'),
 
     Blockquote(),
 
@@ -2296,8 +2296,8 @@ Checks = html.Div(children=[
     in the first 10 seconds of running.
 
     It is possible to customize the health checks performed on your app by adding a file named `CHECKS` to
-    the root directory of your app. In this file you can specify **Checks Settings** to instruct DDS when
-    and how to perform the checks. You can also configure **Checks Instructions** to tell DDS what endpoints to
+    the root directory of your app. In this file you can specify **Checks Settings** to instruct Dash Enterprise when
+    and how to perform the checks. You can also configure **Checks Instructions** to tell Dash Enterprise what endpoints to
     test and what content it should find there.
 
     &nbsp;
@@ -2308,10 +2308,10 @@ Checks = html.Div(children=[
     rc.Markdown('''
 
     You can specify values for `WAIT`, `TIMEOUT`, and `ATTEMPTS` to set the period of time
-    that DDS waits before performing the check, the amount of time before it times out, and the number of times
+    that Dash Enterprise waits before performing the check, the amount of time before it times out, and the number of times
     it will run them before determining that the deployment failed.
 
-    In the example `CHECKS` file below, DDS will wait 15 seconds before performing the check, allow up to 10 seconds
+    In the example `CHECKS` file below, Dash Enterprise will wait 15 seconds before performing the check, allow up to 10 seconds
     for a response from the app and perform the check 3 times before marking it as a failure.
 
     '''),
@@ -2332,7 +2332,7 @@ Checks = html.Div(children=[
 
     rc.Markdown('''
 
-   The instructions are specified in the format of a relative link followed by content that DDS
+   The instructions are specified in the format of a relative link followed by content that Dash Enterprise
    should find in the response. The expected content can be omitted if text content doesn't make sense (e.g if
    you want to check whether an image can be served). The example below checks the layout for the text `Sample App`,
    that `_dash-undo-redo` is included in the dash.css file and that dash-logo.png is being served by the app.
@@ -2693,15 +2693,15 @@ StagingApp = html.Div(children=[
     separate applications: one for "production" consumption and another one
     for testing. You will share the URL of the "production" app to your
     end-users and you will use your "testing" app to try out different changes
-    before you send them to your production app. With Dash Deployment
-    Server, creating a separate testing app is easy:
+    before you send them to your production app. With Dash Enterprise,
+    creating a separate testing app is easy:
 
     ***
 
     ### Initialize a New Dash App
 
-    <dccLink href="/dash-enterprise/initialize" children="Initialize a new app"/> in the Dash
-    Deployment Server UI. We recommend giving it the same name as your
+    <dccLink href="/dash-enterprise/initialize" children="Initialize a new app"/> in the
+    Dash Enterprise UI. We recommend giving it the same name as your
     other app but appending `-stage` to it (e.g. `analytics-stage`).
 
     ***
@@ -2834,8 +2834,8 @@ pdfService = html.Div(children=[
         #### Basic Example
 
         This example provides a simple UI around the PDF API. You can run this
-        example locally or you can deploy this example to Dash
-        Deployment Server. A few things to note:
+        example locally or you can deploy this example to Dash Enterprise.
+        A few things to note:
 
          - If you're testing locally, you will have to specify default values for your
         DASH_DOMAIN_BASE, DASH_APP_NAME and DASH_SECRET_KEY. You can find them in the list of your app's
@@ -3204,8 +3204,8 @@ Troubleshooting = html.Div(children=[
             under the "Modify SSH Config" heading.
 
             The next two emphasized lines show the public keys that were offered (and
-            in this case rejected) by the server. If the RSA key that you added to Dash Deployment
-            Server is not among those offered you will need to add it to your `ssh-agent`
+            in this case rejected) by the server. If the RSA key that you added to
+            Dash Enterprise is not among those offered you will need to add it to your `ssh-agent`
             with `ssh-add ~/path/to/your/key`. More details on `ssh-agent` are included in the
             <dccLink href="/dash-enterprise/ssh" children="ssh chapter"/>.
             ''')
@@ -3321,7 +3321,7 @@ Portal = html.Div(children=[
 
     In order for your app to appear on the Dash App Portal, you need
     enable the *Show in Portal* Toggle in your app's settings from
-    within the DDS app manager and then edit your app's metadata to
+    within the Dash Enterprise app manager and then edit your app's metadata to
     make it easier to find/customize its appearance.
 
     > Note that only users with access to your app will be able
@@ -3346,7 +3346,7 @@ Portal = html.Div(children=[
 
     ### Customize the Portal
 
-    From the DDS app Manager, access the *Portal* tab
+    From the Dash Enterprise app Manager, access the *Portal* tab
     to see its settings (or go to `/Manager/settings/portal/general`).
 
     &nbsp;
@@ -3400,7 +3400,7 @@ AdminPanel = html.Div(children=[
     '''),
 
     html.Img(
-        alt='DDS admin panel link',
+        alt='Dash Enterprise admin panel link',
         src=tools.relpath('/assets/images/dds/dash-enterprise-admin-panel-link.png'),
         style={
             'width': '100%', 'border': 'thin lightgrey solid',
@@ -3472,8 +3472,8 @@ Analytics = html.Div(children=[
     rc.Markdown('''
     #### Dash App Analytics
 
-    After you have successfully deployed a Dash App to the Dash Deployment
-    Server, you can monitor app performance via the app analytics and logs.
+    After you have successfully deployed a Dash App to Dash Enterprise,
+    you can monitor app performance via the app analytics and logs.
     Here, navigate to the Dash Enterprise UI and select the app to
     display analytics.
 
@@ -3501,7 +3501,7 @@ Logs = html.Div(children=[
     ***
 
     Dash apps create a log of usage data as well as any `print` statements
-    called from your app. These logs can be accessed via the DDS UI or from the
+    called from your app. These logs can be accessed via the Dash Enterprise UI or from the
     command line. Note that they will be cleared each time you re-deploy
     your app.
 
@@ -3509,8 +3509,8 @@ Logs = html.Div(children=[
 
     #### Dash App Logs (via UI)
 
-    If you have successfully deployed a Dash App to the Dash Deployment
-    Server, you can view the app's logs via the Dash Enterprise UI.
+    If you have successfully deployed a Dash App to the Dash Enterprise,
+    you can view the app's logs via the Dash Enterprise UI.
     From your list of apps, open the app and then select **Logs**. This will
     display the most recent 500 log entries for your app. For the complete list,
     use the command line method outlined below.
@@ -3633,8 +3633,8 @@ Git = html.Div(children=[
 
     If you have created a new folder for your Dash App, or have an existing
     folder on your local machine, you need to initialize a local Git
-    repository before you can deploy your Dash App to the Dash Deployment
-    Server. You need to initialize the local Git repository from your app's
+    repository before you can deploy your Dash App to the Dash Enterprise.
+    You need to initialize the local Git repository from your app's
     root folder, thus:
 
     '''),
@@ -3862,8 +3862,8 @@ Git = html.Div(children=[
 
     If you have created a new branch and are happy with the changes, you can
     add and commit these changes using the common `git add . ` and
-    `git commit -m "description"` commands. To deploy these to Dash Deployment
-    Server, you will need to deploy the branch into master:
+    `git commit -m "description"` commands. To deploy these to Dash Enterprise,
+    you will need to deploy the branch into master:
 
     '''),
 

--- a/dash_docs/tutorial/deployment.py
+++ b/dash_docs/tutorial/deployment.py
@@ -27,7 +27,7 @@ built-in SSL support, LDAP authentication, and more.
 [Learn more about Dash Enterprise](https://plot.ly/dash/pricing) or
 [get in touch to start a trial](https://go.plot.ly/dash-doc).
 
-For existing customers, see the [Dash Enterprise Documentation](/dash-enterprise).
+For existing customers, see the <dccLink href="/dash-enterprise" children="Dash Enterprise Documentation"/>.
 
 ### Dash and Flask
 

--- a/dash_docs/tutorial/devtools.py
+++ b/dash_docs/tutorial/devtools.py
@@ -22,7 +22,7 @@ layout = html.Div([
     Hot reloading works by running a "file watcher" that examines your working directory to check for changes. When a change is detected, Dash reloads your application in an efficient way automatically. A few notes:
     - Hot reloading is triggered when you _save_ a file.
     - Dash examines the files in your working directory.
-    - CSS files are automatically "watched" by examining the `assets/` folder. [Learn more about css](/external-resources)
+    - CSS files are automatically "watched" by examining the `assets/` folder. <dccLink href="/external-resources" children="Learn more about css"/>
     - If only CSS changed, then Dash will only refresh that CSS file.
     - When your Python code has changed, Dash will re-run the entire file and then refresh the application in the browser.
     - If your application initialization is slow, then you might want to consider how to save certain initialization steps to file. For example, if your app initialization downloads a static file from a remote service, perhaps you could include it locally.

--- a/dash_docs/tutorial/external_css_and_js.py
+++ b/dash_docs/tutorial/external_css_and_js.py
@@ -211,7 +211,7 @@ layout = html.Div([
     Give it a try: Change the color in `typography.css` from `hotpink` to `orange` and see your application update.
 
     > Don't like hot-reloading? You can turn this off with `app.run_server(dev_tools_hot_reload=False)`.
-    > Learn more in [Dash Dev Tools documentation](/devtools). Questions? See the [community forum hot reloading discussion](https://community.plot.ly/t/announcing-hot-reload/14177).
+    > Learn more in <dccLink href="/devtools" children="Dash Dev Tools documentation"/>. Questions? See the [community forum hot reloading discussion](https://community.plot.ly/t/announcing-hot-reload/14177).
 
     '''),
 

--- a/dash_docs/tutorial/faqs.py
+++ b/dash_docs/tutorial/faqs.py
@@ -22,11 +22,14 @@ layout = html.Div([
     reusable_components.Markdown('''
     # FAQs and Gotchas
 
-    > This is the *7th* and final chapter of the essential [Dash Tutorial](/).
-    > The [previous chapter](/sharing-data-between-callbacks) described how to
-    > share data between callbacks. The [rest of the Dash documentation](/)
-    > covers other topics like multi-page apps and component libraries.
-
+    <blockquote>
+    This is the <b>7th</b> and final chapter of the essential
+    <dccLink children="Dash Tutorial" href="/"/>.
+    The <dccLink children="previous chapter" href="/sharing-data-between-callbacks"/>
+    described how to share data between callbacks.
+    The <dccLink children="rest of the Dash documentation" href="/"/>
+    covers other topics like multi-page apps and component libraries.
+    </blockquote>
 
     ## Frequently Asked Questions
 
@@ -43,11 +46,12 @@ layout = html.Div([
       `dash-core-components` accept the attribute `className`, which corresponds
       to the HTML element attribute `class`.
 
-      The [Dash HTML Components](/dash-html-components) section in the Dash User
+      The <dccLink children="Dash HTML Components" href="/dash-html-components"/>
+      section in the Dash User
       Guide explains how to supply `dash-html-components` with both inline
       styles and CSS class names that you can target with CSS style sheets. The
-      [Adding CSS & JS and Overriding the Page-Load
-      Template](/external-resources) section in the Dash Guide explains how you
+      <dccLink children="Adding CSS & JS and Overriding the Page-Load
+      Template" href="/external-resources"/> section in the Dash Guide explains how you
       can link your own style sheets to Dash apps.
 
     ------------------------
@@ -55,23 +59,23 @@ layout = html.Div([
     **Q:** *How can I add JavaScript to my Dash app?*
 
     **A:** You can add your own scripts to your Dash app, just like you would
-      add a JavaScript file to an HTML document. See the [Adding CSS & JS and
-      Overriding the Page-Load Template](/external-resources) section in the
+      add a JavaScript file to an HTML document. See the <dccLink children="Adding CSS & JS and
+      Overriding the Page-Load Template" href="/external-resources"/> section in the
       Dash Guide.
 
     ------------------------
 
     **Q:** *Can I make a Dash app with multiple pages?*
 
-    **A:** Yes! Dash has support for multi-page apps. See the [Multi-Page Apps
-      and URL Support](/urls) section in the Dash User Guide.
+    **A:** Yes! Dash has support for multi-page apps. See the <dccLink children="Multi-Page Apps
+      and URL Support" href="/urls"/> section in the Dash User Guide.
 
     ------------------------
 
     **Q:** *How I can I organise my Dash app into multiple files?*
 
-    **A:** A strategy for doing this can be found in the [Multi-Page Apps
-      and URL Support](/urls) section in the Dash User Guide.
+    **A:** A strategy for doing this can be found in the <dccLink children="Multi-Page Apps
+      and URL Support" href="/urls"/> section in the Dash User Guide.
 
     ------------------------
 
@@ -130,7 +134,7 @@ layout = html.Div([
 
     In general, if you are looking to add custom clientside behavior in your
     application, we recommend encapsulating that behavior in a
-    [custom Dash component](/plugins).
+    <dccLink children="custom Dash component" href="/plugins"/>.
 
     ------------------------
 
@@ -160,7 +164,7 @@ layout = html.Div([
     can be especially true of how the callback system works. This section
     outlines some common Dash gotchas that you might encounter as you start
     building out more complex Dash apps. If you have read through the rest of
-    the [Dash Tutorial](/) and are encountering unexpected behaviour, this is a
+    the <dccLink children="Dash Tutorial" href="/"/> and are encountering unexpected behaviour, this is a
     good section to read through. If you still have residual questions, the
     [Dash Community forums](https://community.plot.ly/c/dash) is a great place
     to ask them.

--- a/dash_docs/tutorial/faqs.py
+++ b/dash_docs/tutorial/faqs.py
@@ -23,7 +23,7 @@ layout = html.Div([
     # FAQs and Gotchas
 
     <blockquote>
-    This is the <b>7th</b> and final chapter of the essential
+    This is the 7th and final chapter of the essential
     <dccLink children="Dash Tutorial" href="/"/>.
     The <dccLink children="previous chapter" href="/sharing-data-between-callbacks"/>
     described how to share data between callbacks.

--- a/dash_docs/tutorial/getting_started_part_1.py
+++ b/dash_docs/tutorial/getting_started_part_1.py
@@ -26,7 +26,7 @@ layout = html.Div([
     # Dash Layout
 
     <blockquote>
-    This is the *2nd* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    This is the 2nd chapter of the <dccLink children="Dash Tutorial" href="/"/>.
     The <dccLink href="/installation" children="previous chapter"/> covered installation
     and the <dccLink href="/getting-started-part-2" children="next chapter"/> covers Dash callbacks.
     </blockquote>

--- a/dash_docs/tutorial/getting_started_part_1.py
+++ b/dash_docs/tutorial/getting_started_part_1.py
@@ -25,9 +25,11 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Dash Layout
 
-    > This is the *2nd* chapter of the [Dash Tutorial](/).
-    > The <dccLink href="/installation" children="previous chapter"/> covered installation
-    > and the <dccLink href="/getting-started-part-2" children="next chapter"/> covers Dash callbacks.
+    <blockquote>
+    This is the *2nd* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    The <dccLink href="/installation" children="previous chapter"/> covered installation
+    and the <dccLink href="/getting-started-part-2" children="next chapter"/> covers Dash callbacks.
+    </blockquote>
     '''),
 
 

--- a/dash_docs/tutorial/getting_started_part_1.py
+++ b/dash_docs/tutorial/getting_started_part_1.py
@@ -26,8 +26,8 @@ layout = html.Div([
     # Dash Layout
 
     > This is the *2nd* chapter of the [Dash Tutorial](/).
-    > The [previous chapter](/installation) covered installation
-    > and the [next chapter](/getting-started-part-2) covers Dash callbacks.
+    > The <dccLink href="/installation" children="previous chapter"/> covered installation
+    > and the <dccLink href="/getting-started-part-2" children="next chapter"/> covers Dash callbacks.
     '''),
 
 
@@ -43,7 +43,7 @@ layout = html.Div([
     Dash apps are composed of two parts. The first part is the "`layout`" of
     the app and it describes what the application looks like.
     The second part describes the interactivity of the application and will be
-    covered in the [next chapter](/getting-started-part-2).
+    covered in the <dccLink href="/getting-started-part-2" children="next chapter"/>.
 
     Dash provides Python classes for all of the visual components of
     the application. We maintain a set of components in the
@@ -92,7 +92,7 @@ layout = html.Div([
     6. The fonts in your application will look a little bit different than
         what is displayed here. This application is using a
         custom CSS stylesheet to modify the default styles of the elements.
-        You can learn more in the [css tutorial](/external-resources),
+        You can learn more in the <dccLink href="/external-resources" children="css tutorial"/>,
         but for now you can initialize your app with
     ```
     external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
@@ -112,7 +112,7 @@ will automatically refresh your browser when you make a change in your code.
 Give it a try: change the title "Hello Dash" in your application or change the `x` or the `y` data. Your app should auto-refresh with your change.
 
 > Don't like hot-reloading? You can turn this off with `app.run_server(dev_tools_hot_reload=False)`.
-> Learn more in [Dash Dev Tools documentation](/devtools) Questions? See the [community forum hot reloading discussion](https://community.plot.ly/t/announcing-hot-reload/14177).
+> Learn more in <dccLink href="/devtools" children="Dash Dev Tools documentation"/> Questions? See the [community forum hot reloading discussion](https://community.plot.ly/t/announcing-hot-reload/14177).
 
 #### More about HTML
 

--- a/dash_docs/tutorial/getting_started_part_2.py
+++ b/dash_docs/tutorial/getting_started_part_2.py
@@ -23,18 +23,19 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Basic Dash Callbacks
 
-    > This is the *3rd* chapter of the [Dash Tutorial](/).
-    > The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app `layout`
-    > and the <dccLink href="/state" children="next chapter"/> covers an additional concept of callbacks
-    > known as `state`. Just getting started? Make sure to
-    > <dccLink href="/installation" children="install the necessary dependencies"/>.
-
+    <blockquote>
+    This is the *3rd* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app `layout`
+    and the <dccLink href="/state" children="next chapter"/> covers an additional concept of callbacks
+    known as `state`. Just getting started? Make sure to
+    <dccLink href="/installation" children="install the necessary dependencies"/>.
+    </blockquote>
     '''),
 
     reusable_components.Markdown('''
 
-        In the [previous chapter on the `app.layout`](/getting-started) we
-        learned that the `app.layout` describes what the app looks like and is
+        In the <dccLink href="/getting-started"> previous chapter on the <code>app.layout</code>
+        </dccLink> we learned that the `app.layout` describes what the app looks like and is
         a hierarchical tree of components.
         The `dash_html_components` library provides classes for all of the HTML
         tags, and the keyword arguments describe the HTML attributes like

--- a/dash_docs/tutorial/getting_started_part_2.py
+++ b/dash_docs/tutorial/getting_started_part_2.py
@@ -24,10 +24,10 @@ layout = html.Div([
     # Basic Dash Callbacks
 
     > This is the *3rd* chapter of the [Dash Tutorial](/).
-    > The [previous chapter](/getting-started) covered the Dash app `layout`
-    > and the [next chapter](/state) covers an additional concept of callbacks
+    > The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app `layout`
+    > and the <dccLink href="/state" children="next chapter"/> covers an additional concept of callbacks
     > known as `state`. Just getting started? Make sure to
-    > [install the necessary dependencies](/installation).
+    > <dccLink href="/installation" children="install the necessary dependencies"/>.
 
     '''),
 

--- a/dash_docs/tutorial/getting_started_part_2.py
+++ b/dash_docs/tutorial/getting_started_part_2.py
@@ -25,17 +25,18 @@ layout = html.Div([
 
     <blockquote>
     This is the 3rd chapter of the <dccLink children="Dash Tutorial" href="/"/>.
-    The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app `layout`
+    The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app <code>layout</code>
     and the <dccLink href="/state" children="next chapter"/> covers an additional concept of callbacks
-    known as `state`. Just getting started? Make sure to
+    known as <code>state</code>. Just getting started? Make sure to
     <dccLink href="/installation" children="install the necessary dependencies"/>.
     </blockquote>
     '''),
 
     reusable_components.Markdown('''
 
-        In the <dccLink href="/getting-started"> previous chapter on the <code>app.layout</code>
-        </dccLink> we learned that the `app.layout` describes what the app looks like and is
+        In the <dccLink
+            href="/getting-started"
+            children="previous chapter on `app.layout`"
         a hierarchical tree of components.
         The `dash_html_components` library provides classes for all of the HTML
         tags, and the keyword arguments describe the HTML attributes like

--- a/dash_docs/tutorial/getting_started_part_2.py
+++ b/dash_docs/tutorial/getting_started_part_2.py
@@ -37,6 +37,7 @@ layout = html.Div([
         In the <dccLink
             href="/getting-started"
             children="previous chapter on `app.layout`"
+        /> we learned that the `app.layout` describes what the app looks like and is
         a hierarchical tree of components.
         The `dash_html_components` library provides classes for all of the HTML
         tags, and the keyword arguments describe the HTML attributes like

--- a/dash_docs/tutorial/getting_started_part_2.py
+++ b/dash_docs/tutorial/getting_started_part_2.py
@@ -24,7 +24,7 @@ layout = html.Div([
     # Basic Dash Callbacks
 
     <blockquote>
-    This is the *3rd* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    This is the 3rd chapter of the <dccLink children="Dash Tutorial" href="/"/>.
     The <dccLink href="/getting-started" children="previous chapter"/> covered the Dash app `layout`
     and the <dccLink href="/state" children="next chapter"/> covers an additional concept of callbacks
     known as `state`. Just getting started? Make sure to

--- a/dash_docs/tutorial/graphing.py
+++ b/dash_docs/tutorial/graphing.py
@@ -22,10 +22,10 @@ layout = html.Div([
     # Interactive Visualizations
 
     > This is the *5th* chapter of the [Dash Tutorial](/).
-    > The [previous chapter](/state) covered callbacks with `State` and `PreventUpdate`.
-    > The [next chapter](/sharing-data-between-callbacks) describes how to
+    > The <dccLink href="/state" children="previous chapter"/> covered callbacks with `State` and `PreventUpdate`.
+    > The <dccLink href="/sharing-data-between-callbacks" children="next chapter"/> describes how to
     > share data between callbacks.
-    > Just getting started? Make sure to [install the necessary dependencies](/installation).
+    > Just getting started? Make sure to <dccLink href="/installation" children="install the necessary dependencies"/>.
 
     The `dash_core_components` library includes a component called `Graph`.
 

--- a/dash_docs/tutorial/graphing.py
+++ b/dash_docs/tutorial/graphing.py
@@ -21,11 +21,13 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Interactive Visualizations
 
-    > This is the *5th* chapter of the [Dash Tutorial](/).
-    > The <dccLink href="/state" children="previous chapter"/> covered callbacks with `State` and `PreventUpdate`.
-    > The <dccLink href="/sharing-data-between-callbacks" children="next chapter"/> describes how to
-    > share data between callbacks.
-    > Just getting started? Make sure to <dccLink href="/installation" children="install the necessary dependencies"/>.
+    <blockquote>
+    This is the <b>5th</b> chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    The <dccLink href="/state" children="previous chapter"/> covered callbacks with `State` and `PreventUpdate`.
+    The <dccLink href="/sharing-data-between-callbacks" children="next chapter"/> describes how to
+    share data between callbacks.
+    Just getting started? Make sure to <dccLink href="/installation" children="install the necessary dependencies"/>.
+    </blockquote>
 
     The `dash_core_components` library includes a component called `Graph`.
 

--- a/dash_docs/tutorial/graphing.py
+++ b/dash_docs/tutorial/graphing.py
@@ -22,7 +22,7 @@ layout = html.Div([
     # Interactive Visualizations
 
     <blockquote>
-    This is the <b>5th</b> chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+    This is the 5th chapter of the <dccLink children="Dash Tutorial" href="/"/>.
     The <dccLink href="/state" children="previous chapter"/> covered callbacks with `State` and `PreventUpdate`.
     The <dccLink href="/sharing-data-between-callbacks" children="next chapter"/> describes how to
     share data between callbacks.

--- a/dash_docs/tutorial/graphing.py
+++ b/dash_docs/tutorial/graphing.py
@@ -23,7 +23,7 @@ layout = html.Div([
 
     <blockquote>
     This is the 5th chapter of the <dccLink children="Dash Tutorial" href="/"/>.
-    The <dccLink href="/state" children="previous chapter"/> covered callbacks with `State` and `PreventUpdate`.
+    The <dccLink href="/state" children="previous chapter"/> covered callbacks with <code>State</code> and <code>PreventUpdate</code>.
     The <dccLink href="/sharing-data-between-callbacks" children="next chapter"/> describes how to
     share data between callbacks.
     Just getting started? Make sure to <dccLink href="/installation" children="install the necessary dependencies"/>.

--- a/dash_docs/tutorial/html_components.py
+++ b/dash_docs/tutorial/html_components.py
@@ -53,7 +53,7 @@ layout = html.Div(children=[
     If you're not comfortable with HTML, don't worry!
     You can get 95% of the way there with just a few elements
     and attributes.
-    Dash's [core component library](/dash-core-components) also supports
+    Dash's <dccLink href="/dash-core-components" children="core component library"/> also supports
     [Markdown](http://commonmark.org/help).
     '''),
 

--- a/dash_docs/tutorial/integrating_dash.py
+++ b/dash_docs/tutorial/integrating_dash.py
@@ -39,7 +39,7 @@ layout = html.Div([
     """
     ## Embedding a Dash app within an Existing Flask App
 
-    As discussed in the [Deployment Chapter](/deployment), Dash uses the Flask
+    As discussed in the <dccLink href="/deployment" children="Deployment Chapter"/>, Dash uses the Flask
     web framework under the hood. This makes it fairly straightforward to
     embed a Dash app at a specific route of an existing Flask app.
 

--- a/dash_docs/tutorial/live_updates.py
+++ b/dash_docs/tutorial/live_updates.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
 > **Heads up! You need to write** `app.layout = serve_layout` **_not_** `app.layout = serve_layout()`.
 > **That is, define** `app.layout` **to the actual function instance.**
 
-You can combine this with [time-expiring caching](/performance) and serve
-a unique `layout` every hour or every day and serve the computed `layout`
+You can combine this with <dccLink children="time-expiring caching" href="/performance"/>
+and serve a unique `layout` every hour or every day and serve the computed `layout`
 from memory in between.
 ''')]

--- a/dash_docs/tutorial/loading_states.py
+++ b/dash_docs/tutorial/loading_states.py
@@ -64,7 +64,7 @@ layout = html.Div([
     ''', style=styles.code_container),
     html.Br(),
     reusable_components.Markdown('''
-    Please also check out the docs for the [Loading component](/dash-core-components/loading) for more information on how to use the Loading component.
+    Please also check out the docs for the <dccLink href="/dash-core-components/loading" children="Loading component"/> for more information on how to use the Loading component.
 
     Aside from using the [`Loading`](/dash-core-components/loading) component, you can check if a certain component
     (either from `dash_core_components` or `dash_html_components`) is loading by checking the

--- a/dash_docs/tutorial/loading_states.py
+++ b/dash_docs/tutorial/loading_states.py
@@ -66,7 +66,8 @@ layout = html.Div([
     reusable_components.Markdown('''
     Please also check out the docs for the <dccLink href="/dash-core-components/loading" children="Loading component"/> for more information on how to use the Loading component.
 
-    Aside from using the [`Loading`](/dash-core-components/loading) component, you can check if a certain component
+    Aside from using the <dccLink href="/dash-core-components/loading"><code>Loading</code></dccLink>
+    component, you can check if a certain component
     (either from `dash_core_components` or `dash_html_components`) is loading by checking the
     `data-dash-is-loading` attribute set on that component's HTML output. This means that
     you can target those components yourself with CSS, and create your own custom spinner

--- a/dash_docs/tutorial/loading_states.py
+++ b/dash_docs/tutorial/loading_states.py
@@ -66,8 +66,8 @@ layout = html.Div([
     reusable_components.Markdown('''
     Please also check out the docs for the <dccLink href="/dash-core-components/loading" children="Loading component"/> for more information on how to use the Loading component.
 
-    Aside from using the <code><dccLink href="/dash-core-components/loading">Loading</dccLink></code>
-    component, you can check if a certain component
+    Aside from using the <dccLink href="/dash-core-components/loading">Loading component</dccLink>,
+    you can check if a certain component
     (either from `dash_core_components` or `dash_html_components`) is loading by checking the
     `data-dash-is-loading` attribute set on that component's HTML output. This means that
     you can target those components yourself with CSS, and create your own custom spinner

--- a/dash_docs/tutorial/loading_states.py
+++ b/dash_docs/tutorial/loading_states.py
@@ -66,7 +66,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     Please also check out the docs for the <dccLink href="/dash-core-components/loading" children="Loading component"/> for more information on how to use the Loading component.
 
-    Aside from using the <dccLink href="/dash-core-components/loading">Loading component</dccLink>,
+    Aside from using the <dccLink href="/dash-core-components/loading" children="Loading component"/>,
     you can check if a certain component
     (either from `dash_core_components` or `dash_html_components`) is loading by checking the
     `data-dash-is-loading` attribute set on that component's HTML output. This means that

--- a/dash_docs/tutorial/loading_states.py
+++ b/dash_docs/tutorial/loading_states.py
@@ -66,7 +66,7 @@ layout = html.Div([
     reusable_components.Markdown('''
     Please also check out the docs for the <dccLink href="/dash-core-components/loading" children="Loading component"/> for more information on how to use the Loading component.
 
-    Aside from using the <dccLink href="/dash-core-components/loading"><code>Loading</code></dccLink>
+    Aside from using the <code><dccLink href="/dash-core-components/loading">Loading</dccLink></code>
     component, you can check if a certain component
     (either from `dash_core_components` or `dash_html_components`) is loading by checking the
     `data-dash-is-loading` attribute set on that component's HTML output. This means that

--- a/dash_docs/tutorial/migration.py
+++ b/dash_docs/tutorial/migration.py
@@ -54,7 +54,7 @@ layout = html.Div([
 
     > **Note that using `app.scripts.append_script` to load external js scripts
     > won't work while `serve_locally=True`. Please use the `external_scripts` argument
-    > in your call to `dash.Dash` instead, as outlined in [the external resources section](/external-resources).**
+    > in your call to `dash.Dash` instead, as outlined in <dccLink href="/external-resources" children="the external resources section"/>.**
 
     ### Removed undo/redo buttons
     The undo & redo buttons in the corner of every app are removed by default,

--- a/dash_docs/tutorial/plugins.py
+++ b/dash_docs/tutorial/plugins.py
@@ -22,7 +22,7 @@ follow the instructions in the README.md:
 [https://github.com/plotly/dash-component-boilerplate](https://github.com/plotly/dash-component-boilerplate)
 
 If you are just getting started with React.js as a Python programmer, please check out our essay
-<dccLink href="/react-for-python-developers">"React for Python Devs"]</dccLink>.
+<dccLink href="/react-for-python-developers">React for Python Devs</dccLink>.
 
 
 ### How Are Components Converted From React.js to Python?

--- a/dash_docs/tutorial/plugins.py
+++ b/dash_docs/tutorial/plugins.py
@@ -22,7 +22,7 @@ follow the instructions in the README.md:
 [https://github.com/plotly/dash-component-boilerplate](https://github.com/plotly/dash-component-boilerplate)
 
 If you are just getting started with React.js as a Python programmer, please check out our essay
-["React for Python Devs"](/react-for-python-developers).
+<dccLink href="/react-for-python-developers">"React for Python Devs"]</dccLink>.
 
 
 ### How Are Components Converted From React.js to Python?

--- a/dash_docs/tutorial/plugins.py
+++ b/dash_docs/tutorial/plugins.py
@@ -22,7 +22,7 @@ follow the instructions in the README.md:
 [https://github.com/plotly/dash-component-boilerplate](https://github.com/plotly/dash-component-boilerplate)
 
 If you are just getting started with React.js as a Python programmer, please check out our essay
-<dccLink href="/react-for-python-developers">React for Python Devs</dccLink>.
+<dccLink href="/react-for-python-developers" children="React for Python Devs"/>.
 
 
 ### How Are Components Converted From React.js to Python?

--- a/dash_docs/tutorial/sharing_state.py
+++ b/dash_docs/tutorial/sharing_state.py
@@ -19,10 +19,10 @@ layout = html.Div([
     # Sharing State Between Callbacks
 
     <blockquote>
-    This is the <b>6th</b> chapter of the essential <dccLink children="Dash Tutorial" href="/"/>.  The
+    This is the 6th chapter of the essential <dccLink children="Dash Tutorial" href="/"/>.  The
     <dccLink href="/interactive-graphing" children="previous chapter"/> covered how to use callbacks
     with the `dash_core_components.Graph` component.  The <dccLink href="/" children="rest of the Dash
-    documentation" covers other topics like multi-page apps and component
+    documentation"/> covers other topics like multi-page apps and component
     libraries.  Just getting started? Make sure to <dccLink children="install the necessary
     dependencies" href="/installation"/>. The <dccLink href="/faqs" children="next and final chapter"/> covers
     frequently asked questions and gotchas.

--- a/dash_docs/tutorial/sharing_state.py
+++ b/dash_docs/tutorial/sharing_state.py
@@ -21,7 +21,7 @@ layout = html.Div([
     <blockquote>
     This is the 6th chapter of the essential <dccLink children="Dash Tutorial" href="/"/>.  The
     <dccLink href="/interactive-graphing" children="previous chapter"/> covered how to use callbacks
-    with the `dash_core_components.Graph` component.  The <dccLink href="/" children="rest of the Dash
+    with the <code>dash_core_components.Graph</code> component.  The <dccLink href="/" children="rest of the Dash
     documentation"/> covers other topics like multi-page apps and component
     libraries.  Just getting started? Make sure to <dccLink children="install the necessary
     dependencies" href="/installation"/>. The <dccLink href="/faqs" children="next and final chapter"/> covers

--- a/dash_docs/tutorial/sharing_state.py
+++ b/dash_docs/tutorial/sharing_state.py
@@ -18,13 +18,15 @@ layout = html.Div([
     reusable_components.Markdown('''
     # Sharing State Between Callbacks
 
-    > This is the *6th* chapter of the essential [Dash Tutorial](/).  The
-    > <dccLink href="/interactive-graphing" children="previous chapter"/> covered how to use callbacks
-    > with the `dash_core_components.Graph` component.  The [rest of the Dash
-    > documentation](/) covers other topics like multi-page apps and component
-    > libraries.  Just getting started? Make sure to [install the necessary
-    > dependencies](/installation). The <dccLink href="/faqs" children="next and final chapter"/> covers
-    > frequently asked questions and gotchas.
+    <blockquote>
+    This is the <b>6th</b> chapter of the essential <dccLink children="Dash Tutorial" href="/"/>.  The
+    <dccLink href="/interactive-graphing" children="previous chapter"/> covered how to use callbacks
+    with the `dash_core_components.Graph` component.  The <dccLink href="/" children="rest of the Dash
+    documentation" covers other topics like multi-page apps and component
+    libraries.  Just getting started? Make sure to <dccLink children="install the necessary
+    dependencies" href="/installation"/>. The <dccLink href="/faqs" children="next and final chapter"/> covers
+    frequently asked questions and gotchas.
+    </blockquote>
 
     One of the core Dash principles explained in the
     <dccLink href="/getting-started-part-2" children="Getting Started Guide on Callbacks"/>

--- a/dash_docs/tutorial/sharing_state.py
+++ b/dash_docs/tutorial/sharing_state.py
@@ -19,15 +19,15 @@ layout = html.Div([
     # Sharing State Between Callbacks
 
     > This is the *6th* chapter of the essential [Dash Tutorial](/).  The
-    > [previous chapter](/interactive-graphing) covered how to use callbacks
+    > <dccLink href="/interactive-graphing" children="previous chapter"/> covered how to use callbacks
     > with the `dash_core_components.Graph` component.  The [rest of the Dash
     > documentation](/) covers other topics like multi-page apps and component
     > libraries.  Just getting started? Make sure to [install the necessary
-    > dependencies](/installation). The [next and final chapter](/faqs) covers
+    > dependencies](/installation). The <dccLink href="/faqs" children="next and final chapter"/> covers
     > frequently asked questions and gotchas.
 
     One of the core Dash principles explained in the
-    [Getting Started Guide on Callbacks](/getting-started-part-2)
+    <dccLink href="/getting-started-part-2" children="Getting Started Guide on Callbacks"/>
     is that **Dash Callbacks must never modify variables outside of their
     scope**. It is not safe to modify any `global` variables.
     This chapter explains why and provides some alternative patterns for
@@ -44,7 +44,7 @@ layout = html.Div([
     results to the rest of the callbacks.
 
     This need has been somewhat ameliorated now that you can have
-    [multiple outputs](/getting-started-part-2) for one callback. This way,
+    <dccLink href="/getting-started-part-2" children="multiple outputs"/> for one callback. This way,
     that expensive task can be done once and immediately used in all the
     outputs. But in some cases this still isn't ideal, for example if there are
     simple follow-on tasks that modify the results, like unit conversions. We

--- a/dash_docs/tutorial/state.py
+++ b/dash_docs/tutorial/state.py
@@ -18,16 +18,16 @@ layout = html.Div([
     reusable_components.Markdown('''
         ## Dash State
         > This is the *4th* chapter of the [Dash Tutorial](/).
-        > The [previous chapter](/getting-started-part-2) covered Dash Callbacks
-        > and the [next chapter](/interactive-graphing) covers interactive
+        > The <dccLink href="/getting-started-part-2" children="previous chapter"/> covered Dash Callbacks
+        > and the <dccLink href="/interactive-graphing" children="next chapter"/> covers interactive
         > graphing and crossfiltering.
         > Just getting started? Make sure to
-        > [install the necessary dependencies](/installation).
+        > <dccLink href="/installation" children="install the necessary dependencies"/>.
     '''),
 
     reusable_components.Markdown('''
         In the previous chapter on
-        [basic Dash callbacks](/getting-started-part-2),
+        <dccLink href="/getting-started-part-2" children="basic Dash callbacks"/>,
         our callbacks looked something like:
     '''),
     Syntax(examples['basic-input'][0]),

--- a/dash_docs/tutorial/state.py
+++ b/dash_docs/tutorial/state.py
@@ -18,7 +18,7 @@ layout = html.Div([
     reusable_components.Markdown('''
         ## Dash State
         <blockquote>
-        This is the *4th* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+        This is the 4th chapter of the <dccLink children="Dash Tutorial" href="/"/>.
         The <dccLink href="/getting-started-part-2" children="previous chapter"/> covered Dash Callbacks
         and the <dccLink href="/interactive-graphing" children="next chapter"/> covers interactive
         graphing and crossfiltering.

--- a/dash_docs/tutorial/state.py
+++ b/dash_docs/tutorial/state.py
@@ -17,12 +17,14 @@ layout = html.Div([
 
     reusable_components.Markdown('''
         ## Dash State
-        > This is the *4th* chapter of the [Dash Tutorial](/).
-        > The <dccLink href="/getting-started-part-2" children="previous chapter"/> covered Dash Callbacks
-        > and the <dccLink href="/interactive-graphing" children="next chapter"/> covers interactive
-        > graphing and crossfiltering.
-        > Just getting started? Make sure to
-        > <dccLink href="/installation" children="install the necessary dependencies"/>.
+        <blockquote>
+        This is the *4th* chapter of the <dccLink children="Dash Tutorial" href="/"/>.
+        The <dccLink href="/getting-started-part-2" children="previous chapter"/> covered Dash Callbacks
+        and the <dccLink href="/interactive-graphing" children="next chapter"/> covers interactive
+        graphing and crossfiltering.
+        Just getting started? Make sure to
+        <dccLink href="/installation" children="install the necessary dependencies"/>.
+        </blockquote>
     '''),
 
     reusable_components.Markdown('''

--- a/dash_docs/tutorial/table/editing_recipes_chapter.py
+++ b/dash_docs/tutorial/table/editing_recipes_chapter.py
@@ -193,7 +193,7 @@ layout = html.Div([
     ## Uploading Data
 
     A nice recipe is to tie the
-    <code><dccLink href="/dash-core-components/upload">dcc.Upload</dccLink></code>
+    <code><dccLink href="/dash-core-components/upload" children="dcc.Upload"/></code>
     with the Table component. After the user has uploaded the data, they
     could edit the contents or rename the rows.
 

--- a/dash_docs/tutorial/table/editing_recipes_chapter.py
+++ b/dash_docs/tutorial/table/editing_recipes_chapter.py
@@ -192,7 +192,8 @@ layout = html.Div([
     reusable_components.Markdown(dedent('''
     ## Uploading Data
 
-    A nice recipe is to tie the <dccLink href="/dash-core-components/upload"><code>dcc.Upload</code></dccLink>
+    A nice recipe is to tie the
+    <code><dccLink href="/dash-core-components/upload">dcc.Upload</dccLink></code>
     with the Table component. After the user has uploaded the data, they
     could edit the contents or rename the rows.
 

--- a/dash_docs/tutorial/table/editing_recipes_chapter.py
+++ b/dash_docs/tutorial/table/editing_recipes_chapter.py
@@ -192,7 +192,7 @@ layout = html.Div([
     reusable_components.Markdown(dedent('''
     ## Uploading Data
 
-    A nice recipe is to tie the [`dcc.Upload`](/dash-core-components/upload)
+    A nice recipe is to tie the <dccLink href="/dash-core-components/upload"><code>dcc.Upload</code></dccLink>
     with the Table component. After the user has uploaded the data, they
     could edit the contents or rename the rows.
 

--- a/dash_docs/tutorial/table/filtering_chapter.py
+++ b/dash_docs/tutorial/table/filtering_chapter.py
@@ -130,7 +130,7 @@ layout = html.Div(
         For large dataframes, you can perform the filtering in Python instead
         of the default clientside filtering. You can find more information on
         performing operations in python in the
-        [Python Callbacks chapter](/datatable/callbacks).
+        <dccLink href="/datatable/callbacks" children="Python Callbacks chapter"/>.
 
         The syntax is (now) the same as front-end filtering, but it's up to the
         developer to implement the logic to apply these filters on the Python

--- a/dash_docs/tutorial/table/interactivity_chapter.py
+++ b/dash_docs/tutorial/table/interactivity_chapter.py
@@ -44,7 +44,7 @@ layout = html.Div(
         > spaces or special characters (including `-`, particularly in dates)
         > you need to wrap them in quotes.
         > Single quotes `'`, double quotes `"`, or backticks `\\`` all work.
-        > [Full filter syntax reference](/datatable/filtering)
+        > <dccLink href="/datatable/filtering" children="Full filter syntax reference"/>
         """)),
 
         reusable_components.Markdown(dedent("""
@@ -55,7 +55,7 @@ layout = html.Div(
         Note that if `data` is an `Input` then the entire
         `data` will be passed over the network: if your dataframe is large,
         then this will become slow. For large dataframes, you can perform the
-        [sorting or filtering in Python instead](/datatable/callbacks).
+        <dccLink href="/datatable/callbacks" children="sorting or filtering in Python instead"/>.
         """)),
 
         reusable_components.Markdown(

--- a/dash_docs/tutorial/table/styling_chapter.py
+++ b/dash_docs/tutorial/table/styling_chapter.py
@@ -95,7 +95,7 @@ layout = html.Div(
         number of decimals throughout the column.
 
         > To learn about formatting numbers and dates, see the
-        > [data types section](/datatable/typing)
+        > <dccLink href="/datatable/typing" children="data types section"/>
 
         For textual data, left-aligning the text is usually easier to read.
 
@@ -334,7 +334,7 @@ layout = html.Div(
 
         The `filter` keyword in `style_data_conditional` uses the same
         filtering expression language as the table's interactive filter UI.
-        See the [DataTable filtering chapter](/datatable/filtering) for more
+        See the <dccLink href="/datatable/filtering" children="DataTable filtering chapter"/> for more
         info.
         """),
         Display("""

--- a/dash_docs/tutorial/table/table_typing_chapter.py
+++ b/dash_docs/tutorial/table/table_typing_chapter.py
@@ -52,7 +52,7 @@ layout = html.Div([
 
     The following schemes are supported by all types:
     - `input`: a text input field
-    - `dropdown`: see [DataTable Dropdowns](/datatable/dropdowns) for more details
+    - `dropdown`: see <dccLink href="/datatable/dropdowns" children="DataTable Dropdowns"/> for more details
 
     #### Markdown
     The `markdown` presentation scheme allows for the raw value of each cell to be rendered
@@ -81,7 +81,7 @@ layout = html.Div([
     the input to make it fit with the expected data type. Specific validation cases can be
     configured on a per-column basis.
 
-    See the table's [reference](/datatable/reference) `on_change.action`, `on_change.failure`
+    See the table's <dccLink href="/datatable/reference" children="reference"/> `on_change.action`, `on_change.failure`
     and `validation` column nested properties for details.
     ''')),
 

--- a/dash_docs/tutorial/urls.py
+++ b/dash_docs/tutorial/urls.py
@@ -12,11 +12,8 @@ layout = [reusable_components.Markdown('''
     application, making browsing very fast.
 
     There are two new components that aid page navigation:
-    <dccLink href="/dash-core-components/location">
-        dash_core_components.Location
-    </dccLink> and <dccLink href="/dash-core-components/link">
-            dash_core_components.Link
-    </dccLink>.
+    <dccLink href="/dash-core-components/location" children="`dash_core_components.Location`"/>
+    and <dccLink href="/dash-core-components/link" children="`dash_core_components.Link`"/>.
 
     `dash_core_components.Location` represents the location bar in your web browser
     through the `pathname` property. Here's a simple example:

--- a/dash_docs/tutorial/urls.py
+++ b/dash_docs/tutorial/urls.py
@@ -12,7 +12,12 @@ layout = [reusable_components.Markdown('''
     application, making browsing very fast.
 
     There are two new components that aid page navigation:
-    [`dash_core_components.Location`](/dash-core-components/location) and [`dash_core_components.Link`](dash-core-components/link).
+    <dccLink href="/dash-core-components/location">
+        <code>dash_core_components.Location</code>
+    </dccLink> and
+    <dccLink href="/dash-core-components/link">
+        <code>dash_core_components.Link</code>
+    </dccLink>.
 
     `dash_core_components.Location` represents the location bar in your web browser
     through the `pathname` property. Here's a simple example:

--- a/dash_docs/tutorial/urls.py
+++ b/dash_docs/tutorial/urls.py
@@ -12,17 +12,11 @@ layout = [reusable_components.Markdown('''
     application, making browsing very fast.
 
     There are two new components that aid page navigation:
-    <code>
-        <dccLink href="/dash-core-components/location">
-            dash_core_components.Location
-        </dccLink>
-    </code>
-    and
-    <code>
-        <dccLink href="/dash-core-components/link">
+    <dccLink href="/dash-core-components/location">
+        dash_core_components.Location
+    </dccLink> and <dccLink href="/dash-core-components/link">
             dash_core_components.Link
-        </dccLink>
-    </code>.
+    </dccLink>.
 
     `dash_core_components.Location` represents the location bar in your web browser
     through the `pathname` property. Here's a simple example:

--- a/dash_docs/tutorial/urls.py
+++ b/dash_docs/tutorial/urls.py
@@ -12,12 +12,17 @@ layout = [reusable_components.Markdown('''
     application, making browsing very fast.
 
     There are two new components that aid page navigation:
-    <dccLink href="/dash-core-components/location">
-        <code>dash_core_components.Location</code>
-    </dccLink> and
-    <dccLink href="/dash-core-components/link">
-        <code>dash_core_components.Link</code>
-    </dccLink>.
+    <code>
+        <dccLink href="/dash-core-components/location">
+            dash_core_components.Location
+        </dccLink>
+    </code>
+    and
+    <code>
+        <dccLink href="/dash-core-components/link">
+            dash_core_components.Link
+        </dccLink>
+    </code>.
 
     `dash_core_components.Location` represents the location bar in your web browser
     through the `pathname` property. Here's a simple example:

--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -1,0 +1,32 @@
+from dash_docs.reusable_components.Markdown import replace_relative_links
+import os
+import pytest
+
+@pytest.mark.parametrize(
+    "markdown_string, expected_output", [
+    [
+        '<dccLink href="/test" children="that"/>',
+        '<dccLink href="/Docs/test" children="that"/>',
+    ],
+
+    [
+        '''
+        <dccLink href="/test">
+            <code>that</that>
+        </dccLink>,
+        ''',
+        '''
+        <dccLink href="/Docs/test">
+            <code>that</that>
+        </dccLink>,
+        '''
+    ],
+])
+def test_relative_links(markdown_string, expected_output):
+    os.environ['DASH_DOCS_URL_PREFIX'] = '/Docs/'
+    try:
+        assert replace_relative_links(markdown_string) == expected_output
+    except Exception as e:
+        os.environ['DASH_DOCS_URL_PREFIX'] = ''
+        raise e
+    os.environ['DASH_DOCS_URL_PREFIX'] = ''


### PR DESCRIPTION
The regex, FWIW:
`\[([\w\s]+)\]\(\/([\w\s\-\_\/]+)\)`

replaced with: `<dccLink href="/$2" children="$1"/>`

across `*.py`