### PR TITLE
Fix Oracle and pyodbc links

### DIFF
--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -996,8 +996,8 @@ ConfigSys = html.Div(children=[
     We have a collection of sample apps that install common system-level
     dependencies. These applications are _ready to deploy_:
 
-    - [Oracle cx_Oracle Database](https://github.com/plotly/dash-on-premise-sample-app/pull/3/files)
-    - [Pyodbc Database Driver](https://github.com/plotly/dash-on-premise-sample-app/pull/2)
+    - [Oracle cx_Oracle Database](https://github.com/plotly/dash-on-premise-sample-app/pull/2)
+    - [Pyodbc Database Driver](https://github.com/plotly/dash-on-premise-sample-app/pull/3/files)
 
     &nbsp;
 

--- a/dash_docs/tutorial/dash_deployment_server_examples.py
+++ b/dash_docs/tutorial/dash_deployment_server_examples.py
@@ -997,7 +997,7 @@ ConfigSys = html.Div(children=[
     dependencies. These applications are _ready to deploy_:
 
     - [Oracle cx_Oracle Database](https://github.com/plotly/dash-on-premise-sample-app/pull/2)
-    - [Pyodbc Database Driver](https://github.com/plotly/dash-on-premise-sample-app/pull/3/files)
+    - [Pyodbc Database Driver](https://github.com/plotly/dash-on-premise-sample-app/pull/3/)
 
     &nbsp;
 


### PR DESCRIPTION
## Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `reusable_components.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL

## Content

Pyodbc and Oracle links were swapped on the `Configuring System Dependencies` page. This PR un-swaps them so that the links are correct.