### PR TITLE
Fixes for R clientside callbacks example

### DIFF
--- a/dash_docs/assets/clientside_example.js
+++ b/dash_docs/assets/clientside_example.js
@@ -1,5 +1,5 @@
 window.dash_clientside = Object.assign({}, window.dash_clientside, {
-    clientside: {
+    clientside_examples: {
         update_graph: function(data, scale) {
         return {
             'data': data,

--- a/dash_docs/assets/pagemenu.js
+++ b/dash_docs/assets/pagemenu.js
@@ -1,7 +1,8 @@
-if(!window.dash_clientside) {window.dash_clientside = {};}
-window.dash_clientside.clientside = {
-  pagemenu: function (children) {
-    console.warn('updating pagemenu');
-    return String(Date.now());
-  }
-}
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+  clientside: {
+    pagemenu: function (children) {
+      console.warn('updating pagemenu');
+      return String(Date.now());
+    }
+  }
+});

--- a/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.R
+++ b/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.R
@@ -85,7 +85,7 @@ app$callback(
     input('clientside-graph-scale', 'value')
   ),
   clientsideFunction(
-    namespace = 'clientside',
+    namespace = 'clientside_examples',
     function_name = 'update_graph'
   )
 )

--- a/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.R
+++ b/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.R
@@ -19,7 +19,7 @@ app$layout(htmlDiv(list(
     data = list(
       list(
         'x' = df[df$country == 'Canada', "year"],
-        'y' = df[df$country == 'Canada', "year"]
+        'y' = df[df$country == 'Canada', "pop"]
       )
     )
   ),
@@ -52,9 +52,11 @@ app$layout(htmlDiv(list(
   ),
   htmlHr(),
   htmlDetails(
-    htmlSummary('Contents of figure storage'),
-    dccMarkdown(
-      id='clientside-figure-json'
+    list(
+      htmlSummary('Contents of figure storage'),
+      dccMarkdown(
+        id='clientside-figure-json'
+        )
     )
   )
 )))
@@ -65,11 +67,11 @@ app$callback(
     input('clientside-graph-indicator', 'value'),
     input('clientside-graph-country', 'value')
   ),
-  update_store_data <- function(indicator, selected_country) {
+  function(indicator, selected_country) {
     dff = df[df$country == selected_country,]
     return(list(list(
-      'x' = dff$year,
-      'y' = dff$indicator,
+      'x' = dff[, "year"],
+      'y' = dff[, indicator],
       'mode' = 'markers'
     )))
   }
@@ -89,12 +91,12 @@ app$callback(
 )
 
 app$callback(
-  output('clientside-figure-json', 'figure'),
+  output('clientside-figure-json', 'children'),
   params = list(
     input('clientside-figure-store', 'data')
   ),
-  generated_figure_json <- function(data) {
-    return(jsonlite::prettify(data))
+  function(input_data) {
+    return(jsonlite::prettify(dash:::to_JSON(input_data)))
   }
 )
 

--- a/dash_docs/chapters/clientside_callbacks/index.R
+++ b/dash_docs/chapters/clientside_callbacks/index.R
@@ -86,7 +86,7 @@ app$callback(
 
     dccMarkdown("
 ```js
-window.my_clientside_library = {
+window.my_clientside_example = {
 my_function: function(input_value_1, input_value_2) {
    return (
      parseFloat(input_value_1, 10) +


### PR DESCRIPTION
This PR proposes to apply a few minor fixes to the clientside callbacks example in the Dash for R docs:
- wrap `children` of `htmlDetails` (`htmlSummary`, `dccMarkdown`) with a `list` to avoid console error
- use `dash:::to_JSON` before running `jsonlite::prettify` to avoid parse error
- pass `pop` instead of `year` within `dccStore`
- index using `[, "year"]` instead of `year`, since the latter is a function within `data.table` (resolves `invalid subscript type 'closure'` error)
- use `dff[, indicator],` instead of `dff$indicator` to avoid passing `NULL` for `y` vector
- modifies the `namespace` to avoid overriding the `clientside-example.js` with `pagemenu.js`, and corrects the `namespace` in the example formatted with markdown also

🙏 to @Marc-Andre-Rivet for helping me resolve the latter issue