### PR TITLE
Add docs for slider.drag_value

### DIFF
--- a/dash_docs/chapters/dash_core_components/Slider/examples/slider_drag.py
+++ b/dash_docs/chapters/dash_core_components/Slider/examples/slider_drag.py
@@ -1,0 +1,23 @@
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+import dash
+
+external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+app.layout = html.Div([
+    dcc.Slider(id='slider-drag'),
+    html.Div(id='slider-drag-output', style={'margin-top': 20})
+])
+
+
+@app.callback(Output('slider-drag-output', 'children'),
+              [Input('slider-drag', 'drag_value'), Input('slider-drag', 'value')])
+def display_value(drag_value, value):
+    return 'drag_value: {} | value: {}'.format(drag_value, value)
+
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/dash_docs/chapters/dash_core_components/Slider/index.py
+++ b/dash_docs/chapters/dash_core_components/Slider/index.py
@@ -96,6 +96,20 @@ dcc.Slider(
         style={'overflow': 'hidden', 'padding': '20px'}
     ),
 
+    html.H3('Using drag_value'),
+    rc.Markdown("Rather than changing the updatemode of the slider, "
+                "you can also use `drag_value` an an input. This makes it "
+                "possible to react differently to drag and mouseup."),
+    rc.Markdown(
+        examples['slider_drag.py'][0],
+        style=styles.code_container,
+    ),
+    html.Div(
+        examples['slider_drag.py'][1],
+        className='example-container',
+        style={'overflow': 'hidden', 'padding': '20px'}
+    ),
+
     html.H3("Slider Properties"),
     rc.ComponentReference('Slider')
 ])


### PR DESCRIPTION
See feature added in https://github.com/plotly/dash-core-components/pull/888

* [ ] Should we also add docs for this in RangeSlider?
* [ ] This can only be merged once dcc has a new release.
