### PR TITLE
removing webinar sidebar, replacing with hiring graphic

### DIFF
--- a/dash_docs/run.py
+++ b/dash_docs/run.py
@@ -95,9 +95,9 @@ header = html.Div(
 )
 
 DEFAULT_AD = dict(
-    alt='Simplify Big Data Visualization with Dash HoloViews, a webinar with Jon Mease.',
-    src=tools.relpath('/assets/images/sidebar/Webinar-HoloViews.jpg'),
-    href='https://go.plotly.com/dash-holoviews'
+    alt='We\'re hiring! View our open positions.',
+    src=tools.relpath('/assets/images/sidebar/Hiring.png'),
+    href='https://grnh.se/6667434d2us'
 )
 
 app.title = 'Dash User Guide and Documentation - Dash by Plotly'


### PR DESCRIPTION
Since Jon's webinar is today, I am removing his webinar promo graphic and replacing it with a hiring graphic that we previously used.

After:
![image](https://user-images.githubusercontent.com/50333592/102370074-a6b74f00-3f8a-11eb-8ce9-3d835b2a0e47.png)

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand