### PR TITLE
dash circular callbacks documentation

### DIFF
--- a/dash_docs/chapters/advanced_callbacks/examples/circular_checkbox.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/circular_checkbox.py
@@ -1,0 +1,49 @@
+import dash
+from dash.dependencies import Input, Output, State
+import dash_core_components as dcc
+import dash_html_components as html
+
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+options = [
+    {"label": "New York City", "value": "NYC"},
+    {"label": "Montréal", "value": "MTL"},
+    {"label": "San Francisco", "value": "SF"},
+]
+all_cities = [option["value"] for option in options]
+
+app.layout = html.Div(
+    [
+        dcc.Checklist(
+            id="all-checklist",
+            options=[{"label": "All", "value": "All"}],
+            value=[],
+            labelStyle={"display": "inline-block"},
+        ),
+        dcc.Checklist(
+            id="city-checklist",
+            options=options,
+            value=[],
+            labelStyle={"display": "inline-block"},
+        ),
+    ]
+)
+@app.callback(
+    Output("city-checklist", "value"),
+    Output("all-checklist", "value"),
+    Input("city-checklist", "value"),
+    Input("all-checklist", "value"),
+)
+def sync_checklists(cities_selected, all_selected):
+    ctx = dash.callback_context
+    input_id = ctx.triggered[0]["prop_id"].split(".")[0]
+    if input_id == "city-checklist":
+        all_selected = ["All"] if set(cities_selected) == set(all_cities) else []
+    else:
+        cities_selected = all_cities if all_selected else []
+    return cities_selected, all_selected
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
@@ -3,44 +3,31 @@ from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 
-app = dash.Dash(__name__)
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 
-app.layout = html.Div(children=[
-    dcc.Slider(
-        id='slider-circular',
-        min=0, max=20,
-    ),
-    dcc.Input(
-        id='input-circular',
-        type='number',
-        debounce=False,
-        value=3
-    ),
-])
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 
-
-@app.callback(
-    Output('input-circular', 'value'),
-    Output('slider-circular', 'value'),
-    Input('input-circular', 'value'),
-    Input('slider-circular', 'value'),
+app.layout = html.Div(
+    [
+        dcc.Slider(
+            id="slider", min=0, max=20, 
+            marks={i: str(i) for i in range(21)}, 
+            value=3
+        ),
+        dcc.Input(
+            id="input", type="number", min=0, max=20, value=3
+        ),
+    ]
 )
-def callback(iv, sv):
+@app.callback(
+    Output("input", "value"),
+    Output("slider", "value"),
+    Input("input", "value"),
+    Input("slider", "value"),
+)
+def callback(input_value, slider_value):
     ctx = dash.callback_context
-    if not ctx.triggered:
-        # default to input value during initialization
-        if iv is not None:
-            value = iv
-        else:
-            value = sv
-    else:
-        trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
-        if trigger_id == 'input':
-            value = iv
-        else:
-            value = sv
+    trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
+    value = input_value if trigger_id == "input" else slider_value
     return value, value
-
-
-if __name__ == '__main__':
-    app.run_server(debug=True)
+app.run_server(debug=True)

--- a/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
@@ -10,24 +10,26 @@ app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 app.layout = html.Div(
     [
         dcc.Slider(
-            id="slider", min=0, max=20, 
+            id="slider-circular", min=0, max=20, 
             marks={i: str(i) for i in range(21)}, 
             value=3
         ),
         dcc.Input(
-            id="input", type="number", min=0, max=20, value=3
+            id="input-circular", type="number", min=0, max=20, value=3
         ),
     ]
 )
 @app.callback(
-    Output("input", "value"),
-    Output("slider", "value"),
-    Input("input", "value"),
-    Input("slider", "value"),
+    Output("input-circular", "value"),
+    Output("slider-circular", "value"),
+    Input("input-circular", "value"),
+    Input("slider-circular", "value"),
 )
 def callback(input_value, slider_value):
     ctx = dash.callback_context
     trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
     value = input_value if trigger_id == "input" else slider_value
     return value, value
-app.run_server(debug=True)
+    
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/circular_slider_input.py
@@ -1,0 +1,46 @@
+import dash
+from dash.dependencies import Input, Output
+import dash_core_components as dcc
+import dash_html_components as html
+
+app = dash.Dash(__name__)
+
+app.layout = html.Div(children=[
+    dcc.Slider(
+        id='slider-circular',
+        min=0, max=20,
+    ),
+    dcc.Input(
+        id='input-circular',
+        type='number',
+        debounce=False,
+        value=3
+    ),
+])
+
+
+@app.callback(
+    Output('input-circular', 'value'),
+    Output('slider-circular', 'value'),
+    Input('input-circular', 'value'),
+    Input('slider-circular', 'value'),
+)
+def callback(iv, sv):
+    ctx = dash.callback_context
+    if not ctx.triggered:
+        # default to input value during initialization
+        if iv is not None:
+            value = iv
+        else:
+            value = sv
+    else:
+        trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
+        if trigger_id == 'input':
+            value = iv
+        else:
+            value = sv
+    return value, value
+
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/dash_docs/chapters/advanced_callbacks/examples/circular_units_input.py
+++ b/dash_docs/chapters/advanced_callbacks/examples/circular_units_input.py
@@ -1,0 +1,41 @@
+import dash
+from dash.dependencies import Input, Output, State
+import dash_core_components as dcc
+import dash_html_components as html
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+app.layout = html.Div([
+    html.Div('Convert Temperature'),
+    'Celsius',
+    dcc.Input(
+        id="celsius",
+        value=0.0,
+        type="number"
+    ),
+    ' = Fahrenheit',
+    dcc.Input(
+        id="fahrenheit",
+        value=32.0,
+        type="number",
+    ),
+])
+
+@app.callback(
+    Output("celsius", "value"),
+    Output("fahrenheit", "value"),
+    Input("celsius", "value"),
+    Input("fahrenheit", "value"),
+)
+def sync_input(celsius, fahrenheit):
+    ctx = dash.callback_context
+    input_id = ctx.triggered[0]["prop_id"].split(".")[0]
+    if input_id == "celsius":
+        fahrenheit= None if celsius is None else (float(celsius) * 9/5) + 32
+    else:
+        celsius = None if fahrenheit is None else (float(fahrenheit) - 32) * 5/9
+    return celsius, fahrenheit
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/dash_docs/chapters/advanced_callbacks/index.py
+++ b/dash_docs/chapters/advanced_callbacks/index.py
@@ -206,6 +206,35 @@ def slow_function(input):
     In this case, `prevent_initial_call` will prevent the `update_output()` callback from firing when its input is first inserted into the app layout as a result of the `display_page()` callback. This is because both the input and output of the callback are already contained within the app layout when the callback executes.
 
     However, because the app layout contains only the output of the callback, and not its input, `prevent_initial_call` will not prevent the `update_layout_div()` callback from firing. Since `suppress_callback_exceptions=True` is specified here, Dash has to assume that the input is present in the app layout when the app is initialized. From the perspective of the output element in this example, the new input component is handled as if an existing input had been provided a new value, rather than treating it as initially rendered.
-    ''')
+    '''),
+    
+    rc.Markdown(
+    '''
+    ## Circular Callbacks
+    
+    As of `dash v1.19.0`, you can create circular updates 
+     _within the same callback_.
+    
+    Circular callback chains that involve multiple callbacks are not supported.
+    
+    Circular callbacks can be used to keep multiple inputs synchronized to 
+    each other. 
+    
+    ### Synchronizing a Slider with a Text Input Example
+    '''
+    ),
+    
+    rc.Syntax(examples['circular_slider_input.py'][0]),
+    rc.Example(examples['circular_slider_input.py'][1]),
+    
+    rc.Markdown(
+    '''
+    ### Displaying Two Inputs with Different Units Example
+    '''
+    ),
+    
+    rc.Syntax(examples['circular_units_input.py'][0]),
+    rc.Example(examples['circular_units_input.py'][1]),
+    
 
 ])

--- a/dash_docs/chapters/advanced_callbacks/index.py
+++ b/dash_docs/chapters/advanced_callbacks/index.py
@@ -235,6 +235,16 @@ def slow_function(input):
     
     rc.Syntax(examples['circular_units_input.py'][0]),
     rc.Example(examples['circular_units_input.py'][1]),
+
+    
+    rc.Markdown(
+    '''
+    ### Synchronizing Two Checklists
+    '''
+    ),
+    
+    rc.Syntax(examples['circular_checkbox.py'][0]),
+    rc.Example(examples['circular_checkbox.py'][1]),
     
 
 ])


### PR DESCRIPTION
Documenting the feature added in https://github.com/plotly/dash/pull/1525 🎉 

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL