### PR TITLE
Update generate_sitemap() to maintain original newlines

### DIFF
--- a/generate_sitemap.py
+++ b/generate_sitemap.py
@@ -19,8 +19,13 @@ def create_sitemap():
 
 def generate_sitemap():
     sitemap = create_sitemap()
-    with open('dash_docs/assets/sitemap.xml', 'w') as f:
-        f.write(sitemap)
+    # Use the same newlines as is currently used
+    with open('dash_docs/assets/sitemap.xml', 'rb') as f:
+        old_sitemap = f.read().decode()
+    if "\r" in old_sitemap:
+        sitemap = sitemap.replace("\n", "\r\n")
+    with open('dash_docs/assets/sitemap.xml', 'wb') as f:
+        f.write(sitemap.encode())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm on Windows, and I have git configured to *not* convert newlines on push/pull. If I run `generate_sitemap.py`, it will write with `\r\n` because of Pythons automatic newline handling, causing a huge diff.

This PR changes the logic in `generate_sitemap.py` to simply write the sitemap with the same newlines as the current file.