### PR TITLE
Fix escaped quote not showing up in docs

### DIFF
--- a/dash_docs/chapters/dash_html_components/index.py
+++ b/dash_docs/chapters/dash_html_components/index.py
@@ -34,7 +34,7 @@ layout = html.Div(children=[
         html.H1('Hello Dash'),
         html.Div([
             html.P('Dash converts Python classes into HTML'),
-            html.P('This conversion happens behind the scenes by Dash\'s JavaScript front-end')
+            html.P("This conversion happens behind the scenes by Dash's JavaScript front-end")
         ])
     ])
     ```


### PR DESCRIPTION
This currently shows up incorrectly at the home page:

![image](https://user-images.githubusercontent.com/4560057/104391811-95178780-54f5-11eb-9d8c-c6c369bf28b6.png)

https://dash.plotly.com/dash-html-components

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand