### PR TITLE
Fix bug in the pattern matching callback docs

### DIFF
--- a/dash_docs/chapters/pattern_matching_callbacks/index.py
+++ b/dash_docs/chapters/pattern_matching_callbacks/index.py
@@ -38,8 +38,8 @@ layout = html.Div([
     - Notice how the `id` in `dcc.Dropdown` is a _dictionary_ rather than a _string_.
     This is a new feature that we enabled for pattern-matching callbacks
     (previously, IDs had to be strings).
-    - In our second callback, we have `Input({'type': 'dropdown', 'index': ALL}, 'value')`.
-    This means "match any input that has an ID dictionary where `'type'` is `'dropdown'`
+    - In our second callback, we have `Input({'type': 'filter-dropdown', 'index': ALL}, 'value')`.
+    This means "match any input that has an ID dictionary where `'type'` is `'filter-dropdown'`
     and `'index'` is _anything_. Whenever the `value` property of any of the
     dropdowns change, send _all_ of their values to the callback."
     - The keys & values of the ID dictionary (`type`, `index`, `filter-dropdown`)


### PR DESCRIPTION
I *think* that the second bullet in the explication for the example should be discussing type `filter-dropdown`, that seems to be what's in the code and the other bullets.

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL