### PR TITLE
apply relpath to chapter links so that TOC links work in dash enterprise docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: |
               . venv/bin/activate
               set -eo pipefail
-              pip install --progress-bar off -e git+https://github.com/plotly/dash.git@dev#egg=dash[testing]
+              pip install --progress-bar off -e git+https://github.com/plotly/dash.git@test-window-store#egg=dash[testing]
               python -m pytest tests/unit
               pytest --log-cli-level INFO --nopercyfinalize --junitxml=test-reports/snapshots.xml tests/integration
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
     environment:
       PERCY_ENABLE: 0
 
-
 workflows:
   version: 2
   python3.7:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
 
   "python-3.7": &test-template
     docker:
-      - image: circleci/python:3.7-stretch-browsers
+      - image: circleci/python:3.7.5-stretch-browsers
         environment:
           PERCY_PARALLEL_TOTAL: '-1'
     steps:
@@ -53,14 +53,14 @@ jobs:
   "python-3.6":
     <<: *test-template
     docker:
-      - image: circleci/python:3.6-stretch-browsers
+      - image: circleci/python:3.6.9-stretch-browsers
     environment:
       PERCY_ENABLE: 0
 
   "python-2.7":
     <<: *test-template
     docker:
-      - image: circleci/python:2.7-stretch-browsers
+      - image: circleci/python:2.7.16-stretch-browsers
     environment:
       PERCY_ENABLE: 0
 

--- a/dash_docs/reusable_components/Chapter.py
+++ b/dash_docs/reusable_components/Chapter.py
@@ -1,5 +1,6 @@
 import dash_html_components as html
 import dash_core_components as dcc
+from dash_docs.tools import relpath
 from .Markdown import Markdown
 
 def s(string_block):
@@ -11,7 +12,7 @@ def Chapter(name, href=None, caption=None):
         html.Li(
             linkComponent(
                 name,
-                href=href,
+                href=relpath(href),
                 id=href,
                 className='toc--chapter-link'
             ),

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     ],
     include_package_data=True,
     install_requires=[],
-    version='0.3.1'
+    version='0.3.2'
 )


### PR DESCRIPTION
resolves https://github.com/plotly/dash-enterprise-docs/issues/158

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I used e.g. `<dccLink href="/getting-started" children="the first chapter"/>` instead of `[the first chapter](/getting-started)`.
