### PR TITLE
Replace this with self in React for Python guide classes example

### DIFF
--- a/dash_docs/chapters/react_for_python_developers/index.py
+++ b/dash_docs/chapters/react_for_python_developers/index.py
@@ -353,7 +353,7 @@ class MyComponent(Component):
         self.a = a;
         super().__init__(a)
 
-    def render(this):
+    def render(self):
         return self.a;
 ```
 

--- a/dash_docs/chapters/react_for_python_developers/index.py
+++ b/dash_docs/chapters/react_for_python_developers/index.py
@@ -347,7 +347,7 @@ console.log(add(4, 6)); // 10
 > Heads up! Classes, among other features, are new language features in JavaScript. Technically, they're part of a new version of JavaScript called ES6. When we build our JavaScript code, a tool called Babel will convert these new language features into simpler JavaScript that older browsers like IE11 can understand.
 
 JavaScript classes are very similar to Python classes. For example, this Python class:
-```js
+```py
 class MyComponent(Component):
     def __init__(self, a):
         super().__init__()

--- a/dash_docs/chapters/react_for_python_developers/index.py
+++ b/dash_docs/chapters/react_for_python_developers/index.py
@@ -350,8 +350,8 @@ JavaScript classes are very similar to Python classes. For example, this Python 
 ```js
 class MyComponent(Component):
     def __init__(self, a):
+        super().__init__()
         self.a = a;
-        super().__init__(a)
 
     def render(self):
         return self.a;
@@ -360,7 +360,7 @@ class MyComponent(Component):
 would be written in JavaScript as:
 ```js
 class MyComponent extends Component {
-  init() {
+  init(a) {
       super();
       this.a = a;
   }


### PR DESCRIPTION
Make Python and JS class examples in [React for Python Developers](https://dash.plotly.com/react-for-python-developers) guide similar.

Fixes #1088

<hr>

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

<!--If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL-->