### PR TITLE
Add information about graph responsiveness.

### DIFF
--- a/dash_docs/tutorial/core_component_examples.py
+++ b/dash_docs/tutorial/core_component_examples.py
@@ -255,6 +255,61 @@ dcc.Graph(
     - Graph transitions for smooth transitions or animations on Graph updates
     https://community.plot.ly/t/exploring-a-transitions-api-for-dcc-graph/15468
     """),
+
+    html.H2('Graph Resizing and Responsiveness'),
+    reusable_components.Markdown("""
+
+    There are quite a few options that you can take advantage of if
+    you want the size of your graph to be reactive.
+
+    The default `plotly.js` behavior dictates that the graph should
+    resize upon window resize. However, in some cases, you might want
+    to resize the graph based on the size of its parent container
+    instead. (You can set the size of the parent container with the
+    `style.height` and `style.width` properties.)
+
+    The `responsive` property of the `dcc.Graph` component allows you
+    to define your desired behavior. In short, it accepts as a value
+    `True`, `False`, or `'auto'`:
+
+    * `True` forces the graph to be responsive to window and parent
+      resize, regardless of any other specifications in
+      `figure.layout` or `config`
+    * `False` forces the graph to be non-responsive to window and
+      parent resize, regardless of any other specifications in
+      `figure.layout` or `config`
+    * `'auto'` preserves the legacy behavior (size and resizability
+      are determined by values specified in `figure.layout` and
+      `config.responsive`)
+
+    """),
+
+    html.H3('How Resizing Works - Advanced'),
+    reusable_components.Markdown("""
+
+    The properties of `dcc.Graph` that can control the size of the
+    graph (other than `responsive`) are:
+
+    * `figure.layout.height` - explicitly sets the height
+    * `figure.layout.width` - explicitly sets the width
+    * `figure.layout.autosize` - if `True`, sets the height and width
+      of the graph to that of its parent container
+    * `config.responsive` - if `True`, changes the height and width of
+      the graph upon window resize
+
+    The `responsive` property works in conjunction with the above
+    properties in the following way:
+
+    * `True`: `config.responsive` and `figure.layout.autosize` are
+    overriden with `True` values, and `figure.layout.height` and
+    `figure.layout.width` are unset
+    * `False`: `config.responsive` and `figure.layout.autosize` are
+      both overriden with `False` values
+    * `'auto'`: the resizability of the plot is determined the
+      same way as it used to be (i.e., with the four properties above)
+
+  """),
+
     html.H3('Graph Properties'),
     generate_prop_info('Graph')
 ])


### PR DESCRIPTION
## About 
Closes #720 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/getting-started') children="the first chapter"/>` instead of `[the first chapter](/getting-started)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.
