### PR TITLE
Update installation instructions for boilerplate guide

### DIFF
--- a/dash_docs/chapters/react_for_python_developers/index.py
+++ b/dash_docs/chapters/react_for_python_developers/index.py
@@ -143,8 +143,8 @@ This allows users to create a project with custom values formatted for the proje
 ### Build the project
 
 - `npm run build:js` generate the JavaScript bundle `project_shortname.min.js`
-- `npm run build:py_and_r` generate the Python and R class files for the components.
-- `npm run build` generate everything: the JavaScript bundles and the Python and R class files.
+- `npm run build:backends` generate the Python, R and Julia class files for the components.
+- `npm run build` generate everything: the JavaScript bundles and the Python, R and Julia class files.
 
 ### Release the project
 


### PR DESCRIPTION
Follows this change: https://github.com/plotly/dash-component-boilerplate/pull/117

`npm run build:py_and_r` -> `npm run build:backends`

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL