### PR TITLE
Add demo button in banner 

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -101,6 +101,7 @@ h6 { font-size: 20px; line-height: 1.6;  margin-bottom: 0.75rem; margin-top: 0.7
     border-bottom-width: 1px;
     cursor: pointer;
     opacity: 0.5;
+    word-wrap: break-word;
 }
 .page-menu--link:hover {
     border-bottom-style: solid;

--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -479,14 +479,23 @@ a {
     }
 }
 
-@media (max-width: 800px) {
-    .header .links iframe {
+@media (max-width: 1000px) {
+    .header .links a.links--announcements {
+        display: none;
+    }
+    .header .links a.links--gallery {
+        display: none;
+    }
+    .header .links a.links--show-and-tell {
+        display: none;
+    }
+    .header .links a.links--community-forum {
         display: none;
     }
 }
 
-@media (max-width: 700px) {
-    .header .links {
+@media (max-width: 550px) {
+    .header .links Iframe {
         display: none;
     }
 }

--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -444,14 +444,17 @@ a {
   }
 }
 
-@media (max-width: 1150px) {
+/* @media (max-width: 1150px) {
     .page-menu {
         display: none;
     }
-}
+} */
 
-@media (max-width: 950px) {
+@media (max-width: 1000px) {
     .sidebar-container {
+        display: none;
+    }
+    .page-menu {
         display: none;
     }
     .content {

--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -444,12 +444,6 @@ a {
   }
 }
 
-/* @media (max-width: 1150px) {
-    .page-menu {
-        display: none;
-    }
-} */
-
 @media (max-width: 1000px) {
     .sidebar-container {
         display: none;

--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -479,13 +479,13 @@ a {
     }
 }
 
-@media (max-width: 705px) {
+@media (max-width: 800px) {
     .header .links iframe {
         display: none;
     }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
     .header .links {
         display: none;
     }

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -52,10 +52,10 @@ header = html.Div(
             # make sure to check that the responsive design still works
             # The breakpoints are set in override.css
             html.Div(className='links', children=[
-                html.A('Announcements', className='announcements', href='https://community.plotly.com/tag/announcements'),
-                html.A('Gallery', className='gallery', href='https://dash-gallery.plotly.host'),
-                html.A('Show & Tell', className='show-and-tell', href='https://community.plotly.com/tag/show-and-tell'),
-                html.A('Community Forum', className='community-forum', href='https://community.plotly.com/c/dash'),
+                html.A('Announcements', className='links--announcements', href='https://community.plotly.com/tag/announcements'),
+                html.A('Gallery', className='links--gallery', href='https://dash-gallery.plotly.host'),
+                html.A('Show & Tell', className='links--show-and-tell', href='https://community.plotly.com/tag/show-and-tell'),
+                html.A('Community Forum', className='links--community-forum', href='https://community.plotly.com/c/dash'),
                 html.Iframe(
                     src="https://ghbtns.com/github-btn.html?user=plotly&repo=dash&type=star&count=true&size=small",
                     style={
@@ -66,7 +66,7 @@ header = html.Div(
                         'width': '120px',
                     } 
                 ),
-                html.A('dash enterprise demo', className='demo-button', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
+                html.A('dash enterprise demo', className='links--demo-button', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
                     style={
                         'background-color': '#f4564e', 
                         'border-radius': '1.22rem',

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -66,7 +66,7 @@ header = html.Div(
                         'width': '120px',
                     } 
                 ),
-                html.A('dash enterprise demo', className='Links', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
+                html.A('dash enterprise demo', className='demo-button', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
                     style={
                         'background-color': '#f4564e', 
                         'border-radius': '1.22rem',
@@ -81,6 +81,7 @@ header = html.Div(
                         'padding': '.55rem 1.22rem',
                         'margin-right': '5px',
                         'text-align': 'center',
+                        'verticalAlign': 'middle',
                         'text-decoration': 'none',
                         'text-transform': 'uppercase',
                         'transition': 'background-color .2s ease-in-out'

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -66,11 +66,11 @@ header = html.Div(
                         'width': '120px',
                     } 
                 ),
-                html.A('get a demo', className='Links', href='https://plotly.com/get-demo/', 
+                html.A('dash enterprise demo', className='Links', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
                     style={
-                        'background-color': '#60bab6', 
+                        'background-color': '#f4564e', 
                         'border-radius': '1.22rem',
-                        'color': '#fff!important',
+                        'color': 'white',
                         'cursor': 'pointer',
                         'display': 'inline-block',
                         'font-style': 'italic',

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -52,10 +52,10 @@ header = html.Div(
             # make sure to check that the responsive design still works
             # The breakpoints are set in override.css
             html.Div(className='links', children=[
-                html.A('Announcements', href='https://community.plotly.com/tag/announcements'),
-                html.A('Gallery', href='https://dash-gallery.plotly.host'),
-                html.A('Show & Tell', href='https://community.plotly.com/tag/show-and-tell'),
-                html.A('Community Forum', href='https://community.plotly.com/c/dash'),
+                html.A('Announcements', className='announcements', href='https://community.plotly.com/tag/announcements'),
+                html.A('Gallery', className='gallery', href='https://dash-gallery.plotly.host'),
+                html.A('Show & Tell', className='show-and-tell', href='https://community.plotly.com/tag/show-and-tell'),
+                html.A('Community Forum', className='community-forum', href='https://community.plotly.com/c/dash'),
                 html.Iframe(
                     src="https://ghbtns.com/github-btn.html?user=plotly&repo=dash&type=star&count=true&size=small",
                     style={
@@ -87,7 +87,7 @@ header = html.Div(
                         'transition': 'background-color .2s ease-in-out'
                     }
                 ),
-            ])
+            ]),           
         ]
     )
 )

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -47,7 +47,7 @@ header = html.Div(
                 ), href='/', id='logo-home'),
             ], className='logo'),
 
-            # HEADS UP!
+            # HEADS UP! 
             # If you are modifying these header links,
             # make sure to check that the responsive design still works
             # The breakpoints are set in override.css
@@ -63,7 +63,27 @@ header = html.Div(
                         'height': '30px',
                         'verticalAlign': 'middle',
                         'marginTop': '9px',
-                        'width': '120px'
+                        'width': '120px',
+                    } 
+                ),
+                html.A('get a demo', className='Links', href='https://plotly.com/get-demo/', 
+                    style={
+                        'background-color': '#60bab6', 
+                        'border-radius': '1.22rem',
+                        'color': '#fff!important',
+                        'cursor': 'pointer',
+                        'display': 'inline-block',
+                        'font-style': 'italic',
+                        'font-weight': '700',
+                        'line-height': '1.2',
+                        'letter-spacing': '1.33px',
+                        'outline': 'none',
+                        'padding': '.55rem 1.22rem',
+                        'margin-right': '5px',
+                        'text-align': 'center',
+                        'text-decoration': 'none',
+                        'text-transform': 'uppercase',
+                        'transition': 'background-color .2s ease-in-out'
                     }
                 ),
             ])


### PR DESCRIPTION
Added Dash Enterprise demo button in Dash documentation banner as per dash-core [#263](https://github.com/plotly/dash-core/issues/263).

Also included right-hand sidebar word-wrap and max-width as per dash-enterprise-docs [#540](https://github.com/plotly/dash-enterprise-docs/issues/540).

## Banner

### Before
![image](https://user-images.githubusercontent.com/11036740/93288673-705f0d80-f7aa-11ea-9ee7-e44882f58bba.png)

### After
![banner_button_3](https://user-images.githubusercontent.com/11036740/93289797-43602a00-f7ad-11ea-8931-b71a5c8de46f.gif)

## Resizing

### Before 
![banner_button_3_resizing](https://user-images.githubusercontent.com/11036740/93355546-3161a400-f80c-11ea-9c7a-5de4ba8aacba.gif)

### After
![banner_button_4_resizing](https://user-images.githubusercontent.com/11036740/93504226-32b3cf00-f8e7-11ea-876b-e13137265dc4.gif)
