### PR TITLE
docs: fix spelling

### DIFF
--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -106,7 +106,7 @@ DASH_ENTERPRISE_URLS = {
             'name': 'Add Authentication to your Dash App',
             'description': (
                 '''
-                Protect your applicaton behind a login screen &
+                Protect your application behind a login screen &
                 access user authentication data in your Dash apps.
                 [Learn more](https://plotly.com/dash/authentication-middleware/).
                 '''

--- a/dash_docs/chapters/auth/index.py
+++ b/dash_docs/chapters/auth/index.py
@@ -31,7 +31,7 @@ layout = html.Div([
     # Dash Enterprise Auth
 
     > If your company has licensed Dash Enterprise, then view authentication
-    > documentation by visting
+    > documentation by visiting
     >
     > **`https://<your-dash-enterprise-platform>/Docs/dash-enterprise`**
     >

--- a/dash_docs/chapters/basic_callbacks/index.jl
+++ b/dash_docs/chapters/basic_callbacks/index.jl
@@ -157,7 +157,7 @@ app.layout = html_div() do
 
     A word of caution: it's not always a good idea to combine Outputs, even if you can:
     - If the Outputs depend on some but not all of the same inputs, keeping them separate
-    can avoid unneccessary updates.
+    can avoid unnecessary updates.
     - If they have the same inputs but do independent computations with these same inputs,
     keeping the callbacks separate can allow them to run in parallel.
     """),

--- a/dash_docs/chapters/dash_core_components/Graph/index.py
+++ b/dash_docs/chapters/dash_core_components/Graph/index.py
@@ -153,10 +153,10 @@ dcc.Graph(
     properties in the following way:
 
     * `True`: `config.responsive` and `figure.layout.autosize` are
-    overriden with `True` values, and `figure.layout.height` and
+    overridden with `True` values, and `figure.layout.height` and
     `figure.layout.width` are unset
     * `False`: `config.responsive` and `figure.layout.autosize` are
-      both overriden with `False` values
+      both overridden with `False` values
     * `'auto'`: the resizability of the plot is determined the
       same way as it used to be (i.e., with the four properties above)
 

--- a/dash_docs/chapters/dash_cytoscape/callbacks/index.R
+++ b/dash_docs/chapters/dash_cytoscape/callbacks/index.R
@@ -260,7 +260,7 @@ default_stylesheet <- list(
   "),
   dccMarkdown("
 This is generally declared at the beginning of your script, before layout
-declaration (therefore it is shared accross sessions). The city graph will
+declaration (therefore it is shared across sessions). The city graph will
 look something like this:
   "),
   # Block 4.7

--- a/dash_docs/chapters/dash_datatable/editing/index.py
+++ b/dash_docs/chapters/dash_datatable/editing/index.py
@@ -153,7 +153,7 @@ layout = html.Div([
     out the empty values.
 
     When you clear a cell, the DataTable will set its contents to `''`
-    (emtpy string). So, for consistency, we recommend initializing your
+    (empty string). So, for consistency, we recommend initializing your
     empty data with `''`.
 
     > Heads up! In the future, when we introduce proper data types,

--- a/dash_docs/chapters/dash_datatable/part3/examples/example1.R
+++ b/dash_docs/chapters/dash_datatable/part3/examples/example1.R
@@ -47,7 +47,7 @@ app$callback(output = list(id = 'datatable_interactivity_container', property = 
              function(rows, derived_virtual_selected_rows) {
                # When the table is first rendered, `derived_virtual_data` and
                # `derived_virtual_selected_rows` will be `list(NULL)`. This is due to an
-               # idiosyncracy in Dash (unsupplied properties are always NULL and Dash
+               # idiosyncrasy in Dash (unsupplied properties are always NULL and Dash
                # calls the dependent callbacks when the component is first rendered).
                # So, if `rows` is `list(NULL)`, then the component was just rendered
                # and its value will be the same as the component's dataframe.

--- a/dash_docs/chapters/dash_datatable/part4/index.R
+++ b/dash_docs/chapters/dash_datatable/part4/index.R
@@ -43,7 +43,7 @@ but it will only filter and sort the data that exists on the page.
 This should be avoided.
 Your users might expect that sorting and filtering is
 happening on the entire dataset and, with large pages,
-might not be aware that this is only occuring on the current page.
+might not be aware that this is only occurring on the current page.
 
 Instead, we recommend implementing sorting and filtering on the backend as well.
 ie, on the entire dataset.

--- a/dash_docs/chapters/dash_datatable/part6/index.R
+++ b/dash_docs/chapters/dash_datatable/part6/index.R
@@ -67,7 +67,7 @@ we recommend initializing your table with a large number of empty rows and colum
 The DataTable will always return all of the cells in the table,
 even if the cells haven't been filled out. So, you'll likely want to filter out the empty values.
 
-When you clear a cell, the DataTable will set its contents to `''` (emtpy string).
+When you clear a cell, the DataTable will set its contents to `''` (empty string).
 So, for consistency, we recommend initializing your empty data with `''`.
 
 > Heads up! In the future, when we introduce proper data types,

--- a/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
+++ b/dash_docs/chapters/dash_enterprise/dash_enterprise_chapters.py
@@ -3424,7 +3424,7 @@ Troubleshooting = html.Div(children=[
 
         > Background
 
-        > Dash Enterprise uses buildpack technolgy in order to automatically
+        > Dash Enterprise uses buildpack technology in order to automatically
         > build Docker containers. These buildpacks are detected automatically
         > dependeing on the files within the project file.
 
@@ -3458,7 +3458,7 @@ Troubleshooting = html.Div(children=[
 
         > Background
 
-        > Dash Enterprise uses buildpack technolgy in order to automatically
+        > Dash Enterprise uses buildpack technology in order to automatically
         > build Docker containers. These buildpacks are detected automatically
         > dependeing on the files within the project file.
 

--- a/dash_docs/chapters/devtools/index.py
+++ b/dash_docs/chapters/devtools/index.py
@@ -95,7 +95,7 @@ This includes:
     - `time (avg milliseconds)` - How long the request took. This is the same as the summary on the green box.
         - `total` - The total time of the request.
         - `compute` - The time spent running your callback function and serializing & deserializing the data. Serialization and deserialization is a data conversion step that the `dash` framework framework performs when receiving and sending data to the client.
-        - `network` - The time spent transfering the data from the browser client to the server and back.
+        - `network` - The time spent transferring the data from the browser client to the server and back.
         - `user: <task-id>` - (Optional) Custom timing events captured by `dash.callback_context.record_timing` (see "Custom Timing Events" below)
     - `data transfer (avg bytes)`
         - `download` - The number of bytes sent from the browser client to the server. This is the data that is passed into your callback function: the `Input` & `State`.

--- a/dash_docs/tutorial/core_component_examples.py
+++ b/dash_docs/tutorial/core_component_examples.py
@@ -301,10 +301,10 @@ dcc.Graph(
     properties in the following way:
 
     * `True`: `config.responsive` and `figure.layout.autosize` are
-    overriden with `True` values, and `figure.layout.height` and
+    overridden with `True` values, and `figure.layout.height` and
     `figure.layout.width` are unset
     * `False`: `config.responsive` and `figure.layout.autosize` are
-      both overriden with `False` values
+      both overridden with `False` values
     * `'auto'`: the resizability of the plot is determined the
       same way as it used to be (i.e., with the four properties above)
 

--- a/dash_docs/utils.R
+++ b/dash_docs/utils.R
@@ -15,7 +15,7 @@ LoadExampleCode <- function(filename, wd = NULL) {
     # and return it
     list('app\\$layout\\(', 'layout <- htmlDiv\\('),
     # Since app is in the namespace from the `app.R` import,
-    # it will implicity be picked up by the
+    # it will implicitly be picked up by the
     # `eval` call below
     list('app <- Dash\\$new\\(\\)', ''),
     list('app\\$run_server\\(\\)', '')


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL