### PR TITLE
Add red links to "find out of you are using dash enterprise"

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -512,6 +512,10 @@ a {
     color: #f4564e !important;
 }
 
+.lookup-red-links a[href="https://go.plotly.com/company-lookup"] {
+    color: #f4564e !important;
+}
+
 .tab.tab--selected {
     border-top-color: #80cfbe !important;
 }

--- a/dash_docs/chapters/auth/index.py
+++ b/dash_docs/chapters/auth/index.py
@@ -19,14 +19,14 @@ layout = html.Div([
     2. `dash-auth`, a simple [basic auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
     implementation.
 
-    Dash Enterprise can be
-    installed on a Linux server at your company or the Kubernetes service
-    of every major cloud:
-
-    > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=auth&utm_campaign=nov&utm_content=azure)
-    > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=auth&utm_campaign=nov&utm_content=aws)
-    > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=auth&utm_campaign=nov&utm_content=linux)
-    > - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
+    > Dash Enterprise can be installed on the Kubernetes 
+    > services of 
+    > [AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws), 
+    > [Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure), 
+    > [GCP](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux), 
+    > or an 
+    > [on-premise Linux Server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux).
+    > [Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
 
     # Dash Enterprise Auth
 
@@ -78,7 +78,7 @@ layout = html.Div([
     `DASH_LOGOUT_URL`. You can do this by running your code with `DASH_LOGOUT_URL=plot.ly python app.py`.
 
     ## Dash Enterprise Auth Example
-    '''),
+    ''', className="lookup-red-links"),
 
     rc.Syntax(dedent('''
     import dash

--- a/dash_docs/chapters/basic_callbacks/index.py
+++ b/dash_docs/chapters/basic_callbacks/index.py
@@ -56,8 +56,11 @@ layout = html.Div([
     rc.Markdown('''
     > If you're using Dash Enterprise's [Data Science Workspaces](https://plotly.com/dash/workspaces),
     > copy & paste the below code into your Workspace ([see video](https://plotly.com/dash/workspaces/#screencast)).
-    > _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_
     ''') if not tools.is_in_dash_enterprise() else '',
+
+    rc.Markdown('''
+    > _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_
+    ''', className='red-links') if not tools.is_in_dash_enterprise() else '',
 
     rc.Markdown(
         examples['getting_started_interactive_simple.py'][0],

--- a/dash_docs/chapters/basic_callbacks/index.py
+++ b/dash_docs/chapters/basic_callbacks/index.py
@@ -58,9 +58,9 @@ layout = html.Div([
     > copy & paste the below code into your Workspace ([see video](https://plotly.com/dash/workspaces/#screencast)).
     ''') if not tools.is_in_dash_enterprise() else '',
 
-    rc.Markdown('''
-    > _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_
-    ''', className='red-links') if not tools.is_in_dash_enterprise() else '',
+    rc.Markdown(
+        '> _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_', 
+        className='red-links') if not tools.is_in_dash_enterprise() else '',
 
     rc.Markdown(
         examples['getting_started_interactive_simple.py'][0],

--- a/dash_docs/chapters/basic_callbacks/index.py
+++ b/dash_docs/chapters/basic_callbacks/index.py
@@ -56,11 +56,8 @@ layout = html.Div([
     rc.Markdown('''
     > If you're using Dash Enterprise's [Data Science Workspaces](https://plotly.com/dash/workspaces),
     > copy & paste the below code into your Workspace ([see video](https://plotly.com/dash/workspaces/#screencast)).
-    ''') if not tools.is_in_dash_enterprise() else '',
-
-    rc.Markdown(
-        '> _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_', 
-        className='red-links') if not tools.is_in_dash_enterprise() else '',
+    > _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_
+    ''', className="lookup-red-links") if not tools.is_in_dash_enterprise() else '',
 
     rc.Markdown(
         examples['getting_started_interactive_simple.py'][0],

--- a/dash_docs/chapters/deployment/index.py
+++ b/dash_docs/chapters/deployment/index.py
@@ -11,14 +11,16 @@ layout = html.Div(children=[
     own machine. To share a Dash app, you need to "deploy" it to a server.
 
     Our recommend method for securely deploying Dash applications is
-    [Dash Enterprise](https://plotly.com/dash). Dash Enterprise can be
-    installed on a Linux server at your company or the Kubernetes service
-    of every major cloud:
-
-    > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=azure)
-    > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=aws)
-    > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=linux)
-    > - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
+    [Dash Enterprise](https://plotly.com/dash). 
+    
+    > Dash Enterprise can be installed on the Kubernetes 
+    > services of 
+    > [AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws), 
+    > [Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure), 
+    > [GCP](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux), 
+    > or an 
+    > [on-premise Linux Server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux).
+    > [Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
 
     ## Dash Enterprise Deployment
 
@@ -30,15 +32,8 @@ layout = html.Div(children=[
     > (Replace `<your-dash-enterprise-platform>` with the hostname of your
     > licensed Dash Enterprise in your VPC).
     >
-    '''),
-
-    rc.Markdown('''
     > [Look up the hostname for your company's license](https://go.plotly.com/company-lookup)
-    ''',
-        className='red-links'
-    ),
 
-    rc.Markdown('''
     [Dash Enterprise](https://plotly.com/dash/)
     is Plotly's commercial product for developing & deploying
     Dash Apps on your company's on-premises Linux servers or VPC
@@ -76,7 +71,7 @@ layout = html.Div(children=[
     ***
 
     **Step 1. Create a new folder for your project:**
-    '''),
+    ''', className="lookup-red-links"),
 
     rc.Markdown('''
     ```shell

--- a/dash_docs/chapters/deployment/index.py
+++ b/dash_docs/chapters/deployment/index.py
@@ -3,87 +3,95 @@ import dash_html_components as html
 from dash_docs import styles
 from dash_docs import reusable_components as rc
 
-layout = html.Div(children=[rc.Markdown('''
-# Deploying Dash Apps
+layout = html.Div(children=[
+    rc.Markdown('''
+    # Deploying Dash Apps
 
-By default, Dash apps run on `localhost` - you can only access them on your
-own machine. To share a Dash app, you need to "deploy" it to a server.
+    By default, Dash apps run on `localhost` - you can only access them on your
+    own machine. To share a Dash app, you need to "deploy" it to a server.
 
-Our recommend method for securely deploying Dash applications is
-[Dash Enterprise](https://plotly.com/dash). Dash Enterprise can be
-installed on a Linux server at your company or the Kubernetes service
-of every major cloud:
+    Our recommend method for securely deploying Dash applications is
+    [Dash Enterprise](https://plotly.com/dash). Dash Enterprise can be
+    installed on a Linux server at your company or the Kubernetes service
+    of every major cloud:
 
-> - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=azure)
-> - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=aws)
-> - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=linux)
-> - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
+    > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=azure)
+    > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=aws)
+    > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=deployment&utm_campaign=nov&utm_content=linux)
+    > - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
 
-## Dash Enterprise Deployment
+    ## Dash Enterprise Deployment
 
-> If your company has licensed Dash Enterprise, then view the deployment
-> documentation by visiting
->
-> **`https://<your-dash-enterprise-platform>/Docs/dash-enterprise`**
->
-> (Replace `<your-dash-enterprise-platform>` with the hostname of your
-> licensed Dash Enterprise in your VPC).
->
-> [Look up the hostname for your company's license](https://go.plotly.com/company-lookup)
+    > If your company has licensed Dash Enterprise, then view the deployment
+    > documentation by visiting
+    >
+    > **`https://<your-dash-enterprise-platform>/Docs/dash-enterprise`**
+    >
+    > (Replace `<your-dash-enterprise-platform>` with the hostname of your
+    > licensed Dash Enterprise in your VPC).
+    >
+    '''),
 
-[Dash Enterprise](https://plotly.com/dash/)
-is Plotly's commercial product for developing & deploying
-Dash Apps on your company's on-premises Linux servers or VPC
-([AWS](https://plotly.com/dash/aws), [Google Cloud](https://plotly.com/dash), or [Azure](https://plotly.com/dash/azure)).
+    rc.Markdown('''
+    > [Look up the hostname for your company's license](https://go.plotly.com/company-lookup)
+    ''',
+        className='red-links'
+    ),
 
-In addition to [easy, git-based deployment](https://plotly.com/dash/app-manager), the Dash Enterprise platform provides a complete Analytical App Stack.
-This includes:
-- [LDAP & SAML Authentication Middleware](https://plotly.com/dash/authentication)
-- [Data Science Workspaces](https://plotly.com/dash/workspaces)
-- [High Availability & Horizontal Scaling](https://plotly.com/dash/kubernetes)
-- [Job Queue Support](https://plotly.com/dash/job-queue)
-- [Enterprise-Wide Dash App Portal](https://plotly.com/dash/app-manager)
-- [Design Kit](https://plotly.com/dash/design-kit)
-- [Reporting, Alerting, Saved Views, and PDF Reports](https://plotly.com/dash/snapshot-engine)
-- [Dashboard Toolkit](https://plotly.com/dash/toolkit)
-- [Embedding Dash apps in Existing websites or Salesforce](https://plotly.com/dash/embedding)
-- [AI App Catalog](https://plotly.com/dash/ai-and-ml-templates)
-- [Big Data Best Practices](https://plotly.com/dash/big-data-for-python)
-- [GPU support](https://plotly.com/dash/gpu-dask-acceleration)
+    rc.Markdown('''
+    [Dash Enterprise](https://plotly.com/dash/)
+    is Plotly's commercial product for developing & deploying
+    Dash Apps on your company's on-premises Linux servers or VPC
+    ([AWS](https://plotly.com/dash/aws), [Google Cloud](https://plotly.com/dash), or [Azure](https://plotly.com/dash/azure)).
 
-![The Analytical App Stack](/assets/images/dds/stack.png)
+    In addition to [easy, git-based deployment](https://plotly.com/dash/app-manager), the Dash Enterprise platform provides a complete Analytical App Stack.
+    This includes:
+    - [LDAP & SAML Authentication Middleware](https://plotly.com/dash/authentication)
+    - [Data Science Workspaces](https://plotly.com/dash/workspaces)
+    - [High Availability & Horizontal Scaling](https://plotly.com/dash/kubernetes)
+    - [Job Queue Support](https://plotly.com/dash/job-queue)
+    - [Enterprise-Wide Dash App Portal](https://plotly.com/dash/app-manager)
+    - [Design Kit](https://plotly.com/dash/design-kit)
+    - [Reporting, Alerting, Saved Views, and PDF Reports](https://plotly.com/dash/snapshot-engine)
+    - [Dashboard Toolkit](https://plotly.com/dash/toolkit)
+    - [Embedding Dash apps in Existing websites or Salesforce](https://plotly.com/dash/embedding)
+    - [AI App Catalog](https://plotly.com/dash/ai-and-ml-templates)
+    - [Big Data Best Practices](https://plotly.com/dash/big-data-for-python)
+    - [GPU support](https://plotly.com/dash/gpu-dask-acceleration)
 
-## Heroku for Sharing Public Dash apps for Free
+    ![The Analytical App Stack](/assets/images/dds/stack.png)
 
-Heroku is one of the easiest platforms for deploying and managing public Flask
-applications. The git & buildpack-based deployment of UIs of Heroku and Dash Enterprise
-are nearly identical, enabling an easy transition to Dash Enterprise if you
-are already using Heroku.
+    ## Heroku for Sharing Public Dash apps for Free
 
-[View the official Heroku guide to Python](https://devcenter.heroku.com/articles/getting-started-with-python#introduction).
+    Heroku is one of the easiest platforms for deploying and managing public Flask
+    applications. The git & buildpack-based deployment of UIs of Heroku and Dash Enterprise
+    are nearly identical, enabling an easy transition to Dash Enterprise if you
+    are already using Heroku.
 
-Here is a simple example. This example requires a Heroku account,
-`git`, and `virtualenv`.
+    [View the official Heroku guide to Python](https://devcenter.heroku.com/articles/getting-started-with-python#introduction).
 
-***
+    Here is a simple example. This example requires a Heroku account,
+    `git`, and `virtualenv`.
 
-**Step 1. Create a new folder for your project:**
-'''),
+    ***
 
-          rc.Markdown('''
-          ```shell
-          $ mkdir dash_app_example
-          $ cd dash_app_example
-          ```
-          ''', style=styles.code_container),
+    **Step 1. Create a new folder for your project:**
+    '''),
 
-          rc.Markdown('''
+    rc.Markdown('''
+    ```shell
+    $ mkdir dash_app_example
+    $ cd dash_app_example
+    ```
+    ''', style=styles.code_container),
 
-***
+    rc.Markdown('''
 
-**Step 2. Initialize the folder with `git` and a `virtualenv`**
+    ***
 
-'''),
+    **Step 2. Initialize the folder with `git` and a `virtualenv`**
+
+    '''),
 
           rc.Markdown('''
           ```shell

--- a/dash_docs/chapters/getting_started/index.py
+++ b/dash_docs/chapters/getting_started/index.py
@@ -58,7 +58,7 @@ layout = html.Div([
     > copy & paste the below code into your Workspace ([see video](https://plotly.com/dash/workspaces/#screencast)).
     > _[Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)_
 
-    ''') if not tools.is_in_dash_enterprise() else '',
+    ''', className="lookup-red-links") if not tools.is_in_dash_enterprise() else '',
 
     rc.Markdown('''
     To get started, create a file named `app.py` with the following code.

--- a/dash_docs/chapters/home/index.py
+++ b/dash_docs/chapters/home/index.py
@@ -34,7 +34,7 @@ layout = html.Div([
         ]),
 
         dcc.Tab(label='Dash Enterprise', children=[
-            TOC([DASH_ENTERPRISE_URLS])
+            html.Div(TOC([DASH_ENTERPRISE_URLS]), className="lookup-red-links")
         ])
 
     ])

--- a/dash_docs/chapters/integrating_dash/index.py
+++ b/dash_docs/chapters/integrating_dash/index.py
@@ -15,21 +15,16 @@ layout = html.Div([
     Our recommend method for securely embedding Dash applications in existing
     Web Apps is to use the [Embedding Middleware](https://plotly.com/dash/embedding/)
     of Dash Enterprise.
+    
+    > Dash Enterprise can be installed on the Kubernetes 
+    > services of 
+    > [AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws), 
+    > [Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure), 
+    > [GCP](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux), 
+    > or an 
+    > [on-premise Linux Server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux).
+    > [Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
 
-    Dash Enterprise can be
-    installed on a Linux server at your company or the Kubernetes service
-    of every major cloud:
-
-    > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=azure)
-    > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=aws)
-    > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=linux)
-    """),
-    rc.Markdown(
-        "> - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)",
-        className="red-links",
-    ),
-    rc.Markdown(
-    """
     ## Dash Enterprise Embedding Middleware
 
     > If your company has licensed Dash Enterprise, then view the deployment
@@ -68,7 +63,7 @@ layout = html.Div([
      whose `src` attribute points
     towards the address of a deployed Dash app. This allows you to place your
     Dash app in a specific location within an existing web page with your
-    desired dimensions:"""),
+    desired dimensions:""", className='lookup-red-links'),
     rc.Markdown(
     '''
     ```html

--- a/dash_docs/chapters/integrating_dash/index.py
+++ b/dash_docs/chapters/integrating_dash/index.py
@@ -25,9 +25,7 @@ layout = html.Div([
     > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=linux)
     """),
     rc.Markdown(
-    """
-    > - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
-    """,
+        "> - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)",
         className="red-links",
     ),
     rc.Markdown(

--- a/dash_docs/chapters/integrating_dash/index.py
+++ b/dash_docs/chapters/integrating_dash/index.py
@@ -23,8 +23,15 @@ layout = html.Div([
     > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=azure)
     > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=aws)
     > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=integrating&utm_campaign=nov&utm_content=linux)
+    """),
+    rc.Markdown(
+    """
     > - Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
-
+    """,
+        className="red-links",
+    ),
+    rc.Markdown(
+    """
     ## Dash Enterprise Embedding Middleware
 
     > If your company has licensed Dash Enterprise, then view the deployment

--- a/dash_docs/reusable_components/ComponentReference.py
+++ b/dash_docs/reusable_components/ComponentReference.py
@@ -27,7 +27,8 @@ def ComponentReference(component_name, lib=dcc):
             > which has typeahead support for Dash Component Properties.
             > [Find out if your company is using
             > Dash Enterprise](https://go.plotly.com/company-lookup).
-            ''' if not tools.is_in_dash_enterprise() else ''
+            ''' if not tools.is_in_dash_enterprise() else '',
+            className="lookup-red-links"
         )
     ]
 

--- a/dash_docs/reusable_components/WorkspaceBlurb.py
+++ b/dash_docs/reusable_components/WorkspaceBlurb.py
@@ -4,16 +4,17 @@ import dash_html_components as html
 WorkspaceBlurb = html.Div([
   dcc.Markdown(
 '''
-> [Dash Enterprise](https://plotly.com/dash) is the fastest way to write &
-> deploy Dash apps and Jupyter notebooks. Click below to install on one
-> of these clouds:
-> - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure)
-> - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws)
-> - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux)
-'''
-  ),
-  dcc.Markdown(
-    '> Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)',
-    className="red-links"
+> Dash Enterprise is the fastest way to write & deploy Dash apps and 
+> Jupyter notebooks. Dash Enterprise can be installed on the Kubernetes 
+> services of 
+> [AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws), 
+> [Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure), 
+> [GCP](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux), 
+> or an 
+> [on-premise Linux Server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux).
+> 10% of the Fortune 500 uses Dash Enterprise to productionize AI and data science apps.
+> [Find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
+''',
+  className="lookup-red-links",
   )
 ])

--- a/dash_docs/reusable_components/WorkspaceBlurb.py
+++ b/dash_docs/reusable_components/WorkspaceBlurb.py
@@ -1,4 +1,5 @@
 import dash_core_components as dcc
+import dash_html_components as html
 
 WorkspaceBlurb = html.Div([
   dcc.Markdown(

--- a/dash_docs/reusable_components/WorkspaceBlurb.py
+++ b/dash_docs/reusable_components/WorkspaceBlurb.py
@@ -1,6 +1,7 @@
 import dash_core_components as dcc
 
-WorkspaceBlurb = dcc.Markdown(
+WorkspaceBlurb = html.Div([
+  dcc.Markdown(
 '''
 > [Dash Enterprise](https://plotly.com/dash) is the fastest way to write &
 > deploy Dash apps and Jupyter notebooks. Click below to install on one
@@ -8,7 +9,12 @@ WorkspaceBlurb = dcc.Markdown(
 > - [Install Dash Enterprise on Azure](https://plotly.com/dash/azure/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=azure)
 > - [Install Dash Enterprise on AWS](https://plotly.com/dash/aws/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=aws)
 > - [Install Dash Enterprise on an on-premises Linux server](https://plotly.com/dash/on-premises-linux/?utm_source=docs&utm_medium=workspace&utm_campaign=nov&utm_content=linux)
-
-> Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
 '''
-)
+  ),
+  dcc.Markdown(
+'''
+> Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
+''',
+    className="red-links"
+  )
+])

--- a/dash_docs/reusable_components/WorkspaceBlurb.py
+++ b/dash_docs/reusable_components/WorkspaceBlurb.py
@@ -13,9 +13,7 @@ WorkspaceBlurb = html.Div([
 '''
   ),
   dcc.Markdown(
-'''
-> Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)
-''',
+    '> Or, [find out if your company is using Dash Enterprise](https://go.plotly.com/company-lookup)',
     className="red-links"
   )
 ])


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL