### PR TITLE
dash enterprise sidebar link update

### DIFF
--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -457,7 +457,7 @@ URLS = [
         ] +
         ([
             {
-                'url': 'https://dash.plotly.com/dash',
+                'url': 'https://dash.plotly.com/dash-enterprise',
                 'name': 'Dash Enterprise',
                 'description': '''
                     The commercial platform behind Dash Open Source for


### PR DESCRIPTION
Updated sidebar link page from `/dash` to `/dash-enterprise`

![image](https://user-images.githubusercontent.com/11036740/99574187-07ac3100-29a5-11eb-9b70-3bfd7dcf453b.png)


![image](https://user-images.githubusercontent.com/11036740/99574705-b94b6200-29a5-11eb-842a-b58b8d571905.png)
