### PR TITLE
Keep sidebar ad in the lower left corner as the sidebar scrolls over it

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -138,7 +138,6 @@ h6 { font-size: 20px; line-height: 1.6;  margin-bottom: 0.75rem; margin-top: 0.7
     max-width: 250px;
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 60px);
     justify-content: space-between;
 }
 
@@ -225,18 +224,17 @@ summary:hover {
     margin-bottom: 10px;
 }
 
-.sidebar {
-    overflow-y: auto;
+.sidebar-image-link {
+    position: -webkit-sticky;
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    background-color: #e4f5f2;
 }
 
 .sidebar-image {
-   width: calc(100% - 4px);
-}
-
-#fade-out {
-    height: 30px;
-    margin-right: -2px;
-    background-image: linear-gradient(to bottom, rgb(224, 242, 246), white);
+   width: calc(100% - 7px);
+   margin: 2px 5px 2px 0;
 }
 
 

--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -47,7 +47,7 @@ header = html.Div(
                 ), href='/', id='logo-home'),
             ], className='logo'),
 
-            # HEADS UP! 
+            # HEADS UP!
             # If you are modifying these header links,
             # make sure to check that the responsive design still works
             # The breakpoints are set in override.css
@@ -64,11 +64,11 @@ header = html.Div(
                         'verticalAlign': 'middle',
                         'marginTop': '9px',
                         'width': '120px',
-                    } 
+                    }
                 ),
-                html.A('dash enterprise demo', className='links--demo-button', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo', 
+                html.A('dash enterprise demo', className='links--demo-button', href='https://plotly.com/get-demo/?utm_source=docs&utm_medium=banner&utm_campaign=sept&utm_content=demo',
                     style={
-                        'background-color': '#f4564e', 
+                        'background-color': '#f4564e',
                         'border-radius': '1.22rem',
                         'color': 'white',
                         'cursor': 'pointer',
@@ -87,7 +87,7 @@ header = html.Div(
                         'transition': 'background-color .2s ease-in-out'
                     }
                 ),
-            ]),           
+            ]),
         ]
     )
 )
@@ -112,15 +112,17 @@ app.layout = html.Div(
         html.Div(className='content-wrapper', children=[
             html.Div([
                 dugc.Sidebar(urls=SIDEBAR_INDEX),
-                html.A([
+                html.A(
                     html.Img(
                         id='sidebar-image-img',
                         className='sidebar-image',
                         src=DEFAULT_AD['src'],
                         alt=DEFAULT_AD['alt']
                     ),
-                    html.Div(id='fade-out')
-                ], id='sidebar-image-link', href=DEFAULT_AD['href']),
+                    id='sidebar-image-link',
+                    className='sidebar-image-link',
+                    href=DEFAULT_AD['href']
+                ),
             ], className='sidebar-container'),
 
             html.Div([


### PR DESCRIPTION
That way there's only one thing to scroll on the page, so it's easier to find things in the sidebar. As opposed to right now, you have to scroll to the top in order to _see_ the sidebar menu, then if it's long because you opened some sections you have to scroll around in it.

Also this keeps the ad permanently in the corner, though that wasn't the primary purpose from my standpoint.

- [x] tested responsive behavior is still 👌 

@chriddyp what do you think? cc @jingningzhang1 