### PR TITLE
add hyperlink to DangerouslySetInnerHTML

### DIFF
--- a/dash_docs/chapters/dash_html_components/index.R
+++ b/dash_docs/chapters/dash_html_components/index.R
@@ -13,7 +13,7 @@ Instead of writing HTML or using an HTML templating engine, you compose your lay
 The source for this library is on GitHub: [plotly/dash-html-components](https://github.com/plotly/dash-html-components).
 Here is an example of a simple HTML structure:
   "),
-  
+
   utils$LoadAndDisplayComponent(
 "
 library(dashHtmlComponents)
@@ -80,7 +80,7 @@ dccMarkdown("
     ```
     "),
 
-htmlDiv('That dash code will render this HTML markup:'),
+htmlDiv('That Dash code will render this HTML markup:'),
 
 dccMarkdown('
              ```html

--- a/dash_docs/chapters/dash_html_components/index.py
+++ b/dash_docs/chapters/dash_html_components/index.py
@@ -110,7 +110,7 @@ layout = html.Div(children=[
     ```
     ''', style=styles.code_container),
 
-    html.Div('That dash code will render this HTML markup:'),
+    html.Div('That Dash code will render this HTML markup:'),
 
     rc.Markdown('''
     ```html
@@ -127,6 +127,10 @@ layout = html.Div(children=[
     </div>
     ```
     ''', style=styles.code_container),
+
+    rc.Markdown('''
+    Note: If you need to directly render a string of raw, unescaped HTML, you can use the `DangerouslySetInnerHTML` component which is provided by the [dash-dangerously-set-inner-html](https://github.com/plotly/dash-dangerously-set-inner-html) library.`
+    '''),
 
     rc.Markdown('''
     ## Full elements reference:


### PR DESCRIPTION
The purpose of this PR is to link to https://github.com/plotly/dash-dangerously-set-inner-html per https://github.com/plotly/dash-docs/issues/759