### PR TITLE
Add static asset to PR template + suggest reusable_components.Markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,8 @@ If this PR includes a new dataset available at a remote URL:
 - [ ] I have added a mapping between the remote URL and the filename in the
 `datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`
 
+If this PR adds an image or animated GIF:
+- [ ] This image was saved and referenced locally rather than via an external link
+
 If I introduced a new relative link inside `dcc.Markdown`:
-- [ ] I used e.g. `<dccLink href="/getting-started" children="the first chapter"/>` instead of `[the first chapter](/getting-started)`.
+- [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/getting-started') children="the first chapter"/>` instead of `[the first chapter](/getting-started)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.


### PR DESCRIPTION
Suggestion from https://github.com/plotly/dash-docs/pull/783#issuecomment-587119602 and follow-up https://github.com/plotly/dash-docs/pull/783#issuecomment-587122010

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I used e.g. `<dccLink href="/getting-started" children="the first chapter"/>` instead of `[the first chapter](/getting-started)`.
