### PR TITLE
Refactoring of LoadExampleCode

### DIFF
--- a/dash_docs/chapters/basic_callbacks/index.jl
+++ b/dash_docs/chapters/basic_callbacks/index.jl
@@ -2,9 +2,8 @@ using Dash
 using DashHtmlComponents
 using DashCoreComponents
 
-include("/Users/josephdamiba/Downloads/code/work/plotly/dash-docs/dash_docs/utils.jl")
+include("../../utils.jl")
 
-app =  dash()
 
 basic_input = LoadExampleCode("./dash_docs/chapters/basic_callbacks/examples/basic-input.jl")
 
@@ -19,6 +18,16 @@ multi_inputs = LoadExampleCode("./dash_docs/chapters/basic_callbacks/examples/mu
 multi_outputs = LoadExampleCode("./dash_docs/chapters/basic_callbacks/examples/multi-outputs.jl")
 
 simple_callback = LoadExampleCode("./dash_docs/chapters/basic_callbacks/examples/simple-callback.jl")
+
+app =  dash()
+basic_input.callback!(app)
+basic_state.callback!(app)
+callback_chain.callback!(app)
+hello_slider.callback!(app)
+multi_inputs.callback!(app)
+multi_outputs.callback!(app)
+simple_callback.callback!(app)
+
 
 app.layout = html_div() do
     html_h1("Basic Dash Callbacks"),

--- a/dash_docs/chapters/getting_started/index.jl
+++ b/dash_docs/chapters/getting_started/index.jl
@@ -1,8 +1,7 @@
 using Dash
 using DashHtmlComponents
 using DashCoreComponents
-
-include("/Users/josephdamiba/Downloads/code/work/plotly/dash-docs/dash_docs/utils.jl")
+include("../../utils.jl")
 
 getting_started_layout_1 = LoadExampleCode("./dash_docs/chapters/getting_started/examples/getting_started_layout_1.jl")
 

--- a/dash_docs/utils.jl
+++ b/dash_docs/utils.jl
@@ -2,37 +2,69 @@ using Dash, DashCoreComponents, DashHtmlComponents, Printf
 
 function LoadExampleCode(filename, wd = nothing)
   example_file_as_string = read(filename, String)
-  example_ready_for_eval = example_file_as_string
-  replacements = [
-      r"app.layout =" => "layout ="
-      r"app =.*dash\((.*?)\)"m => ""
-      r"run_server\(.*?\)" => ""
-  ]
-  for replacement in replacements
-    example_ready_for_eval = replace(example_ready_for_eval, replacement)
-  end
-  if !isnothing(wd)
-    currentWd = pwd()
-    newWd = string(currentWd, "/", wd)
-    example_ready_for_eval = string("cd(example_ready_for_eval, newWd)")
-  end
-  println(example_ready_for_eval)
 
-  include_string(Main, example_ready_for_eval)
-  return (
-      layout = html_div(
-          className = "example-container",
-          children = layout,
-          style = Dict("marginBottom" => "10px"),
-      ),
-      source_code = html_div(
-          children = dcc_markdown(
-              @sprintf("```julia\n%s\n```", example_file_as_string)
-          ),
-          className = "code-container",
-          style = Dict("borderLeft" => "thin lightgrey solid"),
-      ),
-  )
+  wd = joinpath(pwd(), isnothing(wd) ? "" : wd )
+  return cd(wd) do
+
+    parsed_exprs = ParseExampleExpr(Base.parse_input_line(example_file_as_string; filename = filename))
+    return (
+        layout = html_div(
+            className = "example-container",
+            children = eval(parsed_exprs.layout),
+            style = Dict("marginBottom" => "10px"),
+        ),
+        source_code = html_div(
+            children = dcc_markdown(
+                @sprintf("```julia\n%s\n```", example_file_as_string)
+            ),
+            className = "code-container",
+            style = Dict("borderLeft" => "thin lightgrey solid"),
+        ),
+        callback! = eval(parsed_exprs.callback!)
+    )
+  end
+
+end
+
+function ParseExampleExpr(expr)
+  layout = nothing
+  callback_funcs = Expr(:block)
+  for code_block in expr.args
+    if code_block isa Expr
+        #skip app = ....
+        if code_block.head == :(=) && code_block.args[1] == :app
+          continue
+        end
+        #skip run_server
+        if code_block.head == :call && code_block.args[1] == :run_server
+          continue
+        end
+
+        #skip and save layout
+        if code_block.head == :(=) && code_block.args[1] == :(app.layout)
+          layout = code_block.args[2]
+          continue
+        end
+
+        #skip and append to list callback
+        if is_callback(code_block)
+          push!(callback_funcs.args, code_block)
+          continue
+        end
+
+        eval(code_block)
+
+    end
+  end
+  return (layout = layout, callback! = Expr(:function, :(app,), callback_funcs))
+end
+
+is_callbackcall(expr) = expr.head == :call && expr.args[1] == :callback!
+
+function is_callback(expr)
+  is_callbackcall(expr) && return true #callback!((x)->x, ....)
+  (expr.head == :do && is_callbackcall(expr.args[1])) && return true #do syntax
+  return false
 end
 
 function LoadAndDisplayComponent(example_string)


### PR DESCRIPTION
`LoadExampleCode` now parses example into the`Expr` (AST tree) before executing it. In the resulting tree, all elements are evaled, except for the following:

- `app = ...` and `run_server(...)` ignored
- `app.layout = ...` executed separately and returned as `layout` field in the result of the `LoadExampleCode`
- `callback!(...)`  added to the `callback!(app)` function of the `LoadExampleCode` result. Calling this function with a specific application will accept all callbacks that are encountered in the example  to that application

All the checks above only work at the top level of the code with the example. I.e. there is no recursive traversal of submodules and functions.

