### PR TITLE
inline flask-caching examples with markdown

### DIFF
--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -1228,7 +1228,7 @@ URLS = [
                 'url': '/app-lifecycle',
                 'content': chapters.app_lifecycle.index.layout,
                 'name': 'Dash App Lifecycle',
-                'description': 'An overview of the lifecyle of a Dash app'
+                'description': 'An overview of the lifecycle of a Dash app'
             },
 
             {

--- a/dash_docs/chapters/app_lifecycle/index.R
+++ b/dash_docs/chapters/app_lifecycle/index.R
@@ -8,7 +8,7 @@ layout <- htmlDiv(
     dccMarkdown("
     # Dash App Life Cycle
 
-    This section describes the lifecyle of a Dash app.
+    This section describes the lifecycle of a Dash app.
 
     1. When `Rscript -e \"source('app.R')\"` is run, all of the files in a Dash app are executed. This means that if you have a statement such as `df <- read.csv(...)`, it is run when the program starts, rather than when the page is loaded. Therefore, if the CSV changes after the program starts, `df` will not be updated until the program restarts. In this case, it is recommended to provide data via a periodic `celery` task or by setting `app.layout` as a function to regenerate the layout with each page load.
 

--- a/dash_docs/chapters/app_lifecycle/index.py
+++ b/dash_docs/chapters/app_lifecycle/index.py
@@ -9,7 +9,7 @@ layout = html.Div(children=[
     rc.Markdown('''
     # Dash App Life Cycle
 
-    This section describes the lifecyle of a Dash app.
+    This section describes the lifecycle of a Dash app.
 
     1. When `python app.py` or `gunicorn app:server` is run, all of the files in a Dash app are executed. This means that if you have a statement such as `df = pd.read_csv('...')`, it is run when the program starts, rather than when the page is loaded. Therefore, if the CSV changes after the program starts, `df` will not be updated until the program restarts. In this case, it is recommended to provide data via a periodic `celery` task or by setting `app.layout` as a function to regenerate the layout with each page load.
 

--- a/dash_docs/chapters/performance/index.py
+++ b/dash_docs/chapters/performance/index.py
@@ -48,7 +48,7 @@ data (clear your cache) every hour or every day.
 Here is an example of `Flask-Caching` with Redis:
 '''),
 
-    rc.Syntax(examples['performance_flask_caching.py'][0]),
+    rc.Markdown(examples['performance_flask_caching.py'][0]),
 
     rc.Markdown('''
 
@@ -62,7 +62,7 @@ several callbacks.
 
 '''),
 
-    rc.Syntax(examples['performance_flask_caching_dataset.py'][0]),
+    rc.Markdown(examples['performance_flask_caching_dataset.py'][0]),
 
     rc.Markdown('''
 

--- a/dash_docs/chapters/performance/index.py
+++ b/dash_docs/chapters/performance/index.py
@@ -3,7 +3,6 @@ import dash_html_components as html
 from dash_docs import tools
 from dash_docs import reusable_components as rc
 
-examples = tools.load_examples(__file__)
 
 layout = html.Div(children=[
     rc.Markdown('''# Performance
@@ -48,7 +47,59 @@ data (clear your cache) every hour or every day.
 Here is an example of `Flask-Caching` with Redis:
 '''),
 
-    rc.Markdown(examples['performance_flask_caching.py'][0]),
+    rc.Markdown("""
+    ```python
+
+    import datetime
+    import os
+
+    import dash
+    import dash_core_components as dcc
+    import dash_html_components as html
+    from dash.dependencies import Input, Output
+    from flask_caching import Cache
+
+    external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+    app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+    cache = Cache(app.server, config={
+        # try 'filesystem' if you don't want to setup redis
+        'CACHE_TYPE': 'redis',
+        'CACHE_REDIS_URL': os.environ.get('REDIS_URL', '')
+    })
+    app.config.suppress_callback_exceptions = True
+
+    timeout = 20
+    app.layout = html.Div([
+        html.Div(id='flask-cache-memoized-children'),
+        dcc.RadioItems(
+            id='flask-cache-memoized-dropdown',
+            options=[
+                {'label': 'Option {}'.format(i), 'value': 'Option {}'.format(i)}
+                for i in range(1, 4)
+            ],
+            value='Option 1'
+        ),
+        html.Div('Results are cached for {} seconds'.format(timeout))
+    ])
+
+
+    @app.callback(
+        Output('flask-cache-memoized-children', 'children'),
+        Input('flask-cache-memoized-dropdown', 'value'))
+    @cache.memoize(timeout=timeout)  # in seconds
+    def render(value):
+        return 'Selected "{}" at "{}"'.format(
+            value, datetime.datetime.now().strftime('%H:%M:%S')
+        )
+
+
+    if __name__ == '__main__':
+        app.run_server(debug=True)
+    ```
+
+
+    """    ),
 
     rc.Markdown('''
 
@@ -62,7 +113,111 @@ several callbacks.
 
 '''),
 
-    rc.Markdown(examples['performance_flask_caching_dataset.py'][0]),
+    rc.Markdown("""
+    ```python
+
+    import datetime as dt
+
+    import dash
+    import dash_core_components as dcc
+    import dash_html_components as html
+    import numpy as np
+    import pandas as pd
+    from dash.dependencies import Input, Output
+    from flask_caching import Cache
+
+    external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+    app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+    cache = Cache(app.server, config={
+        'CACHE_TYPE': 'filesystem',
+        'CACHE_DIR': 'cache-directory'
+    })
+
+    TIMEOUT = 60
+
+    @cache.memoize(timeout=TIMEOUT)
+    def query_data():
+        # This could be an expensive data querying step
+        np.random.seed(0)  # no-display
+        df = pd.DataFrame(
+            np.random.randint(0, 100, size=(100, 4)),
+            columns=list('ABCD')
+        )
+        now = dt.datetime.now()
+        df['time'] = [now - dt.timedelta(seconds=5*i) for i in range(100)]
+        return df.to_json(date_format='iso', orient='split')
+
+
+    def dataframe():
+        return pd.read_json(query_data(), orient='split')
+
+    app.layout = html.Div([
+        html.Div('Data was updated within the last {} seconds'.format(TIMEOUT)),
+        dcc.Dropdown(
+            id='live-dropdown',
+            value='A',
+            options=[{'label': i, 'value': i} for i in dataframe().columns]
+        ),
+        dcc.Graph(id='live-graph')
+    ])
+
+
+    @app.callback(Output('live-graph', 'figure'),
+                Input('live-dropdown', 'value'))
+    def update_live_graph(value):
+        df = dataframe()
+        now = dt.datetime.now()
+        return {
+            'data': [{
+                'x': df['time'],
+                'y': df[value],
+                'line': {
+                    'width': 1,
+                    'color': '#0074D9',
+                    'shape': 'spline'
+                }
+            }],
+            'layout': {
+                # display the current position of now
+                # this line will be between 0 and 60 seconds
+                # away from the last datapoint
+                'shapes': [{
+                    'type': 'line',
+                    'xref': 'x', 'x0': now, 'x1': now,
+                    'yref': 'paper', 'y0': 0, 'y1': 1,
+                    'line': {'color': 'darkgrey', 'width': 1}
+                }],
+                'annotations': [{
+                    'showarrow': False,
+                    'xref': 'x', 'x': now, 'xanchor': 'right',
+                    'yref': 'paper', 'y': 0.95, 'yanchor': 'top',
+                    'text': 'Current time ({}:{}:{})'.format(
+                        now.hour, now.minute, now.second),
+                    'bgcolor': 'rgba(255, 255, 255, 0.8)'
+                }],
+                # aesthetic options
+                'margin': {'l': 40, 'b': 40, 'r': 20, 't': 10},
+                'xaxis': {'showgrid': False, 'zeroline': False},
+                'yaxis': {'showgrid': False, 'zeroline': False}
+            }
+        }
+
+
+    if __name__ == '__main__':
+        app.run_server(debug=True)
+
+
+
+    ```
+
+
+
+
+
+
+
+    """),
 
     rc.Markdown('''
 

--- a/dash_docs/chapters/sharing_data/index.py
+++ b/dash_docs/chapters/sharing_data/index.py
@@ -5,8 +5,6 @@ import dash_html_components as html
 from dash_docs import tools
 from dash_docs import reusable_components as rc
 
-examples = tools.load_examples(__file__)
-
 
 layout = html.Div([
     rc.Markdown('''
@@ -526,13 +524,113 @@ def update_output_1(value):
         > [Session Fixation](https://en.wikipedia.org/wiki/Session_fixation)
         > style attacks.
 
+        Here's what this example looks like in code:
+
         '''),
 
-    rc.Syntax(
-        # with Syntax + load_example we are wrapping twice, hence replace()
-        examples['sharing_state_filesystem_sessions.py'][0].replace('```python ', ''),
-        summary="Here's what this example looks like in code:"
-    ),
+    rc.Markdown("""
+    ```python
+    import dash
+    from dash.dependencies import Input, Output
+    import dash_core_components as dcc
+    import dash_html_components as html
+    import datetime
+    from flask_caching import Cache
+    import os
+    import pandas as pd
+    import time
+    import uuid
+
+    external_stylesheets = [
+        # Dash CSS
+        'https://codepen.io/chriddyp/pen/bWLwgP.css',
+        # Loading screen CSS
+        'https://codepen.io/chriddyp/pen/brPBPO.css']
+
+    app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+    cache = Cache(app.server, config={
+        'CACHE_TYPE': 'redis',
+        # Note that filesystem cache doesn't work on systems with ephemeral
+        # filesystems like Heroku.
+        'CACHE_TYPE': 'filesystem',
+        'CACHE_DIR': 'cache-directory',
+
+        # should be equal to maximum number of users on the app at a single time
+        # higher numbers will store more data in the filesystem / redis cache
+        'CACHE_THRESHOLD': 200
+    })
+
+
+    def get_dataframe(session_id):
+        @cache.memoize()
+        def query_and_serialize_data(session_id):
+            # expensive or user/session-unique data processing step goes here
+
+            # simulate a user/session-unique data processing step by generating
+            # data that is dependent on time
+            now = datetime.datetime.now()
+
+            # simulate an expensive data processing task by sleeping
+            time.sleep(5)
+
+            df = pd.DataFrame({
+                'time': [
+                    str(now - datetime.timedelta(seconds=15)),
+                    str(now - datetime.timedelta(seconds=10)),
+                    str(now - datetime.timedelta(seconds=5)),
+                    str(now)
+                ],
+                'values': ['a', 'b', 'a', 'c']
+            })
+            return df.to_json()
+
+        return pd.read_json(query_and_serialize_data(session_id))
+
+
+    def serve_layout():
+        session_id = str(uuid.uuid4())
+
+        return html.Div([
+            html.Div(session_id, id='session-id', style={'display': 'none'}),
+            html.Button('Get data', id='get-data-button'),
+            html.Div(id='output-1'),
+            html.Div(id='output-2')
+        ])
+
+
+    app.layout = serve_layout
+
+
+    @app.callback(Output('output-1', 'children'),
+                Input('get-data-button', 'n_clicks'),
+                Input('session-id', 'children'))
+    def display_value_1(value, session_id):
+        df = get_dataframe(session_id)
+        return html.Div([
+            'Output 1 - Button has been clicked {} times'.format(value),
+            html.Pre(df.to_csv())
+        ])
+
+
+    @app.callback(Output('output-2', 'children'),
+                Input('get-data-button', 'n_clicks'),
+                Input('session-id', 'children'))
+    def display_value_2(value, session_id):
+        df = get_dataframe(session_id)
+        return html.Div([
+            'Output 2 - Button has been clicked {} times'.format(value),
+            html.Pre(df.to_csv())
+        ])
+
+
+    if __name__ == '__main__':
+        app.run_server(debug=True)
+
+
+
+    ```
+
+    """),
 
     html.Div(
         children=html.Img(


### PR DESCRIPTION
addresses https://github.com/plotly/dash-enterprise-docs/issues/716 

The purpose of this PR is to make sure that running `gunicorn --preload index:server` does not result in a `TypeError: sequence item 0: expected str instance, NoneType found` being thrown, which may lead to customer confusion as per the above issue. 

This is achieved by inlining examples that import `flask-caching` with Markdown instead of using the `load_examples()` function, which means that the code is not executed. The `example` folders are kept for future maintainability. 

Test Plan: Run `gunicorn --preload index:server` and note the absence of a `TypeError`. 

