### PR TITLE
datepickers date/datetime usage

### DIFF
--- a/dash_docs/chapters/dash_core_components/DatePickerRange/examples/date_picker_range.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/examples/date_picker_range.py
@@ -10,9 +10,9 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 app.layout = html.Div([
     dcc.DatePickerRange(
         id='my-date-picker-range',
-        min_date_allowed=dt(1995, 8, 5),
-        max_date_allowed=dt(2017, 9, 19),
-        initial_visible_month=dt(2017, 8, 5),
+        min_date_allowed=dt(1995, 8, 5).date(),
+        max_date_allowed=dt(2017, 9, 19).date(),
+        initial_visible_month=dt(2017, 8, 5).date(),
         end_date=dt(2017, 8, 25).date()
     ),
     html.Div(id='output-container-date-picker-range')
@@ -26,12 +26,12 @@ app.layout = html.Div([
 def update_output(start_date, end_date):
     string_prefix = 'You have selected: '
     if start_date is not None:
-        start_date = dt.strptime(re.split('T| ', start_date)[0], '%Y-%m-%d')
-        start_date_string = start_date.strftime('%B %d, %Y')
+        start_date_object = dt.strptime(start_date, '%Y-%m-%d')
+        start_date_string = start_date_object.strftime('%B %d, %Y')
         string_prefix = string_prefix + 'Start Date: ' + start_date_string + ' | '
     if end_date is not None:
-        end_date = dt.strptime(re.split('T| ', end_date)[0], '%Y-%m-%d')
-        end_date_string = end_date.strftime('%B %d, %Y')
+        end_date_object = dt.strptime(end_date, '%Y-%m-%d')
+        end_date_string = end_date_object.strftime('%B %d, %Y')
         string_prefix = string_prefix + 'End Date: ' + end_date_string
     if len(string_prefix) == len('You have selected: '):
         return 'Select a date to see it displayed here'

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/examples/date_picker_range.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/examples/date_picker_range.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt
+from datetime import date
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
@@ -10,10 +10,10 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 app.layout = html.Div([
     dcc.DatePickerRange(
         id='my-date-picker-range',
-        min_date_allowed=dt(1995, 8, 5).date(),
-        max_date_allowed=dt(2017, 9, 19).date(),
-        initial_visible_month=dt(2017, 8, 5).date(),
-        end_date=dt(2017, 8, 25).date()
+        min_date_allowed=date(1995, 8, 5),
+        max_date_allowed=date(2017, 9, 19),
+        initial_visible_month=date(2017, 8, 5),
+        end_date=date(2017, 8, 25)
     ),
     html.Div(id='output-container-date-picker-range')
 ])
@@ -26,11 +26,11 @@ app.layout = html.Div([
 def update_output(start_date, end_date):
     string_prefix = 'You have selected: '
     if start_date is not None:
-        start_date_object = dt.strptime(start_date, '%Y-%m-%d')
+        start_date_object = date.fromisoformat(start_date)
         start_date_string = start_date_object.strftime('%B %d, %Y')
         string_prefix = string_prefix + 'Start Date: ' + start_date_string + ' | '
     if end_date is not None:
-        end_date_object = dt.strptime(end_date, '%Y-%m-%d')
+        end_date_object = date.fromisoformat(end_date)
         end_date_string = end_date_object.strftime('%B %d, %Y')
         string_prefix = string_prefix + 'End Date: ' + end_date_string
     if len(string_prefix) == len('You have selected: '):

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -19,7 +19,7 @@ layout = html.Div(children=[
         dates to Dash components. Strings are preferred because that's the form
         dates take as callback arguments. If you are using date objects, we
         recommend using `datetime.date` so there is no time part.
-        DatePickerSingle will accept dates with a time part, but this can
+        DatePickerRangewill accept dates with a time part, but this can
         be confusing, particularly for the initial call of a callback. After
         the user chooses a new date there will be no time part, only the date.
         If you already have a `datetime.datetime` object, you can  easily convert

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -111,36 +111,36 @@ layout = html.Div(children=[
                  shown in the table above to change how selected dates are \
                  displayed in the `DatePickerRange` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21),
+    end_date=date(2017,6,21),
     display_format='MMM Do, YY',
     start_date_placeholder_text='MMM Do, YY'
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21),
+    end_date=date(2017,6,21),
     display_format='M-D-Y-Q',
     start_date_placeholder_text='M-D-Y-Q'
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21),
+    end_date=date(2017,6,21),
     display_format='MMMM Y, DD',
     start_date_placeholder_text='MMMM Y, DD'
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21),
+    end_date=date(2017,6,21),
     display_format='X',
     start_date_placeholder_text='X'
 )''', style=styles.code_container),
@@ -153,36 +153,36 @@ dcc.DatePickerRange(
                  shown in the table above to change how calendar titles \
                  are displayed in the `DatePickerRange` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     month_format='MMM Do, YY',
     end_date_placeholder_text='MMM Do, YY',
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     month_format='M-D-Y-Q',
     end_date_placeholder_text='M-D-Y-Q',
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     month_format='MMMM Y',
     end_date_placeholder_text='MMMM Y',
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     month_format='X',
     end_date_placeholder_text='X',
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )'''),
 
     html.Hr(),
@@ -198,7 +198,7 @@ dcc.DatePickerRange(
                   defined in the calendar input boxes when no date is \
                   selected."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     start_date_placeholder_text="Start Period",
@@ -220,13 +220,13 @@ dcc.DatePickerRange(
                   (`with_full_screen_portal`) and another being a simple \
                   screen overlay, like the one shown below (`with_portal`)."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     minimum_nights=5,
     clearable=True,
     with_portal=True,
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )'''),
 
     html.Hr(),
@@ -239,12 +239,12 @@ dcc.DatePickerRange(
                   day of the week. In the example below, Tuesday is \
                   the first day of the week."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     is_RTL=True,
     first_day_of_week=3,
-    start_date=dt(2017,6,21)
+    start_date=date(2017,6,21)
 )''', style=styles.code_container),
     html.Hr(),
     html.H3('DatePickerRange Properties'),

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -17,7 +17,11 @@ layout = html.Div(children=[
                 `YYYY-MM-DD` or date objects from the `datetime` module to provide \
                 dates to Dash components. Strings are preferred because that's the form \
                 dates take as callback arguments. If you are using date objects, we \
-                recommend using `datetime.date` so there is no time part. If you already \
+                recommend using `datetime.date` so there is no time part. \
+                DatePickerSingle will accept dates with a time part, but this can \
+                be confusing, particularly for the initial call of a callback. After \
+                the user chooses a new date there will be no time part, only the date. \
+                If you already \
                 have a `datetime.datetime` object, you can  easily convert it with \
                 `.date()`.  The `min_date_allowed` and `max_date_allowed` \
                 properties define the minimum and maximum selectable dates on the calendar \

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -106,16 +106,16 @@ layout = html.Div(children=[
                  shown in the table above to change how selected dates are \
                  displayed in the `DatePickerRange` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
-    end_date=dt(2017,6,21,23,59,59,999999),
+    end_date=dt(2017,6,21),
     display_format='MMM Do, YY',
     start_date_placeholder_text='MMM Do, YY'
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 dcc.DatePickerRange(
     end_date=dt(2017,6,21),
     display_format='M-D-Y-Q',
@@ -123,7 +123,7 @@ dcc.DatePickerRange(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     end_date=dt(2017,6,21),
@@ -132,7 +132,7 @@ dcc.DatePickerRange(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     end_date=dt(2017,6,21),
@@ -148,7 +148,7 @@ dcc.DatePickerRange(
                  shown in the table above to change how calendar titles \
                  are displayed in the `DatePickerRange` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     month_format='MMM Do, YY',
@@ -156,7 +156,7 @@ dcc.DatePickerRange(
     start_date=dt(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     month_format='M-D-Y-Q',
@@ -164,7 +164,7 @@ dcc.DatePickerRange(
     start_date=dt(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     month_format='MMMM Y',
@@ -172,7 +172,7 @@ dcc.DatePickerRange(
     start_date=dt(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     month_format='X',
@@ -193,7 +193,7 @@ dcc.DatePickerRange(
                   defined in the calendar input boxes when no date is \
                   selected."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     start_date_placeholder_text="Start Period",
@@ -215,7 +215,7 @@ dcc.DatePickerRange(
                   (`with_full_screen_portal`) and another being a simple \
                   screen overlay, like the one shown below (`with_portal`)."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     minimum_nights=5,
@@ -234,7 +234,7 @@ dcc.DatePickerRange(
                   day of the week. In the example below, Tuesday is \
                   the first day of the week."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     is_RTL=True,

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -19,7 +19,7 @@ layout = html.Div(children=[
         dates to Dash components. Strings are preferred because that's the form
         dates take as callback arguments. If you are using date objects, we
         recommend using `datetime.date` so there is no time part.
-        DatePickerRangewill accept dates with a time part, but this can
+        DatePickerRange will accept dates with a time part, but this can
         be confusing, particularly for the initial call of a callback. After
         the user chooses a new date there will be no time part, only the date.
         If you already have a `datetime.datetime` object, you can  easily convert

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -13,12 +13,17 @@ layout = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerRange Example"),
     rc.Markdown("This is a simple example of a `DatePickerRange` \
-                 component tied to a callback. The `min_date_allowed` and \
-                 `max_date_allowed` properties define the minimum and \
-                 maximum selectable \
-                 dates on the calendar while `initial_visible_month` defines \
-                 the calendar month that is first displayed when the \
-                 `DatePickerRange` component is opened."),
+                 component tied to a callback. You can use either strings in the form \
+                `YYYY-MM-DD` or date objects from the `datetime` module to provide \
+                dates to Dash components. Strings are preferred because that's the form \
+                dates take as callback arguments. If you are using date objects, we \
+                recommend using `datetime.date` so there is no time part. If you already \
+                have a `datetime.datetime` object, you can  easily convert it with \
+                `.date()`.  The `min_date_allowed` and `max_date_allowed` \
+                properties define the minimum and maximum selectable dates on the calendar \
+                while `initial_visible_month` defines the calendar month that is \
+                first displayed when the `DatePickerRange` component is opened."),
+                 
     rc.Markdown(
         examples['date_picker_range.py'][0],
         style=styles.code_container

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -12,22 +12,22 @@ layout = html.Div(children=[
     html.H1("DatePickerRange Examples and Reference"),
     html.Hr(),
     html.H3("Simple DatePickerRange Example"),
-    rc.Markdown("This is a simple example of a `DatePickerRange` \
-                 component tied to a callback. You can use either strings in the form \
-                `YYYY-MM-DD` or date objects from the `datetime` module to provide \
-                dates to Dash components. Strings are preferred because that's the form \
-                dates take as callback arguments. If you are using date objects, we \
-                recommend using `datetime.date` so there is no time part. \
-                DatePickerSingle will accept dates with a time part, but this can \
-                be confusing, particularly for the initial call of a callback. After \
-                the user chooses a new date there will be no time part, only the date. \
-                If you already \
-                have a `datetime.datetime` object, you can  easily convert it with \
-                `.date()`.  The `min_date_allowed` and `max_date_allowed` \
-                properties define the minimum and maximum selectable dates on the calendar \
-                while `initial_visible_month` defines the calendar month that is \
-                first displayed when the `DatePickerRange` component is opened."),
-                 
+    rc.Markdown("""
+        This is a simple example of a `DatePickerRange`
+        component tied to a callback. You can use either strings in the form
+        `YYYY-MM-DD` or date objects from the `datetime` module to provide
+        dates to Dash components. Strings are preferred because that's the form
+        dates take as callback arguments. If you are using date objects, we
+        recommend using `datetime.date` so there is no time part.
+        DatePickerSingle will accept dates with a time part, but this can
+        be confusing, particularly for the initial call of a callback. After
+        the user chooses a new date there will be no time part, only the date.
+        If you already have a `datetime.datetime` object, you can  easily convert
+        it with `.date()`.  The `min_date_allowed` and `max_date_allowed`
+        properties define the minimum and maximum selectable dates on the calendar
+        while `initial_visible_month` defines the calendar month that is
+        first displayed when the `DatePickerRange` component is opened.
+    """),           
     rc.Markdown(
         examples['date_picker_range.py'][0],
         style=styles.code_container
@@ -39,14 +39,18 @@ layout = html.Div(children=[
     ),
     html.Hr(),
     html.H3('Month and Display Format'),
-    rc.Markdown("The `display_format` property \
-                 determines how selected dates are displayed \
-                 in the `DatePickerRange` component. The `month_format` \
-                 property determines how calendar headers are displayed when \
-                 the calendar is opened."),
-    html.P("Both of these properties are configured through \
-            strings that utilize a combination of any \
-            of the following tokens."),
+    rc.Markdown("""
+        The `display_format` property
+        determines how selected dates are displayed
+        in the `DatePickerRange` component. The `month_format`
+        property determines how calendar headers are displayed when
+        the calendar is opened.
+    """),
+    html.P("""
+        Both of these properties are configured through
+        strings that utilize a combination of any
+        of the following tokens.
+    """),
     html.Table([
         html.Tr([
             html.Th('String Token', style={'text-align': 'left', 'width': '20%'}),
@@ -111,9 +115,11 @@ layout = html.Div(children=[
     ]),
     html.Br(),
     html.H3("Display Format Examples"),
-    rc.Markdown("You can utilize any permutation of the string tokens \
-                 shown in the table above to change how selected dates are \
-                 displayed in the `DatePickerRange` component."),
+    rc.Markdown("""
+        You can utilize any permutation of the string tokens
+        shown in the table above to change how selected dates are
+        displayed in the `DatePickerRange` component.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -152,10 +158,12 @@ dcc.DatePickerRange(
     html.Br(),
 
     html.H3("Month Format Examples"),
-    rc.Markdown("Similar to the `display_format`, you can set `month_format` \
-                 to any permutation of the string tokens \
-                 shown in the table above to change how calendar titles \
-                 are displayed in the `DatePickerRange` component."),
+    rc.Markdown("""
+        Similar to the `display_format`, you can set `month_format`
+        to any permutation of the string tokens
+        shown in the table above to change how calendar titles
+        are displayed in the `DatePickerRange` component.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -192,15 +200,19 @@ dcc.DatePickerRange(
     html.Hr(),
 
     html.H3("Vertical Calendar and Placeholder Text"),
-    rc.Markdown("The `DatePickerRange` component can be rendered in two \
-                  orientations, either horizontally or vertically. \
-                  If `calendar_orientation` is set to `'vertical'`, it will \
-                  be rendered vertically and will default to `'horizontal'` \
-                  if not defined."),
-    rc.Markdown("The `start_date_placeholder_text` and \
-                  `end_date_placeholder_text` define the grey default text \
-                  defined in the calendar input boxes when no date is \
-                  selected."),
+    rc.Markdown("""
+        The `DatePickerRange` component can be rendered in two
+        orientations, either horizontally or vertically.
+        If `calendar_orientation` is set to `'vertical'`, it will
+        be rendered vertically and will default to `'horizontal'`
+        if not defined.
+    """),
+    rc.Markdown("""
+        The `start_date_placeholder_text` and
+        `end_date_placeholder_text` define the grey default text
+        defined in the calendar input boxes when no date is
+        selected.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 
 dcc.DatePickerRange(
@@ -212,16 +224,22 @@ dcc.DatePickerRange(
     html.Hr(),
 
     html.H3("Minimum Nights, Calendar Clear, and Portals"),
-    rc.Markdown("The `minimum_nights` property defines the number of \
-                  nights that must be in between the range of two \
-                  selected dates."),
-    rc.Markdown("When the `clearable` property is set to `True` \
-                  the component will be rendered with a small 'x' \
-                  that will remove all selected dates when selected."),
-    rc.Markdown("The `DatePickerRange` component supports two different \
-                  portal types, one being a full screen portal \
-                  (`with_full_screen_portal`) and another being a simple \
-                  screen overlay, like the one shown below (`with_portal`)."),
+    rc.Markdown("""
+        The `minimum_nights` property defines the number of
+        nights that must be in between the range of two
+        selected dates.
+    """),
+    rc.Markdown("""
+        When the `clearable` property is set to `True`
+        the component will be rendered with a small 'x'
+        that will remove all selected dates when selected.
+    """),
+    rc.Markdown("""
+        The `DatePickerRange` component supports two different
+        portal types, one being a full screen portal
+        (`with_full_screen_portal`) and another being a simple
+        screen overlay, like the one shown below (`with_portal`).
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -235,12 +253,16 @@ dcc.DatePickerRange(
     html.Hr(),
 
     html.H3("Right to Left Calendars and First Day of Week"),
-    rc.Markdown("When the `is_RTL` property is set to `True` \
-                  the calendar will be rendered from right to left."),
-    rc.Markdown("The `first_day_of_week` property allows you to \
-                  define which day of the week will be set as the first \
-                  day of the week. In the example below, Tuesday is \
-                  the first day of the week."),
+    rc.Markdown("""
+        When the `is_RTL` property is set to `True`
+        the calendar will be rendered from right to left.
+    """),
+    rc.Markdown("""
+        The `first_day_of_week` property allows you to
+        define which day of the week will be set as the first
+        day of the week. In the example below, Tuesday is
+        the first day of the week.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 

--- a/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerRange/index.py
@@ -198,7 +198,6 @@ dcc.DatePickerRange(
                   defined in the calendar input boxes when no date is \
                   selected."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date
 
 dcc.DatePickerRange(
     start_date_placeholder_text="Start Period",

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/examples/date_picker_single.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/examples/date_picker_single.py
@@ -11,10 +11,10 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 app.layout = html.Div([
     dcc.DatePickerSingle(
         id='my-date-picker-single',
-        min_date_allowed=dt(1995, 8, 5),
-        max_date_allowed=dt(2017, 9, 19),
-        initial_visible_month=dt(2017, 8, 5),
-        date=str(dt(2017, 8, 25, 23, 59, 59))
+        min_date_allowed=dt(1995, 8, 5).date(),
+        max_date_allowed=dt(2017, 9, 19).date(),
+        initial_visible_month=dt(2017, 8, 5).date(),
+        date=dt(2017, 8, 25, 23, 59, 59).date()
     ),
     html.Div(id='output-container-date-picker-single')
 ])
@@ -26,8 +26,8 @@ app.layout = html.Div([
 def update_output(date):
     string_prefix = 'You have selected: '
     if date is not None:
-        date = dt.strptime(re.split('T| ', date)[0], '%Y-%m-%d')
-        date_string = date.strftime('%B %d, %Y')
+        date_object = dt.strptime(date, '%Y-%m-%d')
+        date_string = date_object.strftime('%B %d, %Y')
         return string_prefix + date_string
 
 

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/examples/date_picker_single.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/examples/date_picker_single.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt
+from datetime import date
 import dash
 from dash.dependencies import Input, Output
 import dash_html_components as html
@@ -11,10 +11,10 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 app.layout = html.Div([
     dcc.DatePickerSingle(
         id='my-date-picker-single',
-        min_date_allowed=dt(1995, 8, 5).date(),
-        max_date_allowed=dt(2017, 9, 19).date(),
-        initial_visible_month=dt(2017, 8, 5).date(),
-        date=dt(2017, 8, 25, 23, 59, 59).date()
+        min_date_allowed=date(1995, 8, 5),
+        max_date_allowed=date(2017, 9, 19),
+        initial_visible_month=date(2017, 8, 5),
+        date=date(2017, 8, 25)
     ),
     html.Div(id='output-container-date-picker-single')
 ])
@@ -23,13 +23,12 @@ app.layout = html.Div([
 @app.callback(
     Output('output-container-date-picker-single', 'children'),
     [Input('my-date-picker-single', 'date')])
-def update_output(date):
+def update_output(date_value):
     string_prefix = 'You have selected: '
-    if date is not None:
-        date_object = dt.strptime(date, '%Y-%m-%d')
+    if date_value is not None:
+        date_object = date.fromisoformat(date_value)
         date_string = date_object.strftime('%B %d, %Y')
         return string_prefix + date_string
-
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -115,7 +115,7 @@ layout = html.Div(children=[
                  shown in the table above to change how selected dates are \
                  displayed in the `DatePickerSingle` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     date='2017-06-21',
@@ -123,26 +123,26 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
-    date=dt(2017,6,21),
+    date=date(2017,6,21),
     display_format='M-D-Y-Q',
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
-    date=dt(2017,6,21),
+    date=date(2017,6,21),
     display_format='MMMM Y, DD'
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
-    date=dt(2017,6,21),
+    date=date(2017,6,21),
     display_format='X',
 )''', style=styles.code_container),
     html.Br(),
@@ -152,20 +152,20 @@ dcc.DatePickerSingle(
                  shown in the table above to change how calendar titles \
                  are displayed in the `DatePickerSingle` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     month_format='MMM Do, YY',
     placeholder='MMM Do, YY',
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     month_format='M-D-Y-Q',
     placeholder='M-D-Y-Q',
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
@@ -178,12 +178,12 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     month_format='X',
     placeholder='X',
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )''', style=styles.code_container),
     html.Hr(),
     html.H3("Vertical Calendar and Placeholder Text"),
@@ -196,12 +196,12 @@ dcc.DatePickerSingle(
                   text defined in the calendar input boxes when no date is \
                   selected."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     calendar_orientation='vertical',
     placeholder='Select a date',
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )'''),
 
     html.Hr(),
@@ -215,12 +215,12 @@ dcc.DatePickerSingle(
                   (`with_full_screen_portal`) and another being a simple \
                   screen overlay, like the one shown below (`with_portal`)."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     clearable=True,
     with_portal=True,
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )'''),
 
     html.Hr(),
@@ -233,12 +233,12 @@ dcc.DatePickerSingle(
                   day of the week. In the example below, Tuesday is \
                   the first day of the week."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     is_RTL=True,
     first_day_of_week=3,
-    date=dt(2017,6,21)
+    date=date(2017,6,21)
 )'''),
 
     html.Hr(),

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -114,7 +114,7 @@ layout = html.Div(children=[
                  shown in the table above to change how selected dates are \
                  displayed in the `DatePickerSingle` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     date='2017-06-21',
@@ -122,7 +122,7 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     date=dt(2017,6,21),
@@ -130,7 +130,7 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     date=dt(2017,6,21),
@@ -138,7 +138,7 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     date=dt(2017,6,21),
@@ -151,7 +151,7 @@ dcc.DatePickerSingle(
                  shown in the table above to change how calendar titles \
                  are displayed in the `DatePickerSingle` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     month_format='MMM Do, YY',
@@ -159,7 +159,7 @@ dcc.DatePickerSingle(
     date=dt(2017,6,21)
 )'''),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     month_format='M-D-Y-Q',
@@ -177,12 +177,12 @@ dcc.DatePickerSingle(
 )'''),
 
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     month_format='X',
     placeholder='X',
-    date=dt(2017,6,21,0,0,0,0)
+    date=dt(2017,6,21)
 )''', style=styles.code_container),
     html.Hr(),
     html.H3("Vertical Calendar and Placeholder Text"),
@@ -195,7 +195,7 @@ dcc.DatePickerSingle(
                   text defined in the calendar input boxes when no date is \
                   selected."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     calendar_orientation='vertical',
@@ -214,7 +214,7 @@ dcc.DatePickerSingle(
                   (`with_full_screen_portal`) and another being a simple \
                   screen overlay, like the one shown below (`with_portal`)."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     clearable=True,
@@ -232,7 +232,7 @@ dcc.DatePickerSingle(
                   day of the week. In the example below, Tuesday is \
                   the first day of the week."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     is_RTL=True,

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -115,7 +115,6 @@ layout = html.Div(children=[
                  shown in the table above to change how selected dates are \
                  displayed in the `DatePickerSingle` component."),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date
 
 dcc.DatePickerSingle(
     date='2017-06-21',

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -14,12 +14,13 @@ layout = html.Div(children=[
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
     rc.Markdown("This is a simple example of a `DatePickerSingle` \
-        component tied to a callback. You can use either date objects \
-        (`datetime.date` or `datetime.datetime`) or strings in the form \
-        `YYYY-MM-DD` to provide dates to Dash components. Strings are \
-        preferred because that's the form dates take as callback arguments. \
-        Be aware that any time information included in a datetime object \
-        or string will be ignored. The `min_date_allowed` and `max_date_allowed` \
+        component tied to a callback. You can use either strings in the form \
+        `YYYY-MM-DD` or date objects from the `datetime` module to provide \
+        dates to Dash components. Strings are preferred because that's the form \
+        dates take as callback arguments. If you are using date objects, we \
+        recommend using `datetime.date` so there is no time part. If you already \
+        have a `datetime.datetime` object, you can  easily convert it with \
+        `.date()`.  The `min_date_allowed` and `max_date_allowed` \
         properties define the minimum and maximum selectable dates on the calendar \
         while `initial_visible_month` defines the calendar month that is \
         first displayed when the `DatePickerSingle` component is opened."),

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -13,21 +13,22 @@ layout = html.Div(children=[
     html.H1("DatePickerSingle Examples and Reference"),
     html.Hr(),
     html.H3("Simple DatePickerSingle Example"),
-    rc.Markdown("This is a simple example of a `DatePickerSingle` \
-        component tied to a callback. You can use either strings in the form \
-        `YYYY-MM-DD` or date objects from the `datetime` module to provide \
-        dates to Dash components. Strings are preferred because that's the form \
-        dates take as callback arguments. If you are using date objects, we \
-        recommend using `datetime.date` so there is no time part. \
-        DatePickerSingle will accept dates with a time part, but this can \
-        be confusing, particularly for the initial call of a callback. After \
-        the user chooses a new date there will be no time part, only the date. \
-        If you already \
-        have a `datetime.datetime` object, you can  easily convert it with \
-        `.date()`.  The `min_date_allowed` and `max_date_allowed` \
-        properties define the minimum and maximum selectable dates on the calendar \
-        while `initial_visible_month` defines the calendar month that is \
-        first displayed when the `DatePickerSingle` component is opened."),
+    rc.Markdown("""
+        This is a simple example of a `DatePickerSingle`
+        component tied to a callback. You can use either strings in the form
+        `YYYY-MM-DD` or date objects from the `datetime` module to provide
+        dates to Dash components. Strings are preferred because that's the form
+        dates take as callback arguments. If you are using date objects, we
+        recommend using `datetime.date` so there is no time part.
+        DatePickerSingle will accept dates with a time part, but this can
+        be confusing, particularly for the initial call of a callback. After
+        the user chooses a new date there will be no time part, only the date.
+        If you already have a `datetime.datetime` object, you can  easily convert
+        it with `.date()`.  The `min_date_allowed` and `max_date_allowed`
+        properties define the minimum and maximum selectable dates on the calendar
+        while `initial_visible_month` defines the calendar month that is
+        first displayed when the `DatePickerSingle` component is opened.
+    """),
     rc.Markdown(
         examples['date_picker_single.py'][0],
         style=styles.code_container
@@ -41,14 +42,18 @@ layout = html.Div(children=[
     html.Hr(),
 
     html.H3('Month and Display Format'),
-    rc.Markdown("The `display_format` property \
-                 determines how selected dates are displayed \
-                 in the `DatePickerSingle` component. The `month_format` \
-                 property determines how calendar headers are displayed when \
-                 the calendar is opened."),
-    html.P("Both of these properties are configured through \
-            strings that utilize a combination of any \
-            of the following tokens."),
+    rc.Markdown("""
+        The `display_format` property
+        determines how selected dates are displayed
+        in the `DatePickerSingle` component. The `month_format`
+        property determines how calendar headers are displayed when
+        the calendar is opened.
+    """),
+    html.P("""
+        Both of these properties are configured through
+        strings that utilize a combination of any
+        of the following tokens.
+    """),
     html.Table([
         html.Tr([
             html.Th('String Token', style={'text-align': 'left', 'width': '20%'}),
@@ -115,9 +120,11 @@ layout = html.Div(children=[
     html.Br(),
 
     html.H3("Display Format Examples"),
-    rc.Markdown("You can utilize any permutation of the string tokens \
-                 shown in the table above to change how selected dates are \
-                 displayed in the `DatePickerSingle` component."),
+    rc.Markdown("""
+        You can utilize any permutation of the string tokens
+        shown in the table above to change how selected dates are
+        displayed in the `DatePickerSingle` component.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 
 dcc.DatePickerSingle(
@@ -150,10 +157,12 @@ dcc.DatePickerSingle(
 )''', style=styles.code_container),
     html.Br(),
     html.H3("Month Format Examples"),
-    rc.Markdown("Similar to the `display_format`, you can set `month_format` \
-                 to any permutation of the string tokens \
-                 shown in the table above to change how calendar titles \
-                 are displayed in the `DatePickerSingle` component."),
+    rc.Markdown("""
+        Similar to the `display_format`, you can set `month_format`
+        to any permutation of the string tokens
+        shown in the table above to change how calendar titles
+        are displayed in the `DatePickerSingle` component.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -190,14 +199,18 @@ dcc.DatePickerSingle(
 )''', style=styles.code_container),
     html.Hr(),
     html.H3("Vertical Calendar and Placeholder Text"),
-    rc.Markdown("The `DatePickerSingle` component can be rendered in two \
-                  orientations, either horizontally or vertically. \
-                  If `calendar_orientation` is set to `'vertical'`, it will \
-                  be rendered vertically and will default to `'horizontal'` \
-                  if not defined."),
-    rc.Markdown("The `placeholder` defines the grey default \
-                  text defined in the calendar input boxes when no date is \
-                  selected."),
+    rc.Markdown("""
+        The `DatePickerSingle` component can be rendered in two
+        orientations, either horizontally or vertically.
+        If `calendar_orientation` is set to `'vertical'`, it will
+        be rendered vertically and will default to `'horizontal'`
+        if not defined.
+    """),
+    rc.Markdown("""
+        The `placeholder` defines the grey default
+        text defined in the calendar input boxes when no date is
+        selected.
+        """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -210,13 +223,17 @@ dcc.DatePickerSingle(
     html.Hr(),
 
     html.H3("Calendar Clear and Portals"),
-    rc.Markdown("When the `clearable` property is set to `True` \
-                  the component will be rendered with a small 'x' \
-                  that will remove all selected dates when selected."),
-    rc.Markdown("The `DatePickerSingle` component supports two different \
-                  portal types, one being a full screen portal \
-                  (`with_full_screen_portal`) and another being a simple \
-                  screen overlay, like the one shown below (`with_portal`)."),
+    rc.Markdown("""
+        When the `clearable` property is set to `True`
+        the component will be rendered with a small 'x'
+        that will remove all selected dates when selected.
+    """),
+    rc.Markdown("""
+        The `DatePickerSingle` component supports two different
+        portal types, one being a full screen portal
+        (`with_full_screen_portal`) and another being a simple
+        screen overlay, like the one shown below (`with_portal`).
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 
@@ -229,12 +246,16 @@ dcc.DatePickerSingle(
     html.Hr(),
 
     html.H3("Right to Left Calendars and First Day of Week"),
-    rc.Markdown("When the `is_RTL` property is set to `True` \
-                  the calendar will be rendered from right to left."),
-    rc.Markdown("The `first_day_of_week` property allows you to \
-                  define which day of the week will be set as the first \
-                  day of the week. In the example below, Tuesday is \
-                  the first day of the week."),
+    rc.Markdown("""
+        When the `is_RTL` property is set to `True` 
+        the calendar will be rendered from right to left.
+    """),
+    rc.Markdown("""
+        The `first_day_of_week` property allows you to
+        define which day of the week will be set as the first
+        day of the week. In the example below, Tuesday is
+        the first day of the week.
+    """),
     rc.ComponentBlock('''import dash_core_components as dcc
 from datetime import date
 

--- a/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
+++ b/dash_docs/chapters/dash_core_components/DatePickerSingle/index.py
@@ -18,7 +18,11 @@ layout = html.Div(children=[
         `YYYY-MM-DD` or date objects from the `datetime` module to provide \
         dates to Dash components. Strings are preferred because that's the form \
         dates take as callback arguments. If you are using date objects, we \
-        recommend using `datetime.date` so there is no time part. If you already \
+        recommend using `datetime.date` so there is no time part. \
+        DatePickerSingle will accept dates with a time part, but this can \
+        be confusing, particularly for the initial call of a callback. After \
+        the user chooses a new date there will be no time part, only the date. \
+        If you already \
         have a `datetime.datetime` object, you can  easily convert it with \
         `.date()`.  The `min_date_allowed` and `max_date_allowed` \
         properties define the minimum and maximum selectable dates on the calendar \

--- a/dash_docs/chapters/dash_core_components/index.py
+++ b/dash_docs/chapters/dash_core_components/index.py
@@ -225,7 +225,7 @@ dcc.RadioItems(
 
     html.H2(dcc.Link('DatePickerSingle', href=tools.relpath('/dash-core-components/datepickersingle'))),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerSingle(
     id='date-picker-single',
@@ -238,7 +238,7 @@ dcc.DatePickerSingle(
 
     html.H2(dcc.Link('DatePickerRange', href=tools.relpath('/dash-core-components/datepickerrange'))),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import datetime as dt
+from datetime import date as dt
 
 dcc.DatePickerRange(
     id='date-picker-range',

--- a/dash_docs/chapters/dash_core_components/index.py
+++ b/dash_docs/chapters/dash_core_components/index.py
@@ -225,11 +225,11 @@ dcc.RadioItems(
 
     html.H2(dcc.Link('DatePickerSingle', href=tools.relpath('/dash-core-components/datepickersingle'))),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerSingle(
     id='date-picker-single',
-    date=dt(1997, 5, 10)
+    date=date(1997, 5, 10)
 )
 ''', style=styles.code_container),
     dcc.Link('More DatePickerSingle Examples and Reference',
@@ -238,11 +238,11 @@ dcc.DatePickerSingle(
 
     html.H2(dcc.Link('DatePickerRange', href=tools.relpath('/dash-core-components/datepickerrange'))),
     rc.ComponentBlock('''import dash_core_components as dcc
-from datetime import date as dt
+from datetime import date
 
 dcc.DatePickerRange(
     id='date-picker-range',
-    start_date=dt(1997, 5, 3),
+    start_date=date(1997, 5, 3),
     end_date_placeholder_text='Select a date!'
 )
 ''', style=styles.code_container),


### PR DESCRIPTION
Fixes https://github.com/plotly/dash-core-components/issues/781 by adding documentation to explain proper usage of `datetime.date`, `datetime.datetime`, and strings for `DatePickerSingle` and `DatePickerRange`. Descriptions of usage and the inline examples have been updated.

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand
