### PR TITLE
Add reusable components for Dash.jl documentation

### DIFF
--- a/dash_docs/reusable_components/Chapter.jl
+++ b/dash_docs/reusable_components/Chapter.jl
@@ -1,0 +1,32 @@
+using DashHtmlComponents
+
+function Chapter(name::String, href::Union{Nothing, String}, caption::Union{Nothing, String})
+    divTitle = html_a(
+        name,
+        href = href,
+        id = href,
+        className = "toc--chapter-link"
+    )
+    divCaption = html_small(
+        className = "toc--chapter-content",
+        children = dcc_markdown(caption),
+        style = (display = "block", marginTop = "3px",)
+    )
+    if !isnothing(caption)
+        return(
+            html_div(
+                className = "toc--chapter",
+                style = (marginTop = "10px",),
+                children = (divTitle, divCaption,)
+            )
+        )
+    else
+        return(
+            html_div(
+                className = "toc--chapter",
+                style = (marginTop = "10px",),
+                children = (divTitle)
+            )
+        )
+    end
+end

--- a/dash_docs/reusable_components/Example.jl
+++ b/dash_docs/reusable_components/Example.jl
@@ -1,0 +1,8 @@
+using DashHtmlComponents
+
+function Example(example::String)
+    return html_div(
+        example,
+        className = "example-container"
+    )
+end

--- a/dash_docs/reusable_components/Header.jl
+++ b/dash_docs/reusable_components/Header.jl
@@ -1,0 +1,10 @@
+using DashHtmlComponents
+
+function Header(title::String)
+    return html_div(
+        html_h2(
+            title,
+            style = (borderBottom = "thin lightgrey solid", marginRight = 20,)
+        )
+    )
+end

--- a/dash_docs/reusable_components/Section.jl
+++ b/dash_docs/reusable_components/Section.jl
@@ -1,0 +1,20 @@
+using DashHtmlComponents
+
+function Section(title::String, links::String, description::Union{Nothing, String}, headerStyle = ())
+    return(
+        html_div(
+            className = "toc--section",
+            children = (
+                html_h2(
+                    title,
+                    style = merge((borderBottom = "thin lightgrey solid", marginTop = 50,), headerStyle, )
+                ),
+                html_div(description),
+                html_ul(
+                    links,
+                    className = "toc--chapters"
+                )
+            )
+        )
+    )
+end

--- a/dash_docs/reusable_components/Syntax.jl
+++ b/dash_docs/reusable_components/Syntax.jl
@@ -1,0 +1,22 @@
+using DashHtmlComponents
+
+function Syntax(children::Component; style = code_container, summary = "")
+    if (summary != "")
+        return(
+            html_details(
+                (
+                    html_summary(children = summary),
+                    html_div(children)
+                ),
+                open = true
+            )
+        )
+    else
+        return(
+            dcc_markdown(
+                children,
+                style = style
+            )
+        )
+    end
+end

--- a/dash_docs/styles.jl
+++ b/dash_docs/styles.jl
@@ -1,0 +1,15 @@
+code_container = (borderLeft = "thin #C8D4E3 solid",)
+
+container_padding_bottom = (
+    padding = 0,
+    paddingBottom = "15px",
+)
+
+notebox = (
+    width = "90%",
+    margin = "0 auto",
+    border = "1px solid lightgrey",
+    textAlign = "center",
+    borderRadius = "5px",
+    backgroundColor = "lightgrey",
+)


### PR DESCRIPTION
Closes #968 

This PR proposes to add the following essential "reusable components" for Julia, which were ported from the ones used in the Dash for R documentation:
- Chapter.jl
- Example.jl
- Header.jl
- Section.jl
- Syntax.jl

In addition, a `styles.jl` file would be introduced, which supplies the necessary `code_container`, `container_padding_bottom`, and `notebox` tuples for the components.