### PR TITLE
avoid linter warning from dash-daq example

### DIFF
--- a/dash_docs/chapters/dash_daq/examples/indicator.py
+++ b/dash_docs/chapters/dash_daq/examples/indicator.py
@@ -24,9 +24,9 @@ app.layout = html.Div([
     [dash.dependencies.Input('my-indicator-button', 'n_clicks')]
 )
 def update_output(value):
-    if value % 2 is 0:
+    if value % 2 == 0:
         value = True
-    else: 
+    else:
         value = False
     return value
 


### PR DESCRIPTION
Just resolving a warning seen when running locally:

```
<string>:27: SyntaxWarning:

"is" with a literal. Did you mean "=="?
```