### PR TITLE
add description of using persistenceTransforms on non-nested persisted props

### DIFF
--- a/dash_docs/chapters/persistence/index.py
+++ b/dash_docs/chapters/persistence/index.py
@@ -135,5 +135,12 @@ layout = html.Div([
     prop, because persistence is only maintained if the extracted value of the
     prop before applying persistence is the same as it was before the user's
     changes.
-    ''')
+
+    It is also possible to define and use `persistenceTransforms` on non-nested
+    props, i.e. `propName`, in order to apply some transformation to your
+    persisted prop. An example of this is used in DatePickerSingle and
+    DatePickerRange to strip the time portion of persisted `date`, `start_date`,
+    and `end_date` props. You can check out the [PR in
+    dash-core-components](https://github.com/plotly/dash-core-components/pull/854).
+
 ])

--- a/dash_docs/chapters/persistence/index.py
+++ b/dash_docs/chapters/persistence/index.py
@@ -142,5 +142,5 @@ layout = html.Div([
     DatePickerRange to strip the time portion of persisted `date`, `start_date`,
     and `end_date` props. You can check out the [PR in
     dash-core-components](https://github.com/plotly/dash-core-components/pull/854).
-
+  ''')
 ])


### PR DESCRIPTION
Following up on https://github.com/plotly/dash-core-components/pull/854 and https://github.com/plotly/dash/pull/1376, add brief description on the ability to use `PersistenceTransforms` on non-nested persisted props.


Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand


