### PR TITLE
Updated details for werkzeug DispatcherMiddleware usage, added dash-d…

### DIFF
--- a/dash_docs/chapters/integrating_dash/index.py
+++ b/dash_docs/chapters/integrating_dash/index.py
@@ -141,7 +141,7 @@ layout = html.Div([
     rc.Markdown("`wsgi.py`"),
     rc.Syntax(
         """
-            from werkzeug.wsgi import DispatcherMiddleware
+            from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
             from flask_app import flask_app
             from app1 import app as app1

--- a/dash_docs/chapters/support/index.py
+++ b/dash_docs/chapters/support/index.py
@@ -27,7 +27,8 @@ This forum is great for showing off projects, feature requests,
 and general questions.
 
 If you have found a bug, you can open an issue on GitHub at
-[plotly/dash](https://github.com/plotly/dash).
+[plotly/dash](https://github.com/plotly/dash) or 
+[plotly/dash-docs](https://github.com/plotly/dash-docs/).
 
 ### Direct Contact
 


### PR DESCRIPTION
…ocs to support page

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL