### PR TITLE
Tool to build dash docs chapter from notebook + WIP chapter on image annotation

### DIFF
--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -245,6 +245,7 @@ URLS = [
             '/dash-bio/'
             '/dash-daq/',
             '/canvas/',
+            '/annotations/',
             '/cytoscape/'
         ],
         'chapters': [
@@ -545,6 +546,21 @@ URLS = [
                     }
                 ]
             },
+            {
+                'name': 'Dash Image annotations',
+                'chapters': [
+                    {
+                        'url': '/annotations',
+                        'name': 'Overview & Reference',
+                        'content': chapters.dash_annotations.index.layout,
+                        'description': (
+                            'Image rendering, drawing, annotations '
+                            'for image processing applications.'
+                        )
+                    }
+                ]
+            },
+
 
             {
                 'name': 'Dash Cytoscape',

--- a/dash_docs/chapters/__init__.py
+++ b/dash_docs/chapters/__init__.py
@@ -1,6 +1,7 @@
 import os
 from .import basic_callbacks
 from .import auth
+from .import dash_annotations
 from .import dash_core_components
 from .import dash_cytoscape
 from .import d3_react_components

--- a/dash_docs/chapters/dash_annotations/__init__.py
+++ b/dash_docs/chapters/dash_annotations/__init__.py
@@ -1,0 +1,1 @@
+from .import index

--- a/dash_docs/chapters/dash_annotations/dash-annotations.md
+++ b/dash_docs/chapters/dash_annotations/dash-annotations.md
@@ -1,0 +1,388 @@
+---
+jupyter:
+  jupytext:
+    notebook_metadata_filter: all
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.2'
+      jupytext_version: 1.3.0
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.7.3
+---
+
+<!-- #region -->
+# Image annotations with Dash
+
+
+This tutorial shows how to annotate images with different drawing tools with plotly and Dash, and how to use such annotations in Dash apps.
+
+## Annotation tools in plotly figures
+
+With the plotly graphing library, it is possible to draw annotations on Cartesian axes, which are recorded as shape elements of the figure layout. The example below shows how to configure a plotly figure in order to
+- set its dragmode to rectangle annotation 
+- modify the `config` parameter of the figure renderer so that drawing buttons are added to the modebar (so that it is possible to switch between several drawing dragmodes, or between drawing and panning/zooming).
+
+In the figure below, you can try to draw a rectangle by left-clicking and dragging, then you can try the other drawing buttons of the modebar. Also note that we have added a shape programmatically when defining the figure.
+<!-- #endregion -->
+
+## Dash callback triggered when drawing annotations
+
+When using a plotly figure in a `dcc.Graph` component in a Dash app, drawing a shape on the figure will modify the `relayoutData` property of the `dcc.Graph`. You can therefore define a callback listening to `relayoutData`. In the example below we display the content of `relayoutData` inside an `html.Pre`, so that we can inspect the structure of `relayoutData` (when developing your app, you can also just print the variable inside the callback to inspect it). 
+
+```python
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data
+import json
+
+img = data.chelsea()
+fig = px.imshow(img)
+fig.update_layout(
+    dragmode='drawrect')
+
+
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H3("Drag and draw rectangle annotations"),
+    dcc.Graph(id='graph-picture', figure=fig),
+    dcc.Markdown('Characteristics of shapes'),
+    html.Pre(id='annotations-data'),
+])
+
+
+@app.callback(
+    Output('annotations-data', 'children'),
+    [Input("graph-picture", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_new_annotation(relayout_data):
+    if 'shapes' in relayout_data:
+        return json.dumps(relayout_data['shapes'], indent=2)
+    else:
+        return dash.no_update
+
+app.run_server(mode='inline', port=8050)
+```
+
+In the example below, we add all the available drawing tools to the modebar, so that you can inspect the characteristics of drawn shapes for the different types of shapes: rectangles, circles, lines, closed and open paths. 
+
+Rectangles, circles or ellipses and lines are all defined by their bounding-box rectangle, that is by the coordinates of the start and end corners of the rectangle, `x0`, `y0`, `x1` and `y1`. 
+
+As for paths, open and closed, their geometry is defined as an SVG path. 
+
+```python
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data
+import json
+
+img = data.chelsea()
+fig = px.imshow(img)
+fig.update_layout(
+    dragmode='drawclosedpath')
+config={'modeBarButtonsToAdd':
+        ['drawline',
+         'drawopenpath',
+         'drawclosedpath',
+         'drawcircle',
+         'drawrect',
+          'eraseshape']}
+
+# Build App
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H4("Drag and draw annotations - use the modebar to pick a different drawing tool"),
+    dcc.Graph(id='graph-pic', figure=fig, config=config),
+    dcc.Markdown('Characteristics of shapes'),
+    html.Pre(id='annotations-data-pre'),
+])# Define callback to update graph
+
+@app.callback(
+    Output('annotations-data-pre', 'children'),
+    [Input("graph-pic", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_new_annotation(relayout_data):
+    if 'shapes' in relayout_data:
+        return json.dumps(relayout_data['shapes'], indent=2)
+    else:
+        return dash.no_update
+
+app.run_server(mode='inline', port=8050)
+```
+
+### Extracting an image subregion defined by an annotation
+
+Rather than the geometry of annotations, one is often interested in extracting the region of interest of the image delineated by the shape. The two examples show how to do this first for rectangles, and then for a closed path. In these two examples, the histogram of the region delineated by the latest shape is displayed.
+
+```python
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data, exposure
+import json
+
+img = data.camera()
+fig = px.imshow(img, binary_string=True)
+fig.update_layout(
+    dragmode='drawrect')
+
+fig_hist = px.histogram(img.ravel())
+
+# Build App
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H3("Drag a rectangle to show the histogram of the ROI"),
+     html.Div([
+         dcc.Graph(id='graph-pic-camera', figure=fig),
+    ], style={'width': '60%', 'display': 'inline-block', 'padding': '0 0'}),
+    
+    html.Div([
+        dcc.Graph(id='histogram', figure=fig_hist),
+    ], style={'width': '40%', 'display': 'inline-block', 'padding': '0 0'}),
+
+])# Define callback to update graph
+
+@app.callback(
+    Output('histogram', 'figure'),
+    [Input("graph-pic-camera", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_new_annotation(relayout_data):
+    if 'shapes' in relayout_data:
+        last_shape = relayout_data['shapes'][-1]
+        # shape coordinates are floats, we need to convert to ints for slicing
+        x0, y0 = int(last_shape['x0']), int(last_shape['y0'])
+        x1, y1 = int(last_shape['x1']), int(last_shape['y1'])
+        roi_img = img[y0:y1, x0:x1]
+        return px.histogram(roi_img.ravel())
+    else:
+        return dash.no_update
+
+app.run_server(mode='inline', port=8051)
+```
+
+For a path, we need the following steps
+- we retrieve the coordinates of the vertices of the path from the SVG path
+- we use the function `skimage.draw.polygon` to obtain the coordinates of pixels covered by the path
+- then we use the function `scipy.ndimage.binary_fill_holes` in order to set to `True` the pixels enclosed by the path.
+
+```python
+import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data, draw
+import json
+from scipy import ndimage
+
+def path_to_indices(path):
+    """From SVG path to numpy array of coordinates, each row being a (row, col) point
+    """
+    indices_str = [el.replace('M', '').replace(
+        'Z', '').split(',') for el in path.split('L')]
+    return np.rint(np.array(indices_str, dtype=float)).astype(np.int)
+
+def path_to_mask(path, shape):
+    """From SVG path to a boolean array where all pixels enclosed by the path
+    are True, and the other pixels are False.
+    """
+    cols, rows = path_to_indices(path).T
+    rr, cc = draw.polygon(rows, cols)
+    mask = np.zeros(shape, dtype=np.bool)
+    mask[rr, cc] = True
+    mask = ndimage.binary_fill_holes(mask)
+    return mask
+
+img = data.camera()
+fig = px.imshow(img, binary_string=True)
+fig.update_layout(
+    dragmode='drawclosedpath')
+
+fig_hist = px.histogram(img.ravel())
+
+# Build App
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H3("Draw a path to show the histogram of the ROI"),
+     html.Div([
+         dcc.Graph(id='graph-camera', figure=fig),
+    ], style={'width': '60%', 'display': 'inline-block', 'padding': '0 0'}),
+    
+    html.Div([
+        dcc.Graph(id='graph-histogram', figure=fig_hist),
+    ], style={'width': '40%', 'display': 'inline-block', 'padding': '0 0'}),
+
+])# Define callback to update graph
+
+@app.callback(
+    Output('graph-histogram', 'figure'),
+    [Input("graph-camera", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_new_annotation(relayout_data):
+    if 'shapes' in relayout_data:
+        last_shape = relayout_data['shapes'][-1]
+        mask = path_to_mask(last_shape['path'], img.shape)
+        return px.histogram(img[mask])
+    else:
+        return dash.no_update
+
+app.run_server(mode='inline', port=8052)
+```
+
+## Modifying shapes and parsing `relayoutData`
+
+When adding a new shape, the `relayoutData` variable consists in the list of all layout shapes. It is also possible to delete a shape by selecting an existing shape, and by clicking the "delete shape" button in the modebar.
+
+Also, existing shapes can be modified if their `editable` property is set to True. In the example below, you can
+- draw a shape
+- then click on the shape perimeter to select the shape
+- drag one of its vertices to modify the shape
+
+Observe that when modifying the shape, only the modified geometrical parameters are found in the `relayoutData`. 
+
+```python
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data
+import json
+
+img = data.chelsea()
+fig = px.imshow(img)
+fig.update_layout(
+    dragmode='drawclosedpath')
+config={'modeBarButtonsToAdd':
+        ['drawline',
+         'drawopenpath',
+         'drawclosedpath',
+         'drawcircle',
+         'drawrect',
+          'eraseshape']}
+
+# Build App
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H4("Draw a shape, then modify it"),
+    dcc.Graph(id='fig-image', figure=fig, config=config),
+    dcc.Markdown('Characteristics of shapes'),
+    html.Pre(id='annotations-pre'),
+])# Define callback to update graph
+
+@app.callback(
+    Output('annotations-pre', 'children'),
+    [Input("fig-image", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_new_annotation(relayout_data):
+    for key in relayout_data:
+        if 'shapes' in key:
+            return json.dumps(relayout_data[key], indent=2)
+    return dash.no_update
+   
+
+app.run_server(mode='inline', port=8053)
+```
+
+The example below extends on the previous one where the histogram of a ROI is displayed. Here, we tackle both the case where a new shape is drawn, and where an existing shape is modified.
+
+```python
+import plotly.express as px
+import plotly.graph_objects as go
+from jupyter_dash import JupyterDash
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from skimage import data, exposure
+import json
+
+
+
+img = data.camera()
+fig = px.imshow(img, binary_string=True)
+fig.update_layout(
+    dragmode='drawrect')
+
+fig_hist = px.histogram(img.ravel())
+
+# Build App
+app = JupyterDash(__name__)
+app.layout = html.Div([
+    html.H3("Draw a shape, then modify it."),
+     html.Div([
+         dcc.Graph(id='fig-pic', figure=fig),
+    ], style={'width': '60%', 'display': 'inline-block', 'padding': '0 0'}),
+    
+    html.Div([
+        dcc.Graph(id='graph-hist', figure=fig_hist),
+    ], style={'width': '40%', 'display': 'inline-block', 'padding': '0 0'}),
+    html.Pre(id='annotations'),
+])# Define callback to update graph
+
+@app.callback(
+    [Output('graph-hist', 'figure'),
+     Output('annotations', 'children')],
+    [Input("fig-pic", "relayoutData")],
+    prevent_initial_call=True
+)
+def on_relayout(relayout_data):
+    x0, y0, x1, y1 = (None,) * 4
+    if 'shapes' in relayout_data:
+        last_shape = relayout_data['shapes'][-1]
+        x0, y0 = int(last_shape['x0']), int(last_shape['y0'])
+        x1, y1 = int(last_shape['x1']), int(last_shape['y1'])
+        if x0 > x1:
+            x0, x1 = x1, x0
+        if y0 > y1:
+            y0, y1 = y1, y0
+    elif any(['shapes' in key for key in relayout_data]):
+        x0 = int([relayout_data[key] for key in relayout_data if 'x0' in key][0])
+        x1 = int([relayout_data[key] for key in relayout_data if 'x1' in key][0])
+        y0 = int([relayout_data[key] for key in relayout_data if 'y0' in key][0])
+        y1 = int([relayout_data[key] for key in relayout_data if 'y1' in key][0])
+    if all((x0, y0, x1, y1)):
+        roi_img = img[y0:y1, x0:x1]
+        return (px.histogram(roi_img.ravel()),
+                json.dumps(relayout_data, indent=2))
+    else:
+        return (dash.no_update,) * 2
+
+app.run_server(mode='inline', port=8055)
+```

--- a/dash_docs/chapters/dash_annotations/index.py
+++ b/dash_docs/chapters/dash_annotations/index.py
@@ -1,0 +1,30 @@
+import dash_html_components as html
+import dash_core_components as dcc
+from dash_docs import reusable_components as rc
+import os
+import jupytext
+from dash_docs import tools
+from dash_docs import styles
+
+
+def load_notebook(path, relative_path=False):
+    if relative_path:
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+    notebook = jupytext.read(path)
+    notebook_cells = notebook["cells"]
+    layout_elements = []
+    for cell in notebook_cells:
+        if cell["cell_type"] == "markdown":
+            layout_elements.append(rc.Markdown(cell["source"]))
+        elif cell["cell_type"] == "code":
+            code_text, code_block = tools.load_block(cell["source"], nb_cell=True)
+            layout_elements.append(rc.Markdown(code_text, style=styles.code_container))
+            layout_elements.append(html.Div(code_block, className="example-container"))
+    return layout_elements
+
+
+path = "./dash-annotations.md"
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+
+layout = html.Div(load_notebook("./dash-annotations.md", relative_path=True))

--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -1,22 +1,26 @@
 import os
 import re
 
-if os.environ.get('DASH_APP_LOCATION', '') != 'ABSOLUTE':
+if os.environ.get("DASH_APP_LOCATION", "") != "ABSOLUTE":
     from .server import app
 else:
     from server import app
 
+
 def is_in_dash_enterprise():
-    return os.environ.get('DASH_DOCS_URL_PREFIX', '') == '/Docs'
+    return os.environ.get("DASH_DOCS_URL_PREFIX", "") == "/Docs"
 
 
 def relpath(path):
-    if path.startswith('/') and 'DASH_DOCS_URL_PREFIX' in os.environ and not path.startswith('/{}'.format(os.environ['DASH_DOCS_URL_PREFIX'].strip('/'))):
-        # In enterprise docs, all assets are under `/Docs`
-        return '{}{}'.format(
-            os.environ['DASH_DOCS_URL_PREFIX'].rstrip('/'),
-            path
+    if (
+        path.startswith("/")
+        and "DASH_DOCS_URL_PREFIX" in os.environ
+        and not path.startswith(
+            "/{}".format(os.environ["DASH_DOCS_URL_PREFIX"].strip("/"))
         )
+    ):
+        # In enterprise docs, all assets are under `/Docs`
+        return "{}{}".format(os.environ["DASH_DOCS_URL_PREFIX"].rstrip("/"), path)
 
     return path
 
@@ -26,14 +30,15 @@ def exception_handler(func):
         try:
             return func(path, **kwargs)
         except Exception as e:
-            print('\nError running {}\n{}'.format(path, '=' * 76))
+            print("\nError running {}\n{}".format(path, "=" * 76))
             raise e
+
     return wrapper
 
 
 def load_examples(index_filename, omit=[]):
-    dir = os.path.dirname(os.path.relpath(index_filename))
-    example_dir = os.path.join(dir, 'examples')
+    dirname = os.path.dirname(os.path.relpath(index_filename))
+    example_dir = os.path.join(dirname, "examples")
     try:
         example_filenames = os.listdir(example_dir)
     except:
@@ -43,146 +48,145 @@ def load_examples(index_filename, omit=[]):
     examples = {}
     for filename in example_filenames:
         full_filename = os.path.join(example_dir, filename)
-        if filename not in omit and os.path.isfile(full_filename) and filename.endswith('.py'):
+        if (
+            filename not in omit
+            and os.path.isfile(full_filename)
+            and filename.endswith(".py")
+        ):
             examples[filename] = load_example(full_filename)
     return examples
 
+
+@exception_handler
+def load_block(_source, nb_cell=False):
+    # cell from Jupyter notebook
+    if nb_cell:
+        if "import dash" not in _source:
+            _source = _source.replace(
+                "from jupyter_dash import JupyterDash", "import dash"
+            )
+        else:
+            _source = _source.replace("from jupyter_dash import JupyterDash\n", "")
+        _source = _source.replace("app = JupyterDash", "app = dash.Dash")
+        # JupyterDash apps are run with specific parameters which we need to remove
+        find_run_server = re.compile("app\.run_server" + ".*$")
+        _source = find_run_server.sub(
+            "if __name__ == '__main__':\n    app.run_server(debug=True)\n", _source
+        )
+    _example = _source
+    # Use the global app assignment
+    if (
+        "app = dash.Dash" not in _example
+        and "app = CustomDash()" not in _example
+        and "app = JupyterDash" not in _example
+    ):
+        raise Exception("Didn't declare app")
+    _example = _example.replace("app = dash.Dash", "# app = dash.Dash")
+
+    commented_configs = [
+        "app.scripts.config.serve_locally",
+        "app.css.config.serve_locally",
+    ]
+    for config in commented_configs:
+        _example = _example.replace(config, "# {}".format(config))
+
+    if "import dash\n" not in _example:
+        raise Exception("Didn't import dash")
+
+    # return the layout instead of assigning it to the global app
+    if "app.layout = " not in _example:
+        raise Exception("app.layout not assigned")
+    _example = _example.replace("app.layout = ", "layout = ")
+
+    # Remove the "# Run the server" commands
+    if "app.run_server" not in _example:
+        raise Exception("app.run_server missing")
+    _example = _example.replace(
+        "\n    app.run_server", 'print("Running")\n    # app.run_server'
+    )
+
+    # if there are lines that should be included in the syntax but
+    # not executed, simply put a comment on that line starting "# no-exec"
+    # similarly, if there are lines that should be evalued but
+    # not executed, simply put a comment on that line starting "# no-display"
+    no_exec = "# no-exec"
+    no_display = "# no-display"
+    if no_exec in _example:
+        _example = "\n".join(
+            line for line in _example.splitlines() if no_exec not in line
+        )
+
+        find_no_exec = re.compile(r"\s+" + no_exec + ".*")
+        _source = "\n".join(
+            find_no_exec.sub("", line) if no_exec in line else line
+            for line in _source.splitlines()
+        )
+
+    if no_display in _example:
+        _source = "\n".join(
+            line for line in _source.splitlines() if no_display not in line
+        )
+
+        find_no_display = re.compile(r"\s+" + no_display + ".*")
+        _example = "\n".join(
+            find_no_display.sub("", line) if no_display in line else line
+            for line in _example.splitlines()
+        )
+
+    if "$tools" in _example:
+        _example = _example.replace(
+            "$tools", os.path.dirname(os.path.realpath(__file__))
+        )
+
+    # replace remote datasets with local ones
+    # so that the app can run in internet-less environments
+    find_and_replace = {
+        "https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv": "datasets/gapminderDataFiveYear.csv",
+        "https://raw.githubusercontent.com/plotly/datasets/master/gapminder2007.csv": "datasets/gapminder2007.csv",
+        "https://raw.githubusercontent.com/plotly/datasets/master/solar.csv": "datasets/solar.csv",
+        "https://raw.githubusercontent.com/plotly/datasets/master/Emissions%20Data.csv": "datasets/Emissions%20Data.csv",
+        "https://raw.githubusercontent.com/plotly/datasets/master/1962_2006_walmart_store_openings.csv": "datasets/1962_2006_walmart_store_openings.csv",
+        "https://upload.wikimedia.org/wikipedia/commons/e/e4/Mitochondria%2C_mammalian_lung_-_TEM_%282%29.jpg": "datasets/mitochondria.jpg",
+        "https://gist.githubusercontent.com/chriddyp/cb5392c35661370d95f300086accea51/raw/8e0768211f6b747c0db42a9ce9a0937dafcbd8b2/indicators.csv": "datasets/indicators.csv",
+        "https://gist.githubusercontent.com/chriddyp/c78bf172206ce24f77d6363a2d754b59/raw/c353e8ef842413cae56ae3920b8fd78468aa4cb2/usa-agricultural-exports-2011.csv": "datasets/usa-agricultural-exports-2011.csv",
+        "https://gist.githubusercontent.com/chriddyp/5d1ea79569ed194d432e56108a04d188/raw/a9f9e8076b837d541398e999dcbac2b2826a81f8/gdp-life-exp-2007.csv": "datasets/gdp-life-exp-2007.csv",
+        "https://plotly.github.io/datasets/country_indicators.csv": "datasets/country_indicators.csv",
+        "https://github.com/plotly/datasets/raw/master/26k-consumer-complaints.csv": "datasets/26k-consumer-complaints.csv",
+        "https://js.cytoscape.org/demos/colajs-graph/data.json": "datasets/colajs-graph-data.json",
+        "https://js.cytoscape.org/demos/colajs-graph/cy-style.json": "datasets/colajs-graph-cy-style.json",
+        "https://www.publicdomainpictures.net/pictures/60000/nahled/flower-outline-coloring-page.jpg": relpath(
+            "/assets/images/gallery/flower-outline-coloring-page.jpg"
+        ),
+        "https://raw.githubusercontent.com/plotly/datasets/master/mitochondria.jpg": relpath(
+            "/assets/images/gallery/mitochondria.jpg"
+        ),
+    }
+    for key in find_and_replace:
+        if key in _example:
+            _example = _example.replace(key, find_and_replace[key])
+
+    scope = {"app": app}
+    try:
+        exec(_example, scope)
+    except Exception as e:
+        print(_example)
+        raise e
+
+    return (
+        "```python \n" + _source + "```",
+        scope["layout"],  # layout is a global created from the app
+    )
 
 
 @exception_handler
 def load_example(path, relative_path=False):
     if relative_path:
         path = os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
-    with open(path, 'r') as _f:
+    with open(path, "r") as _f:
         _source = _f.read()
-        _example = _source
+        src, code = load_block(_source)
 
-        # Use the global app assignment
-        if 'app = dash.Dash' not in _example and 'app = CustomDash()' not in _example:
-            raise Exception("Didn't declare app")
-        _example = _example.replace('app = dash.Dash', '# app = dash.Dash')
-
-        commented_configs = [
-            'app.scripts.config.serve_locally',
-            'app.css.config.serve_locally'
-        ]
-        for config in commented_configs:
-            _example = _example.replace(
-                config,
-                '# {}'.format(config)
-            )
-
-        if 'import dash\n' not in _example:
-            raise Exception("Didn't import dash")
-
-        # return the layout instead of assigning it to the global app
-        if 'app.layout = ' not in _example:
-            raise Exception('app.layout not assigned')
-        _example = _example.replace('app.layout = ', 'layout = ')
-
-        # Remove the "# Run the server" commands
-        if 'app.run_server' not in _example:
-            raise Exception('app.run_server missing')
-        _example = _example.replace(
-            '\n    app.run_server',
-            'print("Running")\n    # app.run_server'
-        )
-
-        # if there are lines that should be included in the syntax but
-        # not executed, simply put a comment on that line starting "# no-exec"
-        # similarly, if there are lines that should be evalued but
-        # not executed, simply put a comment on that line starting "# no-display"
-        no_exec = '# no-exec'
-        no_display = '# no-display'
-        if no_exec in _example:
-            _example = '\n'.join(
-                line for line in _example.splitlines() if no_exec not in line
-            )
-
-            find_no_exec = re.compile(r'\s+' + no_exec + '.*')
-            _source = '\n'.join(
-                find_no_exec.sub('', line) if no_exec in line else line
-                for line in _source.splitlines()
-            )
-
-        if no_display in _example:
-            _source = '\n'.join(
-                line for line in _source.splitlines() if no_display not in line
-            )
-
-            find_no_display = re.compile(r'\s+' + no_display + '.*')
-            _example = '\n'.join(
-                find_no_display.sub('', line) if no_display in line else line
-                for line in _example.splitlines()
-            )
-
-        if '$tools' in _example:
-            _example = _example.replace('$tools', os.path.dirname(os.path.realpath(__file__)))
-
-        # replace remote datasets with local ones
-        # so that the app can run in internet-less environments
-        find_and_replace = {
-            'https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv':
-            'datasets/gapminderDataFiveYear.csv',
-
-            'https://raw.githubusercontent.com/plotly/datasets/master/gapminder2007.csv':
-            'datasets/gapminder2007.csv',
-
-            'https://raw.githubusercontent.com/plotly/datasets/master/solar.csv':
-            'datasets/solar.csv',
-
-            'https://raw.githubusercontent.com/plotly/datasets/master/Emissions%20Data.csv':
-            'datasets/Emissions%20Data.csv',
-
-            'https://raw.githubusercontent.com/plotly/datasets/master/1962_2006_walmart_store_openings.csv':
-            'datasets/1962_2006_walmart_store_openings.csv',
-
-            'https://upload.wikimedia.org/wikipedia/commons/e/e4/Mitochondria%2C_mammalian_lung_-_TEM_%282%29.jpg':
-            'datasets/mitochondria.jpg',
-
-            'https://gist.githubusercontent.com/chriddyp/cb5392c35661370d95f300086accea51/raw/8e0768211f6b747c0db42a9ce9a0937dafcbd8b2/indicators.csv':
-            'datasets/indicators.csv',
-
-            'https://gist.githubusercontent.com/chriddyp/c78bf172206ce24f77d6363a2d754b59/raw/c353e8ef842413cae56ae3920b8fd78468aa4cb2/usa-agricultural-exports-2011.csv':
-            'datasets/usa-agricultural-exports-2011.csv',
-
-            'https://gist.githubusercontent.com/chriddyp/5d1ea79569ed194d432e56108a04d188/raw/a9f9e8076b837d541398e999dcbac2b2826a81f8/gdp-life-exp-2007.csv':
-            'datasets/gdp-life-exp-2007.csv',
-
-            'https://plotly.github.io/datasets/country_indicators.csv':
-            'datasets/country_indicators.csv',
-
-            'https://github.com/plotly/datasets/raw/master/26k-consumer-complaints.csv':
-            'datasets/26k-consumer-complaints.csv',
-
-            'https://js.cytoscape.org/demos/colajs-graph/data.json':
-            'datasets/colajs-graph-data.json',
-
-            'https://js.cytoscape.org/demos/colajs-graph/cy-style.json':
-            'datasets/colajs-graph-cy-style.json',
-
-            'https://www.publicdomainpictures.net/pictures/60000/nahled/flower-outline-coloring-page.jpg':
-            relpath('/assets/images/gallery/flower-outline-coloring-page.jpg'),
-
-            'https://raw.githubusercontent.com/plotly/datasets/master/mitochondria.jpg':
-            relpath('/assets/images/gallery/mitochondria.jpg'),
-
-        }
-        for key in find_and_replace:
-            if key in _example:
-                _example = _example.replace(key, find_and_replace[key])
-
-        scope = {'app': app}
-        try:
-            exec(_example, scope)
-        except Exception as e:
-            print(_example)
-            raise e
-
-    return (
-        '```python \n' + _source + '```',
-        scope['layout']  # layout is a global created from the app
-    )
+    return src, code
 
 
 def merge(*dict_args):
@@ -197,5 +201,7 @@ def merge(*dict_args):
 
 
 def read_file(path):
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), path), 'r') as f:
+    with open(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), path), "r"
+    ) as f:
         return f.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ itsdangerous==0.24
 Jinja2==2.11.1
 jsonschema==2.6.0
 jupyter-core==4.4.0
+jupytext
 lxml==4.5.0
 Markdown==3.2.1;python_version>="3.5"
 MarkupSafe==1.1.1
@@ -42,7 +43,7 @@ pandas==1.0.3;python_version>="3.0"
 pandas==0.24.2;python_version=="2.7"
 percy==2.0.2
 pip==20.0.2
-plotly==4.8.1
+plotly==4.12.0
 pycodestyle==2.3.1
 pyflakes==1.6.0
 pyorbital==1.3.1


### PR DESCRIPTION
This PR is made of two contributions:
- I modified and extended `tools.py` so that it can parse a jupyter notebook file (to be included as a markdown file for easier version control, but it could also be an `ipynb` file), where every cell is a `JupyterDash` app. Indeed, a notebook is an easy way to develop small apps for documentation (which can also be hosted on binder for example). 
- This tool was motivated by the notebook which I have written for new documentation on image annotations with shape drawing. This tutorial is still work in progress, I'll polish the content and add a few examples today.

I'm interested in an early high-level review of the "notebook to dash docs chapter" process. I noticed a few caveats, for example:
- one must avoid name collisions between different cells of the notebook, because even if every cell of the notebook is a different `JupyterDash` app, all their layouts are merged in a single Dash app. A future improvement could check for collisions and change component names.
- at the moment it is not possible to have cells not defining a Dash app. Since every cell must be transformed into layout elements (and possibly callbacks to be attached), one could also permit to have notebook cells displaying plotly figures, and include the figure in a `dcc.Graph` as layout element.  


Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.


If I introduced a new relative link inside `dcc.Markdown`:
- [x] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.