### PR TITLE
simplify pattern-matching todo example

### DIFF
--- a/SIDEBAR-INDEX.json
+++ b/SIDEBAR-INDEX.json
@@ -162,7 +162,7 @@
             "url": "/dash-core-components/dropdown",
             "name": "dcc.Dropdown",
             "description": "Official examples and reference documentation for dcc.Dropdown. dcc.Dropdown is a dash_core_components component.",
-            "meta_keywords": "children, key, style, disabled, form, name, type, height, action, low, min, start, label, selected, multiple, required, placeholder, rows, wrap, default, options, persistence, persisted_props, persistence_type, clearable, date, optionHeight, multi, searchable, search_value, list, refresh, debug, search, data, css, dropdown, on, stylesheet, layout, container, styles, selection"
+            "meta_keywords": "children, key, style, title, disabled, form, name, type, height, action, low, min, start, label, selected, multiple, required, placeholder, rows, wrap, default, options, persistence, persisted_props, persistence_type, clearable, date, optionHeight, multi, searchable, search_value, list, refresh, debug, search, data, css, dropdown, on, stylesheet, layout, container, styles, selection"
           },
           {
             "url": "/dash-core-components/graph",

--- a/SIDEBAR-INDEX.json
+++ b/SIDEBAR-INDEX.json
@@ -97,7 +97,7 @@
         "url": "/pattern-matching-callbacks",
         "name": "Pattern-Matching Callbacks",
         "description": "The pattern-matching callback selectors `MATCH`, `ALL`, & `ALLSMALLER` allow you to write callbacks that respond to or update an arbitrary or dynamic number of components. New in Dash 1.11.0!",
-        "meta_keywords": "children, n_clicks, key, style, form, name, type, content, low, min, reversed, label, multiple, options, labelStyle, displayed, date, multi, list, pattern, n_submit, debug, color, pathname, count, included, data, dropdown, on, elements, layout, pan, container"
+        "meta_keywords": "children, n_clicks, key, style, form, name, type, content, low, min, reversed, label, multiple, options, labelStyle, displayed, date, multi, list, pattern, n_submit, debug, color, count, included, data, dropdown, on, elements, layout, pan, container"
       },
       {
         "url": "/callback-gotchas",

--- a/dash_docs/chapters/pattern_matching_callbacks/examples/todo.py
+++ b/dash_docs/chapters/pattern_matching_callbacks/examples/todo.py
@@ -3,25 +3,16 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output, State, MATCH, ALL
 
-app = dash.Dash(__name__, suppress_callback_exceptions=True)
+app = dash.Dash(__name__)
 
 app.layout = html.Div([
-    html.Div(id='content'),
-    dcc.Location(id='url')
+    html.Div('Dash To-Do list'),
+    dcc.Input(id="new-item"),
+    html.Button("Add", id="add"),
+    html.Button("Clear Done", id="clear-done"),
+    html.Div(id="list-container"),
+    html.Div(id="totals")
 ])
-
-@app.callback(Output('content', 'children'), [Input('url', 'pathname')])
-def display_content(_):
-    return html.Div([
-        html.Div('Dash To-Do list'),
-        dcc.Input(id="new-item"),
-        html.Button("Add", id="add"),
-        html.Button("Clear Done", id="clear-done"),
-        html.Div(id="list-container"),
-        html.Hr(),
-        html.Div(id="totals")
-    ])
-
 
 style_todo = {"display": "inline", "margin": "10px"}
 style_done = {"textDecoration": "line-through", "color": "#888"}


### PR DESCRIPTION
The `display_content` callback doesn't help this example - nor does the `Hr` and on docs the default style of `Hr` is huge.