### PR TITLE
Remove unneccesary CRAN mirror

### DIFF
--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -869,13 +869,6 @@ Requirements = html.Div(children=[
 
     ```
     # R script to run author supplied code, typically used to install additional R packages
-    # contains placeholders which are inserted by the compile script
-    # NOTE: this script is executed in the chroot context; check paths!
-
-    r <- getOption('repos')
-    r['CRAN'] <- 'http://cloud.r-project.org'
-    options(repos=r)
-
     # ======================================================================
 
     # packages go here


### PR DESCRIPTION
This PR updates the R deployment documentation by removing a few unnecessary lines for setting the CRAN mirror and options along with unneeded comments. 

Setting the CRAN mirror is now handled by the buildpack as referenced by plotly/heroku-buildpack-r#6.

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I used e.g. `<dccLink href="/getting-started" children="the first chapter"/>` instead of `[the first chapter](/getting-started)`.
