### PR TITLE
[READY] Change code stylesheet based on Style guide

### DIFF
--- a/dash_docs/assets/highlight/styles/default.css
+++ b/dash_docs/assets/highlight/styles/default.css
@@ -7,8 +7,8 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
-  background: #F0F0F0;
+  padding: 1.5em;
+  background: #F7FAFC;
 }
 
 
@@ -16,11 +16,11 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 
 .hljs,
 .hljs-subst {
-  color: #444;
+  color: #3F4F75;
 }
 
 .hljs-comment {
-  color: #888888;
+  color: #A1ACC3;
 }
 
 .hljs-keyword,
@@ -29,7 +29,8 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 .hljs-meta-keyword,
 .hljs-doctag,
 .hljs-name {
-  font-weight: bold;
+  /* font-weight: bold; */
+  color: #20293D;
 }
 
 
@@ -43,12 +44,12 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 .hljs-quote,
 .hljs-template-tag,
 .hljs-deletion {
-  color: #880000;
+  color: #60BAB6;
 }
 
 .hljs-title,
 .hljs-section {
-  color: #880000;
+  color: #F4564E;
   font-weight: bold;
 }
 
@@ -66,7 +67,7 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 /* Language color: hue: 90; */
 
 .hljs-literal {
-  color: #78A960;
+  color: #357E94;
 }
 
 .hljs-built_in,
@@ -80,7 +81,7 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 /* Meta color: hue: 200 */
 
 .hljs-meta {
-  color: #1f7199;
+  color: #357E94;
 }
 
 .hljs-meta-string {

--- a/dash_docs/assets/highlight/styles/default.css
+++ b/dash_docs/assets/highlight/styles/default.css
@@ -4,6 +4,11 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 
 */
 
+pre > code {
+    font-family: 'DM Mono', monospace;
+    font-size: 12px
+}
+
 .hljs {
   display: block;
   overflow-x: auto;
@@ -49,7 +54,7 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 
 .hljs-title,
 .hljs-section {
-  color: #F4564E;
+  color: #FF8022;
   font-weight: bold;
 }
 

--- a/dash_docs/assets/highlight/styles/default.css
+++ b/dash_docs/assets/highlight/styles/default.css
@@ -54,7 +54,7 @@ pre > code {
 
 .hljs-title,
 .hljs-section {
-  color: #AB63FA;
+  color: #636EFA;
   font-weight: bold;
 }
 

--- a/dash_docs/assets/highlight/styles/default.css
+++ b/dash_docs/assets/highlight/styles/default.css
@@ -8,7 +8,7 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
   display: block;
   overflow-x: auto;
   padding: 1.5em;
-  background: #F7FAFC;
+  background: #FAFBFC;
 }
 
 
@@ -44,7 +44,7 @@ Original highlight.js style (c) Ivan Sagalaev <maniac@softwaremaniacs.org>
 .hljs-quote,
 .hljs-template-tag,
 .hljs-deletion {
-  color: #60BAB6;
+  color: #299991;
 }
 
 .hljs-title,

--- a/dash_docs/assets/highlight/styles/default.css
+++ b/dash_docs/assets/highlight/styles/default.css
@@ -54,7 +54,7 @@ pre > code {
 
 .hljs-title,
 .hljs-section {
-  color: #FF8022;
+  color: #AB63FA;
   font-weight: bold;
 }
 

--- a/dash_docs/assets/highlight/styles/dm-mono.css
+++ b/dash_docs/assets/highlight/styles/dm-mono.css
@@ -1,0 +1,18 @@
+/* latin-ext */
+@font-face {
+  font-family: 'DM Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('DM Mono Regular'), local('DMMono-Regular'), url(https://fonts.gstatic.com/s/dmmono/v2/aFTU7PB1QTsUX8KYthSQBLyM.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'DM Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('DM Mono Regular'), local('DMMono-Regular'), url(https://fonts.gstatic.com/s/dmmono/v2/aFTU7PB1QTsUX8KYthqQBA.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}


### PR DESCRIPTION
The [Plotly Docs snippets](https://dash-gallery.plotly.host/python-docs-dash-snippets) currently use the proposed styling. Notably, the color of strings have a softer cyan-ish color.

The following colors were changed:
- background color: #F7FAFC
- comments color: #A1ACC3
- regular color: #3F4F75
- keyword, attribute, selector-tag, meta-keyword, doctag, name color: #20293D
- string, number, type, selector color: #60BAB6


Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL