### PR TITLE
813 add redirects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,6 @@ If this PR adds an image or animated GIF:
 
 If I introduced a new relative link inside `dcc.Markdown`:
 - [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.
+
+If I changed the `chapter_index` by removing or relocating a page:
+- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL

--- a/dash_docs/server.py
+++ b/dash_docs/server.py
@@ -136,6 +136,17 @@ def redirect_dcc_confirm():
 def redirect_faq():
     return redirect('/faqs', code=301)
 
+@server.route('/getting-started')
+def redirect_getting_started():
+    return redirect('/layout', code=301)
+
+@server.route('/getting-started-part-2')
+def redirect_getting_started_2():
+    return redirect('/basic-callbacks', code=301)
+
+@server.route('/state')
+def redirect_getting_started_2():
+    return redirect('/basic-callbacks', code=301)
 
 @server.before_request
 def clear_trailing():

--- a/dash_docs/server.py
+++ b/dash_docs/server.py
@@ -145,7 +145,7 @@ def redirect_getting_started_2():
     return redirect('/basic-callbacks', code=301)
 
 @server.route('/state')
-def redirect_getting_started_2():
+def redirect_state():
     return redirect('/basic-callbacks', code=301)
 
 @server.before_request

--- a/dash_docs/tutorial/clientside_callbacks.py
+++ b/dash_docs/tutorial/clientside_callbacks.py
@@ -20,7 +20,7 @@ layout = html.Div([
     - are part of a callback chain that requires multiple roundtrips
     between the browser and Dash
 
-    When the overhead cost of a callback becomes too great and that no
+    When the overhead cost of a callback becomes too great and no
     other optimization is possible, the callback can be modified to be run
     directly in the browser instead of a making a request to Dash.
 


### PR DESCRIPTION
## About 
Follow-up for #813 

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.
