### PR TITLE
Minor typo fix

### DIFF
--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -3794,7 +3794,7 @@ Troubleshooting = html.Div(children=[
 
         This error can happen if you are using a version of `git` that
         is incompatible with Dash Enterprise's `git` server.
-        In `git` `v2.26`, `git` switched the default transportation protocol
+        In `git` `v2.26`, `git` switched the default transport protocol
         to Version 2. Dash Enterprise's git server runs on `git` 2.17.1
         and it only supports version `0`.
 


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [*] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL

@tobinngo @chriddyp This is just a small typo fix. (We say transport protocol in relation to the [transport layer](https://en.wikipedia.org/wiki/Transport_layer) in networking)