### PR TITLE
prevent double relative paths

### DIFF
--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -8,9 +8,7 @@ else:
 
 
 def relpath(path):
-    if path.startswith('/') and
-        'DASH_DOCS_URL_PREFIX' in os.environ and
-        not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
+    if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ and not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
         # In enterprise docs, all assets are under `/Docs`
         return '{}{}'.format(
             os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),

--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -8,9 +8,7 @@ else:
 
 
 def relpath(path):
-    if path.startswith('/') and
-        'DASH_DOCS_URL_PREFIX' in os.environ as and
-        not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
+    if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ as and not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
         # In enterprise docs, all assets are under `/Docs`
         return '{}{}'.format(
             os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),

--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -8,7 +8,9 @@ else:
 
 
 def relpath(path):
-    if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ as and not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
+    if path.startswith('/') and
+        'DASH_DOCS_URL_PREFIX' in os.environ and
+        not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
         # In enterprise docs, all assets are under `/Docs`
         return '{}{}'.format(
             os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),

--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -8,7 +8,9 @@ else:
 
 
 def relpath(path):
-    if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ:
+    if path.startswith('/') and
+        'DASH_DOCS_URL_PREFIX' in os.environ as and
+        not path.startswith('/{}/'.format(os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'))):
         # In enterprise docs, all assets are under `/Docs`
         return '{}{}'.format(
             os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     ],
     include_package_data=True,
     install_requires=[],
-    version='0.3.4'
+    version='0.3.5'
 )


### PR DESCRIPTION
With some usages the path can be doubly relative. I'm not sure exactly what chain of calls makes the path doubly relative, this PR simply prevents it from happening.