### PR TITLE
Add documentation of inline clientside callbacks.

### DIFF
--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -574,8 +574,9 @@ URLS = [
                 'url': '/performance',
                 'content': tutorial.performance.layout,
                 'name': 'Performance',
-                'description': 'There are two main ways to speed up dash apps: '\
-                               'caching and using WebGL chart types.'
+                'description': 'There are three main ways to speed up Dash apps: '\
+                               'caching, using WebGL chart types, and implementing '\
+                               'clientside callbacks.'
             },
 
             {

--- a/dash_docs/tutorial/performance.py
+++ b/dash_docs/tutorial/performance.py
@@ -179,6 +179,28 @@ app.clientside_callback(
     '''),
 
     reusable_components.Markdown('''
+#### Inline Clientside Callbacks
+
+You can also write the JavaScript code directly in your Dash app by
+supplying a value to the "source" argument. Here's an example using
+the same function as above:
+    '''),
+
+    Syntax('''
+from dash.dependencies import Input, Output
+
+app.clientside_callback(
+    Output('out-component', 'value'),
+    [Input('in-component1', 'value'), Input('in-component2', 'value')],
+    source="""
+    function(largeValue1, largeValue2) {
+        return someTransform(largeValue1, largeValue2);
+    }
+    """
+)
+    '''),
+
+    reusable_components.Markdown('''
 
 ***
 

--- a/dash_docs/tutorial/performance.py
+++ b/dash_docs/tutorial/performance.py
@@ -121,9 +121,14 @@ Sometimes callbacks can incur a significant overhead, especially when they :
 between the browser and Dash
 
 
-When the overhead cost of a callback becomes too great and that no other
-optimization is possible, the callback can be modified to be run directly in
-the browser instead of a making a request to Dash.
+When the overhead cost of a callback becomes too great and that no
+other optimization is possible, the callback can be modified to be run
+directly in the browser instead of a making a request to Dash.
+
+The syntax for the callback is almost exactly the same; you use
+`Input` and `Output` as you normally would when declaring a callback,
+but you also define a JavaScript function as the first argument to the
+`@app.callback` decorator.
 
 For example, the following callback:
 
@@ -144,8 +149,31 @@ def large_params_function(largeValue1, largeValue2):
 
 ***
 
-Can be rewritten in JavaScript and added to a `.js` file in the `/assets`
-folder like so:
+Can be rewritten to use JavaScript like so:
+
+'''),
+
+    Syntax('''
+from dash.dependencies import Input, Output
+
+app.clientside_callback(
+    """
+    function(largeValue1, largeValue2) {
+        return someTransform(largeValue1, largeValue2);
+    }
+    """,
+    Output('out-component', 'value'),
+    [Input('in-component1', 'value'), Input('in-component2', 'value')]
+)
+    '''),
+
+    reusable_components.Markdown('''
+
+***
+
+You also have the option of defining the function in a `.js` file in
+your `assets/` folder. To achieve the same result as the code above,
+the contents of the `.js` file would look like this:
 
 '''),
 
@@ -161,7 +189,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
 
 ***
 
-In Dash, the callback is now written as:
+In Dash, the callback would now be written as:
 
 '''),
 
@@ -178,27 +206,7 @@ app.clientside_callback(
 )
     '''),
 
-    reusable_components.Markdown('''
-#### Inline Clientside Callbacks
 
-You can also write the JavaScript code directly in your Dash app by
-supplying a value to the "source" argument. Here's an example using
-the same function as above:
-    '''),
-
-    Syntax('''
-from dash.dependencies import Input, Output
-
-app.clientside_callback(
-    """
-    function(largeValue1, largeValue2) {
-        return someTransform(largeValue1, largeValue2);
-    }
-    """,
-    Output('out-component', 'value'),
-    [Input('in-component1', 'value'), Input('in-component2', 'value')]
-)
-    '''),
 
     reusable_components.Markdown('''
 

--- a/dash_docs/tutorial/performance.py
+++ b/dash_docs/tutorial/performance.py
@@ -190,13 +190,13 @@ the same function as above:
 from dash.dependencies import Input, Output
 
 app.clientside_callback(
-    Output('out-component', 'value'),
-    [Input('in-component1', 'value'), Input('in-component2', 'value')],
-    source="""
+    """
     function(largeValue1, largeValue2) {
         return someTransform(largeValue1, largeValue2);
     }
-    """
+    """,
+    Output('out-component', 'value'),
+    [Input('in-component1', 'value'), Input('in-component2', 'value')]
 )
     '''),
 


### PR DESCRIPTION
### About
Closes https://github.com/plotly/dash-docs/issues/771

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/getting-started') children="the first chapter"/>` instead of `[the first chapter](/getting-started)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.
