### PR TITLE
Contribute notes on shared databases to usage & warnings/limitations sections

### DIFF
--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2617,15 +2617,28 @@ Redis = html.Div(children=[
     ```shell
     redis_instance = redis.StrictRedis.from_url(os.environ["REDIS_URL"])
     ```
+    ''',
+    style=styles.code_container,
+    ),
+
+    rc.Markdown('''
+   
+    &nbsp;
 
     Redis instances support 16 databases, and each database is accessible via the
     specified broker URL using its index.
 
-    Using the `WORKSPACE_ENV` environment variable, application developers can
-    conditionally append a database index when defining `REDIS_URL` so that an  
-    application running in a given workspace does not share its Redis database.
-    For example:
+    Within Dash Workspaces, the `WORKSPACE_ENV` environment variable provides 
+    application developers with a convenient method for conditionally appending 
+    a database index when defining `REDIS_URL`.
 
+    This helps ensure that an application running in a given workspace does not
+    share its Redis database. For example:
+
+    '''),
+
+    rc.Markdown(
+    '''
     ```python
     if 'WORKSPACE_ENV' in os.environ:
         REDIS_URL = os.environ["REDIS_URL"] + '/' + str(1 % 16) 

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2710,6 +2710,12 @@ Celery = html.Div(children=[
 
     &nbsp;
 
+    When combined with Dash Workspaces, Celery offers the capacity to offload
+    longer running and computationally intensive tasks while centralizing
+    development activities. For more details on working with Celery within
+    Dash Workspaces, see [Referencing Redis in Your Code](redis-database)
+    within the Redis chapter of our documentation.    
+
     For more information about Celery, visit
     [Celery's documentation](http://docs.celeryproject.org/en/latest/).
 

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2628,7 +2628,7 @@ Redis = html.Div(children=[
     Redis instances support 16 databases, and each database is accessible via the
     specified broker URL using its index.
 
-    Within Dash Workspaces, the `DASH_WORKSPACE_ENV` environment variable provides 
+    Within Dash Workspaces, the `DASH_ENTERPRISE_ENV` environment variable provides 
     application developers with a convenient method for conditionally appending 
     a database index when defining `REDIS_URL`.
 
@@ -2640,7 +2640,7 @@ Redis = html.Div(children=[
     rc.Markdown(
     '''
     ```python
-    if 'DASH_WORKSPACE_ENV' in os.environ:
+    if os.getenv('DASH_ENTERPRISE_ENV') == 'WORKSPACE':
         REDIS_URL = os.environ["REDIS_URL"] + '/' + str(1 % 16) 
     else:
         REDIS_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2617,6 +2617,23 @@ Redis = html.Div(children=[
     ```shell
     redis_instance = redis.StrictRedis.from_url(os.environ["REDIS_URL"])
     ```
+
+    Redis instances support 16 databases, and each database is accessible via the
+    specified broker URL using its index.
+
+    Using the `WORKSPACE_ENV` environment variable, application developers can
+    conditionally append a database index when defining `REDIS_URL` so that an  
+    application running in a given workspace does not share its Redis database.
+    For example:
+
+    ```python
+    if 'WORKSPACE_ENV' in os.environ:
+        REDIS_URL = os.environ["REDIS_URL"] + '/' + str(1 % 16) 
+    else:
+        REDIS_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')
+
+    celery_app = Celery("Celery App", broker=REDIS_URL)
+    ```    
     ''',
     style=styles.code_container,
     ),

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2628,12 +2628,12 @@ Redis = html.Div(children=[
     Redis instances support 16 databases, and each database is accessible via the
     specified broker URL using its index.
 
-    Within Dash Workspaces, the `DASH_ENTERPRISE_ENV` environment variable provides 
-    application developers with a convenient method for conditionally appending 
-    a database index when defining `REDIS_URL`.
+    **Workspaces**
 
-    This helps ensure that an application running in a given workspace does not
-    share its Redis database. For example:
+    Note: The same `REDIS_URL` and Redis instance is used by deployed applications and workspaces.
+    If you want to use a different Redis database (but the same Redis instance), then specify a 
+    different Redis database number if the code is run within a Workspace by checking the 
+    `DASH_ENTERPRISE_ENV` variable. Redis supports 16 databases on the same instance.
 
     '''),
 

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2710,10 +2710,7 @@ Celery = html.Div(children=[
 
     &nbsp;
 
-    When combined with Dash Workspaces, Celery offers the capacity to offload
-    longer running and computationally intensive tasks while centralizing
-    development activities. For more details on working with Celery within
-    Dash Workspaces, see [Referencing Redis in Your Code](redis-database)
+    Celery requires Redis. In Workspaces, the same Redis instance is shared between the Workspace environment and the deployed application. A shared Redis database between two different apps can cause requests to be intercepted by the wrong app. To configure Redis with Celery in a Workspace-compatible way, see [Referencing Redis in Your Code](/dash-enterprise/redis-database).
     within the Redis chapter of our documentation.    
 
     For more information about Celery, visit

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -2628,7 +2628,7 @@ Redis = html.Div(children=[
     Redis instances support 16 databases, and each database is accessible via the
     specified broker URL using its index.
 
-    Within Dash Workspaces, the `WORKSPACE_ENV` environment variable provides 
+    Within Dash Workspaces, the `DASH_WORKSPACE_ENV` environment variable provides 
     application developers with a convenient method for conditionally appending 
     a database index when defining `REDIS_URL`.
 
@@ -2640,7 +2640,7 @@ Redis = html.Div(children=[
     rc.Markdown(
     '''
     ```python
-    if 'WORKSPACE_ENV' in os.environ:
+    if 'DASH_WORKSPACE_ENV' in os.environ:
         REDIS_URL = os.environ["REDIS_URL"] + '/' + str(1 % 16) 
     else:
         REDIS_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')


### PR DESCRIPTION
This PR proposes to address https://github.com/plotly/streambed/issues/14524 and https://github.com/plotly/dash-enterprise-docs/issues/313 by adding notes on database sharing issues within Dash Workspaces, and how to address them using `DASH_ENTERPRISE_ENV`.

Specifically, changes would be made in the `workspaces/usage` and `workspaces/warnings` sections.

@chriddyp