### PR TITLE
Emphasize changing server host url when deploying

### DIFF
--- a/dash_docs/chapters/deployment/index.R
+++ b/dash_docs/chapters/deployment/index.R
@@ -93,7 +93,7 @@ app$callback(output=list(id='display-value', property='children'),
   }
 )
 
-app$run_server(host = '0.0.0.0', port = Sys.getenv('PORT', 8050))
+app$run_server(host = '0.0.0.0')
 ```
 
 ---

--- a/dash_docs/chapters/deployment/index.R
+++ b/dash_docs/chapters/deployment/index.R
@@ -63,7 +63,7 @@ $ git init        # initializes an empty git repo
 
 ---
 
-Step 3. Initialize the folder with a sample app (`app.R`), a `.gitignore` file (not required, but will avoid committing any files that aren't necessary for your app to function), `Dockerfile`, `heroku.yml` for deployment. Note that you **must change the last line of your app** to `.app$run_server(host = '0.0.0.0')` for your app to work properly on Heroku.
+Step 3. Initialize the folder with a sample app (`app.R`), a `.gitignore` file (not required, but will avoid committing any files that aren't necessary for your app to function), `Dockerfile`, `heroku.yml` for deployment. Note that you **must change the last line of your app** to `app$run_server(host = '0.0.0.0')` for your app to work properly on Heroku.
 
 Create the following files in your project folder:
 

--- a/dash_docs/chapters/deployment/index.R
+++ b/dash_docs/chapters/deployment/index.R
@@ -63,7 +63,7 @@ $ git init        # initializes an empty git repo
 
 ---
 
-Step 3. Initialize the folder with a sample app (`app.R`), a `.gitignore` file (not required, but will avoid committing any files that aren't necessary for your app to function), `Dockerfile`, `heroku.yml` for deployment.
+Step 3. Initialize the folder with a sample app (`app.R`), a `.gitignore` file (not required, but will avoid committing any files that aren't necessary for your app to function), `Dockerfile`, `heroku.yml` for deployment. Note that you **must change the last line of your app** to `.app$run_server(host = '0.0.0.0')` for your app to work properly on Heroku.
 
 Create the following files in your project folder:
 


### PR DESCRIPTION
This is branched from #1083, so please merge that first (I didn't want to add to it since it was already approved).

@rpkyle Only the two last commits are new here emphasizing the need to specify `host = '0.0.0.0'` since this is different from running locally. I also removed the port argument [since it is just set to the default for app$run_server](https://github.com/plotly/dashR/blob/add8dd3d93b23c0feb966e39f711ed58be256373/R/dash.R#L1183)



Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand
