### PR TITLE
Single input

### DIFF
--- a/dash_docs/chapters/advanced_callbacks/examples/prevent_update.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/prevent_update.py
@@ -16,7 +16,7 @@ app.layout = html.Div([
 
 @app.callback(
     [Output('out', 'children'), Output('err', 'children')],
-    [Input('num', 'value')]
+    Input('num', 'value')
 )
 def show_factors(num):
     if num is None:

--- a/dash_docs/chapters/advanced_callbacks/examples/prevent_update_button.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/prevent_update_button.py
@@ -14,7 +14,7 @@ app.layout = html.Div([
 
 @app.callback(
     Output(component_id='body-div', component_property='children'),
-    [Input(component_id='show-secret', component_property='n_clicks')]
+    Input(component_id='show-secret', component_property='n_clicks')
 )
 def update_output(n_clicks):
     if n_clicks is None:

--- a/dash_docs/chapters/basic_callbacks/examples/basic-input.py
+++ b/dash_docs/chapters/basic_callbacks/examples/basic-input.py
@@ -19,7 +19,7 @@ app.layout = html.Div(
 
 @app.callback(
     Output("number-output", "children"),
-    [Input("input-1", "value"), Input("input-2", "value")],
+    Input("input-1", "value"), Input("input-2", "value"),
 )
 def update_output(input1, input2):
     return u'Input 1 is "{}" and Input 2 is "{}"'.format(input1, input2)

--- a/dash_docs/chapters/basic_callbacks/examples/basic-state.py
+++ b/dash_docs/chapters/basic_callbacks/examples/basic-state.py
@@ -17,7 +17,7 @@ app.layout = html.Div([
 
 
 @app.callback(Output('output-state', 'children'),
-              [Input('submit-button-state', 'n_clicks')],
+              Input('submit-button-state', 'n_clicks'),
               [State('input-1-state', 'value'),
                State('input-2-state', 'value')])
 def update_output(n_clicks, input1, input2):

--- a/dash_docs/chapters/basic_callbacks/examples/getting_started_callback_chain.py
+++ b/dash_docs/chapters/basic_callbacks/examples/getting_started_callback_chain.py
@@ -31,14 +31,14 @@ app.layout = html.Div([
 
 @app.callback(
     Output('cities-radio', 'options'),
-    [Input('countries-radio', 'value')])
+    Input('countries-radio', 'value'))
 def set_cities_options(selected_country):
     return [{'label': i, 'value': i} for i in all_options[selected_country]]
 
 
 @app.callback(
     Output('cities-radio', 'value'),
-    [Input('cities-radio', 'options')])
+    Input('cities-radio', 'options'))
 def set_cities_value(available_options):
     return available_options[0]['value']
 

--- a/dash_docs/chapters/basic_callbacks/examples/getting_started_graph.py
+++ b/dash_docs/chapters/basic_callbacks/examples/getting_started_graph.py
@@ -26,7 +26,7 @@ app.layout = html.Div([
 
 @app.callback(
     Output('graph-with-slider', 'figure'),
-    [Input('year-slider', 'value')])
+    Input('year-slider', 'value'))
 def update_figure(selected_year):
     filtered_df = df[df.year == selected_year]
     traces = []

--- a/dash_docs/chapters/basic_callbacks/examples/getting_started_interactive_simple.py
+++ b/dash_docs/chapters/basic_callbacks/examples/getting_started_interactive_simple.py
@@ -15,7 +15,7 @@ app.layout = html.Div([
 
 @app.callback(
     Output(component_id='my-div', component_property='children'),
-    [Input(component_id='my-id', component_property='value')]
+    Input(component_id='my-id', component_property='value')
 )
 def update_output_div(input_value):
     return 'You\'ve entered "{}"'.format(input_value)

--- a/dash_docs/chapters/basic_callbacks/examples/getting_started_multiple_outputs_1.py
+++ b/dash_docs/chapters/basic_callbacks/examples/getting_started_multiple_outputs_1.py
@@ -29,7 +29,7 @@ app.layout = html.Div([
      Output('twos', 'children'),
      Output('threes', 'children'),
      Output('x^x', 'children')],
-    [Input('num-multi', 'value')])
+    Input('num-multi', 'value'))
 def callback_a(x):
     return x**2, x**3, 2**x, 3**x, x**x
 

--- a/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.py
+++ b/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be.py
@@ -95,7 +95,7 @@ app.clientside_callback(
 
 @app.callback(
     Output('clientside-figure-json', 'children'),
-    [Input('clientside-figure-store', 'data')]
+    Input('clientside-figure-store', 'data')
 )
 def generated_figure_json(data):
     return '```\n'+json.dumps(data, indent=2)+'\n```'

--- a/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be_px.py
+++ b/dash_docs/chapters/clientside_callbacks/examples/graph_update_fe_be_px.py
@@ -94,7 +94,7 @@ app.clientside_callback(
 
 @app.callback(
     Output('clientside-figure-json-px', 'children'),
-    [Input('clientside-figure-store-px', 'data')]
+    Input('clientside-figure-store-px', 'data')
 )
 def generated_px_figure_json(data):
     return '```\n'+json.dumps(data, indent=2)+'\n```'


### PR DESCRIPTION
Update documentation of the chapters about callbacks with the PR [#1180](https://github.com/plotly/dash/pull/1180).
Single `Input` in callbacks don't need to be in a list.