### PR TITLE
sidebar fixes from #847

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -237,7 +237,7 @@ summary:hover {
 #fade-out {
     height: 30px;
     margin-right: -2px;
-    background-image: linear-gradient(to bottom, transparent, white);
+    background-image: linear-gradient(to bottom, rgb(224, 242, 246), white);
 }
 
 /* Header */

--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -135,6 +135,10 @@ h6 { font-size: 20px; line-height: 1.6;  margin-bottom: 0.75rem; margin-top: 0.7
     border-right: thin lightgrey solid;
     font-size: 12px;
     max-width: 250px;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 60px);
+    justify-content: space-between;
 }
 
 .sidebar input[type="text"],
@@ -221,18 +225,19 @@ summary:hover {
 }
 
 .sidebar {
-    /* height of header + height of sidebar ad + padding */
-    height: calc(100vh - 60px - 200px - 30px);
     overflow-y: auto;
 }
 
 
 
 .sidebar-image {
-    max-height: 200px;
-    left: 10px;
-    bottom: 10px;
-    position: fixed;
+   width: calc(100% - 4px);
+}
+
+#fade-out {
+    height: 30px;
+    margin-right: -2px;
+    background-image: linear-gradient(to bottom, transparent, white);
 }
 
 /* Header */

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -97,13 +97,13 @@ app.layout = html.Div(
                 dugc.Sidebar(urls=SIDEBAR_INDEX),
                 html.A([
                     html.Img(
-                        id='sidebar-ad-img',
-                        className='sidebar-ad',
+                        id='sidebar-image-img',
+                        className='sidebar-image',
                         src=DEFAULT_AD['src'],
                         alt=DEFAULT_AD['alt']
                     ),
                     html.Div(id='fade-out')
-                ], id='sidebar-ad-link', href=DEFAULT_AD['href']),
+                ], id='sidebar-image-link', href=DEFAULT_AD['href']),
             ], className='sidebar-container'),
 
             html.Div([
@@ -236,8 +236,8 @@ def flat_list(*args):
                Output('backlinks-bottom', 'children'),
                # dummy variable so that a loading state is triggered
                Output('pagemenu', 'dummy2'),
-               Output('sidebar-ad-img', 'src'),
-               Output('sidebar-ad-link', 'href')],
+               Output('sidebar-image-img', 'src'),
+               Output('sidebar-image-link', 'href')],
               [Input('location', 'pathname')])
 def display_content(pathname):
     if pathname is None or pathname == '/':

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -95,12 +95,15 @@ app.layout = html.Div(
         html.Div(className='content-wrapper', children=[
             html.Div([
                 dugc.Sidebar(urls=SIDEBAR_INDEX),
-                html.A(html.Img(
-                    id='sidebar-ad-img',
-                    className='sidebar-image',
-                    src=DEFAULT_AD['src'],
-                    alt=DEFAULT_AD['alt']
-                ), id='sidebar-ad-link', href=DEFAULT_AD['href'])
+                html.A([
+                    html.Img(
+                        id='sidebar-ad-img',
+                        className='sidebar-ad',
+                        src=DEFAULT_AD['src'],
+                        alt=DEFAULT_AD['alt']
+                    ),
+                    html.Div(id='fade-out')
+                ], id='sidebar-ad-link', href=DEFAULT_AD['href']),
             ], className='sidebar-container'),
 
             html.Div([


### PR DESCRIPTION
Fixes https://github.com/plotly/dash-docs/issues/863
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL