### PR TITLE
Add new chapter for Dash Slicer

### DIFF
--- a/dash_docs/assets/sitemap.xml
+++ b/dash_docs/assets/sitemap.xml
@@ -21,6 +21,9 @@
     <loc>https://dash.plotly.com/canvas</loc>
 </url>
 <url>
+    <loc>https://dash.plotly.com/slicer</loc>
+</url>
+<url>
     <loc>https://dash.plotly.com/clientside-callbacks</loc>
 </url>
 <url>

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -599,6 +599,7 @@ URLS = [
             '/dash-bio/'
             '/dash-daq/',
             '/canvas/',
+            '/slicer/',
             '/annotations/',
             '/cytoscape/'
         ],
@@ -921,6 +922,20 @@ URLS = [
                             'Image rendering, drawing, annotations '
                             'for image processing applications '
                             '(legacy tool).'
+                        )
+                    }
+                ]
+            },
+
+            {
+                'name': 'Dash Slicer',
+                'chapters': [
+                    {
+                        'url': '/slicer',
+                        'name': 'Overview & Reference',
+                        'content': chapters.dash_slicer.index.layout,
+                        'description': (
+                            'A volume slicer for Dash.'
                         )
                     }
                 ]

--- a/dash_docs/chapters/__init__.py
+++ b/dash_docs/chapters/__init__.py
@@ -11,6 +11,7 @@ if not os.environ.get('IGNORE_DASH_BIO', False):
 from .import deployment
 from .import external_resources
 from .import dash_canvas
+from .import dash_slicer
 from .import dash_annotations
 from .import getting_started
 from .import faq_gotchas

--- a/dash_docs/chapters/dash_slicer/__init__.py
+++ b/dash_docs/chapters/dash_slicer/__init__.py
@@ -1,0 +1,1 @@
+from .import index

--- a/dash_docs/chapters/dash_slicer/examples/slicer_example1.py
+++ b/dash_docs/chapters/dash_slicer/examples/slicer_example1.py
@@ -1,0 +1,16 @@
+import dash
+import dash_html_components as html
+import imageio
+from dash_slicer import VolumeSlicer
+
+
+app = dash.Dash(__name__, update_title=None)
+
+vol = imageio.volread("imageio:stent.npz")
+slicer = VolumeSlicer(app, vol)
+
+app.layout = html.Div([slicer.graph, slicer.slider, *slicer.stores])
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/dash_docs/chapters/dash_slicer/examples/slicer_example2.py
+++ b/dash_docs/chapters/dash_slicer/examples/slicer_example2.py
@@ -1,0 +1,28 @@
+import dash
+import dash_html_components as html
+import imageio
+from dash_slicer import VolumeSlicer
+
+
+app = dash.Dash(__name__, update_title=None)
+
+vol = imageio.volread("imageio:stent.npz")
+slicer0 = VolumeSlicer(app, vol, axis=0)
+slicer1 = VolumeSlicer(app, vol, axis=1)
+slicer2 = VolumeSlicer(app, vol, axis=2)
+
+app.layout = html.Div(
+    style={
+        "display": "grid",
+        "gridTemplateColumns": "33% 33% 33%",
+    },
+    children=[
+        html.Div([slicer0.graph, html.Br(), slicer0.slider, *slicer0.stores]),
+        html.Div([slicer1.graph, html.Br(), slicer1.slider, *slicer1.stores]),
+        html.Div([slicer2.graph, html.Br(), slicer2.slider, *slicer2.stores]),
+    ],
+)
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/dash_docs/chapters/dash_slicer/examples/slicer_example3.py
+++ b/dash_docs/chapters/dash_slicer/examples/slicer_example3.py
@@ -1,0 +1,29 @@
+import dash
+import dash_html_components as html
+import imageio
+from dash_slicer import VolumeSlicer
+
+
+app = dash.Dash(__name__, update_title=None)
+
+vol = imageio.volread("imageio:stent.npz")
+vol = vol[::3,:,:]
+spacing = 3, 1, 1
+
+slicer0 = VolumeSlicer(app, vol, spacing=spacing, axis=0)
+slicer1 = VolumeSlicer(app, vol, spacing=spacing, axis=1)
+
+app.layout = html.Div(
+    style={
+        "display": "grid",
+        "gridTemplateColumns": "33% 33%",
+    },
+    children=[
+        html.Div([slicer0.graph, html.Br(), slicer0.slider, *slicer0.stores]),
+        html.Div([slicer1.graph, html.Br(), slicer1.slider, *slicer1.stores]),
+    ],
+)
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/dash_docs/chapters/dash_slicer/examples/slicer_example4.py
+++ b/dash_docs/chapters/dash_slicer/examples/slicer_example4.py
@@ -1,0 +1,25 @@
+import json
+import dash
+import dash_html_components as html
+from dash.dependencies import Input, Output
+import imageio
+from dash_slicer import VolumeSlicer
+
+
+app = dash.Dash(__name__, update_title=None)
+
+vol = imageio.volread("imageio:stent.npz")
+slicer = VolumeSlicer(app, vol)
+
+app.layout = html.Div([slicer.graph, slicer.slider, html.Div(id='info'), *slicer.stores])
+
+@app.callback(
+    Output("info", "children"),
+    [Input(slicer.state.id, "data")]
+)
+def update_info(state):
+    return json.dumps(state, indent=4)
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/dash_docs/chapters/dash_slicer/index.py
+++ b/dash_docs/chapters/dash_slicer/index.py
@@ -1,0 +1,126 @@
+import inspect
+
+import dash_html_components as html
+import dash_core_components as dcc
+from dash_docs import styles
+from dash_docs import tools
+from dash_docs import reusable_components as rc
+import dash_slicer
+
+try:
+    from dash_slicer.docs import get_reference_docs
+except ImportError:
+    get_reference_docs = lambda: "TODO"  # while waiting for a new release
+
+
+examples = tools.load_examples(__file__)
+
+
+layout = html.Div([
+    rc.Markdown(f'''
+
+    # Introduction to Dash Slicer
+
+    The ``dash_slicer`` library provides an easy way to visualize 3D image data
+    by slicing along one dimension. Multiple views on the same data can be linked,
+    to help with navigation.
+
+    Install Dash Slicer with:
+
+    ```pip install -U dash-slicer```
+
+    The source is on GitHub at [plotly/dash-slicer](https://github.com/plotly/dash-slicer).
+
+    ## Guide
+
+    ### A first example
+
+    Let's get started with a simple example.
+    (The examples on this page are build with dash-slicer version {dash_slicer.__version__})
+    '''),
+
+    rc.Markdown(
+          examples['slicer_example1.py'][0],
+          style=styles.code_container
+    ),
+    html.Div(examples['slicer_example1.py'][1], className='example-container'),
+
+    rc.Markdown('''
+    In the code above, we first load a 3D numpy array (a volumetric image). Then
+    we instantiate a `VolumeSlicer` object with that data. This object is not
+    a Dash component, but has properties that are. Its `graph` and `slider`
+    are placed in the layout, as well as a handful of `Store` objects that the
+    slicer needs to function.
+
+    If the server is run in debug mode, consider setting `dev_tools_props_check`
+    to False, because it has a big impact on the performance.
+
+    ### Multiple slicers
+
+    In the next example, we create multiple slicers, one for each dimension,
+    and put them in a layout, just like we did in the previous example.
+    '''),
+
+    rc.Markdown(
+          examples['slicer_example2.py'][0],
+          style=styles.code_container
+    ),
+    html.Div(examples['slicer_example2.py'][1], className='example-container'),
+
+    rc.Markdown('''
+    You can see how the slicers are "linked"; each shows the positions
+    of the other slicers. This linking is based on what we call the
+    scene_id. This is a property that can be provided when you
+    instantiate a `VolumeSlicer`. By default, the scene_id is derived
+    from the volume. That's why the linking in this example works: each
+    slicer is given the same numpy array object. By explicitly setting
+    the scene_id, multiple views on different data can be linked as
+    well.
+
+    In addition to using the sliders, you can click in one of the
+    views to make the other views go to the clicked location. Try it!
+
+    ### Anisotropic data
+
+    In the next example, we make the data non-isotropic. This means
+    that the distance between voxels is not equal for all dimensions.
+    The relative soacing can be provided via the `spacing` argument.
+    Similarly, an `origin` can also be provided. Zoom into the view on
+    the right to see that the voxels are elongated.
+    '''),
+
+    rc.Markdown(
+          examples['slicer_example3.py'][0],
+          style=styles.code_container
+    ),
+    html.Div(examples['slicer_example3.py'][1], className='example-container'),
+
+    rc.Markdown('''
+
+    ### Reacting to the slicer state
+
+    This example illustrates how your application can react to the slicer's
+    position and view by using the `state` store as an input. Note that the
+    id of this store is a dict, which makes it possible to write a pattern
+    matching Input to collect the states of all slicers with a certain scene_id.
+    See the reference docs for details.
+    '''),
+
+    rc.Markdown(
+          examples['slicer_example4.py'][0],
+          style=styles.code_container
+    ),
+    html.Div(examples['slicer_example4.py'][1], className='example-container'),
+
+    rc.Markdown('''
+
+    ### More examples
+
+    More examples are available at the
+    [dash-slicer repository](https://github.com/plotly/dash-slicer/tree/main/examples).
+    '''),
+
+
+    html.H2('Reference'),
+    rc.Markdown(get_reference_docs()),
+])

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ dash-auth==1.3.2
 dash-bio-utils==0.0.5
 dash-bio==0.4.8
 dash-canvas==0.1.0
+dash-slicer>=0.1.0
 dash-cytoscape==0.2.0
 dash-dangerously-set-inner-html==0.0.2
 dash-daq==0.5.0
@@ -59,6 +60,7 @@ requests-ftp==0.3.1
 requests[security]==2.21.0
 requests==2.21.0
 retrying==1.3.3
+imageio>=2.8
 scikit-image==0.14.2
 selenium==3.141.0
 six==1.11.0


### PR DESCRIPTION
*DRAFT: this needs some (yet uncommitted) changes to dash-slicer plus a new release*

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

Other todo's:

* [x] Add basic guide with examples.
* [x] Add reference docs.
* [x] Need to commit corresponding changes to `dash_slicer`.
* [ ] Need a new release of `dash_slicer`.
* [ ] Bump the version in requirements.txt
* [x] If I run the server locally, it works fine, except that if I reload the page or navigate to `/slicer` directly, I get a weird `TypeError: unhashable type: 'dict'`.
* [ ] As it now, dash-slicer is Python 3.6+. CI needs to know this.
 
cc @emmanuelle @nicolaskruchten 

For the reference docs, I opted to have the markdown generated by `dash_slicer` (with a function call). I figured that it would be easier to keep the ref docs in sync with the implementation this way, plus we can add the (small) ref docs to the GH readme. But if others prefer to have this logic in dash-docs, we could change this.
