### PR TITLE
add the gallery to the header and update URLs

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -471,13 +471,13 @@ a {
     }
 }
 
-@media (max-width: 670px) {
+@media (max-width: 705px) {
     .header .links iframe {
         display: none;
     }
 }
 
-@media (max-width: 570px) {
+@media (max-width: 600px) {
     .header .links {
         display: none;
     }

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -24,7 +24,7 @@ def Blockquote():
         Plotly's commercial platform for managing and improving
         Dash applications in your organization.
         <dccLink href="/dash-enterprise" children="View the docs"/> or
-        [request a trial](https://go.plotly.com/dash-doc).
+        [request a trial](https://plotly.com/get-demo/).
     ''')
 
 
@@ -2955,7 +2955,7 @@ pdfService = html.Div(children=[
         - Creating high-quality, branded PDF templates
 
         Get in touch with your sales rep or
-        [reach out to us directly](https://go.plotly.com/dash-doc)
+        [reach out to us directly](https://plotly.com/get-demo/)
         to learn more.
 
         '''),

--- a/dash_docs/chapters/dash_enterprise/index.py
+++ b/dash_docs/chapters/dash_enterprise/index.py
@@ -12,7 +12,7 @@ layout = html.Div(className='toc', children=[
                 """Dash Enterprise is Plotly's commercial offering
                    for managing and improving your Dash apps in your
                    organization. [Learn more](https://plotly.com/dash) or
-                   [request a trial](https://go.plotly.com/dash-doc).""")
+                   [request a trial](https://plotly.com/get-demo/).""")
     ]) if 'DASH_DOCS_URL_PREFIX' not in os.environ else '',
 
     rc.Section("Deployment", [

--- a/dash_docs/chapters/deployment/index.R
+++ b/dash_docs/chapters/deployment/index.R
@@ -15,12 +15,12 @@ set of IP addresses.
 
 ## Dash Enterprise 
 
-[Dash Enterprise](https://plotly.com/dash/pricing/?_ga=2.249471751.1080104966.1578062860-1986131108.1567098614) is Plotly's commercial product for deploying Dash
+[Dash Enterprise](https://plotly.com/dash/?_ga=2.249471751.1080104966.1578062860-1986131108.1567098614) is Plotly's commercial product for deploying Dash
 Apps on your company's servers or on AWS, Google Cloud, or Azure. It
 offers an enterprise-wide Dash App Portal, easy git-based deployment,
 automatic URL namespacing, built-in SSL support, LDAP authentication, and
-more. [Learn more about Dash Enterprise](https://plotly.com/dash/pricing?_ga=2.249471751.1080104966.1578062860-1986131108.1567098614) or [get in touch to start a
-trial](https://go.plotly.com/dash-doc?_ga=2.48144423.1080104966.1578062860-1986131108.1567098614).
+more. [Learn more about Dash Enterprise](https://plotly.com/dash?_ga=2.249471751.1080104966.1578062860-1986131108.1567098614) or [get in touch to start a
+trial](https://plotly.com/get-demo/?_ga=2.48144423.1080104966.1578062860-1986131108.1567098614).
 
 For existing customers, see the [Dash Enterprise Documentation](https://dash.plotly.com/dash-enterprise).
 
@@ -197,7 +197,7 @@ When you modify app.R with your own code, you will need to add the changes to gi
 ```
 
 If you're ready to take your apps to the next level, and deliver interactive analytics at scale, we invite you to learn more about Dash Enterprise. 
-[Click here for more information](https://plotly.com/dash/pricing/?_ga=2.176345125.1075922756.1562168385-916141078.1562168385) or [get in touch](https://plotly.typeform.com/to/rkO85m?_ga=2.176345125.1075922756.1562168385-916141078.1562168385).
+[Click here for more information](https://plotly.com/dash/?_ga=2.176345125.1075922756.1562168385-916141078.1562168385) or [get in touch](https://plotly.typeform.com/to/rkO85m?_ga=2.176345125.1075922756.1562168385-916141078.1562168385).
 
   "),
 htmlHr(),

--- a/dash_docs/chapters/deployment/index.py
+++ b/dash_docs/chapters/deployment/index.py
@@ -18,14 +18,14 @@ or view the tutorial on deploying to Heroku below.
 
 ### Dash Enterprise
 
-[Dash Enterprise](https://plotly.com/dash/pricing/)
+[Dash Enterprise](https://plotly.com/dash/)
 is Plotly's commercial product for deploying
 Dash Apps on your company's servers or on AWS, Google Cloud, or Azure.
 It offers an enterprise-wide Dash App Portal,
 easy git-based deployment, automatic URL namespacing,
 built-in SSL support, LDAP authentication, and more.
-[Learn more about Dash Enterprise](https://plotly.com/dash/pricing) or
-[get in touch to start a trial](https://go.plotly.com/dash-doc).
+[Learn more about Dash Enterprise](https://plotly.com/dash) or
+[get in touch to start a trial](https://plotly.com/get-demo/).
 
 For existing customers, see the <dccLink href="/dash-enterprise" children="Dash Enterprise Documentation"/>.
 
@@ -256,6 +256,6 @@ to git and push those changes to heroku.
 
 This workflow for deploying apps on heroku is very similar to how deployment
 works with the Plotly Enterprise's Dash Enterprise.
-[Learn more](https://plotly.com/dash/pricing/) or [get in touch](https://go.plotly.com/dash-doc).
+[Learn more](https://plotly.com/dash/) or [get in touch](https://plotly.com/get-demo/).
 ''')
 ]

--- a/dash_docs/chapters/support/index.R
+++ b/dash_docs/chapters/support/index.R
@@ -19,7 +19,7 @@ a demo of Dash and Dash Enterprise too.
 
 If you or your company would like to sponsor a specific feature or enterprise
 customization, get in touch with our
-[advanced development team](https://plotly.com/dash/pricing/).
+[advanced development team](https://plotly.com/products/consulting-and-oem).
 ### Community Support
 Our community forum at [community.plotly.com](https://community.plotly.com) has
 a topic dedicated on [Dash](https://community.plotly.com/c/dash).

--- a/dash_docs/chapters/support/index.py
+++ b/dash_docs/chapters/support/index.py
@@ -17,7 +17,7 @@ If you or your team would like to demo, trial, or license a Dash Enterprise,
 
 If you or your company would like to sponsor a specific feature or enterprise
 customization, get in touch with our
-[advanced development team](https://plotly.com/dash/pricing/).
+[advanced development team](https://plotly.com/products/consulting-and-oem).
 
 ### Community Support
 

--- a/dash_docs/chapters/whats_dash/index.py
+++ b/dash_docs/chapters/whats_dash/index.py
@@ -32,8 +32,8 @@ layout = html.Div([
 
         Dash is an open source library, released under the permissive MIT license.
         [Plotly](https://plotly.com) develops Dash and offers a [platform for easily deploying Dash
-        apps in an enterprise environment](https://plotly.com/dash/pricing).
-        If you're interested, [please get in touch](https://go.plotly.com/dash-doc).
+        apps in an enterprise environment](https://plotly.com/dash).
+        If you're interested, [please get in touch](https://plotly.com/get-demo/).
 
         ***
 

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -53,6 +53,7 @@ header = html.Div(
             # The breakpoints are set in override.css
             html.Div(className='links', children=[
                 html.A('Announcements', href='https://community.plotly.com/tag/announcements'),
+                html.A('Gallery', href='https://dash-gallery.plotly.host'),
                 html.A('Show & Tell', href='https://community.plotly.com/tag/show-and-tell'),
                 html.A('Community Forum', href='https://community.plotly.com/c/dash'),
                 html.Iframe(

--- a/dash_docs/tutorial/auth.py
+++ b/dash_docs/tutorial/auth.py
@@ -235,7 +235,7 @@ layout = html.Div([
 
     Plotly Auth uses the environment variables `PLOTLY_USERNAME` and `PLOTLY_API_KEY`.
     You can find your username and API key at [https://plotly.com/settings/api](https://plotly.com/settings/api) or,
-    if you are using [Dash Enterprise](https://plotly/dash/pricing), at https://your-plotly-server.com/settings/api.
+    if you are using [Dash Enterprise](https://plotly/dash), at https://your-plotly-server.com/settings/api.
 
     You can set these variables directly in your code with:
     '''.replace('   ', '')),

--- a/run.R
+++ b/run.R
@@ -235,7 +235,7 @@ header <- htmlDiv(
           src = 'https://dash.plotly.com/assets/images/logo-plotly.png'
         ), href = 'https://plotly.com/products/dash', className='logo-link'),
         htmlDiv(className='links', children = list(
-          htmlA('pricing', className='link', href = 'https://plotly.com/dash/pricing'),
+          htmlA('pricing', className='link', href = 'https://plotly.com/dash'),
           htmlA('user guide', className='link', href = '/'),
           htmlA('plotly', className='link', href = 'https://plotly.com/')
         ))
@@ -606,7 +606,7 @@ app$callback(
               list(
                 components$Chapter(
                 'About Dash Deployment Server',
-                href='https://plotly.com/dash/pricing/?_ga=2.180458663.1075922756.1562168385-916141078.1562168385'
+                href='https://plotly.com/dash/?_ga=2.180458663.1075922756.1562168385-916141078.1562168385'
                 ),
                 components$Chapter(
                 'Dash Deployment Server Documentation',


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL