### PR TITLE
add newline to end of example apps so they format correctly

### DIFF
--- a/dash_docs/tools.py
+++ b/dash_docs/tools.py
@@ -180,7 +180,7 @@ def load_example(path, relative_path=False):
             raise e
 
     return (
-        '```python \n' + _source + '```',
+        '```python \n' + _source.rstrip() + '\n```',
         scope['layout']  # layout is a global created from the app
     )
 


### PR DESCRIPTION
Currently, example apps that do not have a trailing newline get an extra set of backticks appended to them. This means that when copying/pasting into a dev environment, users get an error. 

This fix ensures that apps get a trailing newline, preventing this error from occurring. 

Before:
![Screen Shot 2020-11-02 at 5 17 20 PM](https://user-images.githubusercontent.com/1557650/97931627-07bcf780-1d3c-11eb-8c6d-666c9a62f140.png)

After:
![Screen Shot 2020-11-02 at 6 45 46 PM](https://user-images.githubusercontent.com/1557650/97931634-0be91500-1d3c-11eb-8a22-ce0beb22ecaf.png)
