### PR TITLE
Upgrade dash to 1.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
               . venv/bin/activate
               set -eo pipefail
-              pip install --progress-bar off -e git+https://github.com/plotly/dash.git@test-window-store#egg=dash[testing]
+              pip install --progress-bar off -e git+https://github.com/plotly/dash.git@dev#egg=dash[testing]
               python -m pytest tests/unit
               pytest --log-cli-level INFO --nopercyfinalize --junitxml=test-reports/snapshots.xml tests/integration
       - store_artifacts:

--- a/SIDEBAR-INDEX.json
+++ b/SIDEBAR-INDEX.json
@@ -180,7 +180,7 @@
             "url": "/dash-core-components/link",
             "name": "dcc.Link",
             "description": "Official examples and reference documentation for dcc.Link. dcc.Link is a dash_core_components component.",
-            "meta_keywords": "children, key, href, style, name, type, low, min, default, list, refresh, on, elements, styles"
+            "meta_keywords": "children, key, href, target, style, title, form, name, type, open, low, min, required, default, list, refresh, on, elements, styles"
           },
           {
             "url": "/dash-core-components/loading",

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -1016,7 +1016,6 @@ def _search_keywords(children):
                 unicode_or_str1 += unicode(unicode_or_str2)
             except Exception as e2:
                 print(unicode_or_str2)
-                import pdb; pdb.set_trace()
                 raise e2
 
         return unicode_or_str2
@@ -1054,6 +1053,8 @@ def _search_keywords(children):
                 component = getattr(component_library, component_name)()
             elif component_name == 'Circos':
                 component = getattr(component_library, component_name)(layout=None)
+            elif component_name == 'Link':
+                component = getattr(component_library, component_name)(href='')
             else:
                 try:
                     component = getattr(component_library, component_name)(id='_')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ dash-canvas==0.1.0
 dash-cytoscape==0.0.5
 dash-dangerously-set-inner-html==0.0.2
 dash-daq==0.4.0
-dash[testing]==1.9.1
+dash[testing]==1.10.0
 dask==1.2.0
 decorator==4.3.0
 enum34==1.1.6


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL