### PR TITLE
Fix that dict-ids in examples caused server failure

### DIFF
--- a/dash_docs/convert_to_html.py
+++ b/dash_docs/convert_to_html.py
@@ -60,7 +60,7 @@ def _translate_attrib(attrib):
         False: 'false',
         'False': 'false',
     }
-    if attrib in attrib_map:
+    if isinstance(attrib, (str, int)) and attrib in attrib_map:
         return attrib_map[attrib]
     return attrib
 

--- a/dash_docs/convert_to_html.py
+++ b/dash_docs/convert_to_html.py
@@ -60,7 +60,8 @@ def _translate_attrib(attrib):
         False: 'false',
         'False': 'false',
     }
-    if isinstance(attrib, (str, bool, int)) and attrib in attrib_map:
+    # Note that bool is a subclass of int
+    if isinstance(attrib, (str, int)) and attrib in attrib_map:
         return attrib_map[attrib]
     return attrib
 

--- a/dash_docs/convert_to_html.py
+++ b/dash_docs/convert_to_html.py
@@ -60,7 +60,7 @@ def _translate_attrib(attrib):
         False: 'false',
         'False': 'false',
     }
-    if isinstance(attrib, (str, int)) and attrib in attrib_map:
+    if isinstance(attrib, (str, bool, int)) and attrib in attrib_map:
         return attrib_map[attrib]
     return attrib
 


### PR DESCRIPTION
In #1039 I encountered an odd bug: if I navigated to the new chapter it worked fine, but if I refreshed the page, or navigate to the page by entering the url, then I got a descriptive error message, see the image below.

I added some code to the point of failure to see what the value of `attrib` was at that point, and found it was a dictionary-id of a component in one of the examples (well, in all examples, really). 

Fortunately, the fix is easy, I can confirm that the docs in #1039 don't have the bug with the change proposed here. 

![afbeelding](https://user-images.githubusercontent.com/3015475/101496921-a277aa00-396a-11eb-8266-e6733345900b.png)

