### PR TITLE
Add functions to parse strings and evaluate as Julia expressions

### DIFF
--- a/dash_docs/utils.jl
+++ b/dash_docs/utils.jl
@@ -6,7 +6,7 @@ function LoadExampleCode(filename, wd = nothing)
   replacements = [
       r"app.layout =" => "layout ="
       r"app =.*dash\((.*?)\)"m => ""
-      r"run_server(app, \"0.0.0.0\", 8000)" => ""
+      r"run_server\(.*?\)" => ""
   ]
   for replacement in replacements
     example_ready_for_eval = replace(example_ready_for_eval, replacement)
@@ -20,14 +20,15 @@ function LoadExampleCode(filename, wd = nothing)
   return (
       "layout" => html_div(
           className = "example-container",
-          style = ("margin-bottom" => "10px",)
+          children = layout,
+          style = Dict("margin-bottom" => "10px"),
       ),
       "source_code" => html_div(
           children = dcc_markdown(
-              @sprintf("```julia\n%s```", example_file_as_string)
+              @sprintf("```Julia\n%s\n```", example_file_as_string)
           ),
           className = "code-container",
-          style = ("border-left" => "thin lightgrey solid",)
+          style = Dict("border-left" => "thin lightgrey solid"),
       ),
   )
 end
@@ -36,14 +37,14 @@ function LoadAndDisplayComponent(example_string)
   return html_div(
     (
       html_div(
-        children = dcc_markdown(@printf("```julia %s```", example_string)),
+        children = dcc_markdown(@printf("```Julia\n%s```", example_string)),
         className = "code-container",
-        style = ("border-left" => "thin lightgrey solid",)
+        style = Dict("border-left" => "thin lightgrey solid")
       ),
       html_div(
-        children = include_string(Main, example_string)
+        children = include_string(Main, example_string),
         className = "example-container",
-        style = ("margin-bottom" => "10px", "overflow-x" => "initial", )
+        style = Dict("margin-bottom" => "10px", "overflow-x" => "initial")
       ),
     )
   )
@@ -53,14 +54,14 @@ function LoadAndDisplayComponent2(example_string)
   return html_div(
     (
       html_div(
-        children = dcc_markdown(@printf("```julia %s```", example_string)),
+        children = dcc_markdown(@printf("```Julia\n%s```", example_string)),
         className = "code-container",
-        style = ("border-left" => "thin lightgrey solid",)
+        style = Dict("border-left" => "thin lightgrey solid")
       ),
       html_div(
         children = include_string(Main, example_string),
         className = "example-container",
-        style = ("margin-bottom" => "10px", "padding-bottom" => "30px", )
+        style = Dict("margin-bottom" => "10px", "padding-bottom" => "30px")
       ),
     )
   )

--- a/dash_docs/utils.jl
+++ b/dash_docs/utils.jl
@@ -1,0 +1,67 @@
+using Dash, DashCoreComponents, DashHtmlComponents, Printf
+
+function LoadExampleCode(filename, wd = nothing)
+  example_file_as_string = read(filename, String)
+  example_ready_for_eval = example_file_as_string
+  replacements = [
+      r"app.layout =" => "layout ="
+      r"app =.*dash\((.*?)\)"m => ""
+      r"run_server(app, \"0.0.0.0\", 8000)" => ""
+  ]
+  for replacement in replacements
+    example_ready_for_eval = replace(example_ready_for_eval, replacement)
+  end
+  if !isnothing(wd)
+    currentWd = pwd()
+    newWd = string(currentWd, "/", wd)
+    example_ready_for_eval = string("cd(example_ready_for_eval, newWd)")
+  end
+  eval(Meta.parse(example_ready_for_eval))
+  return (
+      "layout" => html_div(
+          className = "example-container",
+          style = ("margin-bottom" => "10px",)
+      ),
+      "source_code" => html_div(
+          children = dcc_markdown(
+              @sprintf("```julia\n%s```", example_file_as_string)
+          ),
+          className = "code-container",
+          style = ("border-left" => "thin lightgrey solid",)
+      ),
+  )
+end
+
+function LoadAndDisplayComponent(example_string)
+  return html_div(
+    (
+      html_div(
+        children = dcc_markdown(@printf("```julia %s```", example_string)),
+        className = "code-container",
+        style = ("border-left" => "thin lightgrey solid",)
+      ),
+      html_div(
+        children = eval(Meta.parse(example_string)),
+        className = "example-container",
+        style = ("margin-bottom" => "10px", "overflow-x" => "initial", )
+      ),
+    )
+  )
+end
+
+function LoadAndDisplayComponent2(example_string)
+  return html_div(
+    (
+      html_div(
+        children = dcc_markdown(@printf("```julia %s```", example_string)),
+        className = "code-container",
+        style = ("border-left" => "thin lightgrey solid",)
+      ),
+      html_div(
+        children = eval(Meta.parse(example_string)),
+        className = "example-container",
+        style = ("margin-bottom" => "10px", "padding-bottom" => "30px", )
+      ),
+    )
+  )
+end

--- a/dash_docs/utils.jl
+++ b/dash_docs/utils.jl
@@ -18,18 +18,18 @@ function LoadExampleCode(filename, wd = nothing)
   end
   include_string(Main, example_ready_for_eval)
   return (
-      "layout" => html_div(
+      layout = html_div(
           className = "example-container",
           children = layout,
           style = Dict("margin-bottom" => "10px"),
       ),
-      "source_code" => html_div(
+      source_code = html_div(
           children = dcc_markdown(
               @sprintf("```Julia\n%s\n```", example_file_as_string)
           ),
           className = "code-container",
           style = Dict("border-left" => "thin lightgrey solid"),
-      ),
+      )
   )
 end
 

--- a/dash_docs/utils.jl
+++ b/dash_docs/utils.jl
@@ -16,7 +16,7 @@ function LoadExampleCode(filename, wd = nothing)
     newWd = string(currentWd, "/", wd)
     example_ready_for_eval = string("cd(example_ready_for_eval, newWd)")
   end
-  eval(Meta.parse(example_ready_for_eval))
+  include_string(Main, example_ready_for_eval)
   return (
       "layout" => html_div(
           className = "example-container",
@@ -41,7 +41,7 @@ function LoadAndDisplayComponent(example_string)
         style = ("border-left" => "thin lightgrey solid",)
       ),
       html_div(
-        children = eval(Meta.parse(example_string)),
+        children = include_string(Main, example_string)
         className = "example-container",
         style = ("margin-bottom" => "10px", "overflow-x" => "initial", )
       ),
@@ -58,7 +58,7 @@ function LoadAndDisplayComponent2(example_string)
         style = ("border-left" => "thin lightgrey solid",)
       ),
       html_div(
-        children = eval(Meta.parse(example_string)),
+        children = include_string(Main, example_string),
         className = "example-container",
         style = ("margin-bottom" => "10px", "padding-bottom" => "30px", )
       ),


### PR DESCRIPTION
This PR proposes to contribute the `LoadExampleCode`, `LoadAndDisplayComponent` and `LoadAndDisplayComponent2` functions to the Dash documentation for Julia. These functions are intended to enable the live code example functionality currently available in the Python and R versions of the Dash docs.