### PR TITLE
revamp installation page: more up-to-date description, and recommend pandas

### DIFF
--- a/dash_docs/chapters/installation/index.py
+++ b/dash_docs/chapters/installation/index.py
@@ -10,13 +10,8 @@ layout = html.Div([
     rc.Markdown("""
     # Dash Installation
 
-    In your terminal, install `dash`. This brings along three component libraries
-    that make up the core of Dash: `dash_html_components`, `dash_core_components`,
-    `dash_table`, along with the `plotly` graphing library. These libraries are
-    under active development, so install and upgrade frequently.
-    These docs are running `dash` version `{}`.
-    Python 2 and 3 are supported.
-    """.format(dash.__version__)),
+    In your terminal, install `dash`.
+    """),
 
     rc.Markdown("""
     ```shell
@@ -27,10 +22,18 @@ layout = html.Div([
     html.Br(),
 
     rc.Markdown("""
+    This brings along three component libraries
+    that make up the core of Dash: `dash_html_components`, `dash_core_components`,
+    `dash_table`, as well as the `plotly` graphing library. These libraries are
+    under active development, so install and upgrade frequently.
+
+    These docs are running `dash` version `{}`.
+    Python 2 and 3 are supported.
+
     We also recommend installing [Pandas](https://pandas.pydata.org/), which is
     required by [Plotly Express](https://plotly.com/python/plotly-express/) and
     used in many of our examples.
-    """),
+    """.format(dash.__version__)),
 
     rc.Markdown("""
     ```shell

--- a/dash_docs/chapters/installation/index.py
+++ b/dash_docs/chapters/installation/index.py
@@ -1,44 +1,46 @@
 # -*- coding: utf-8 -*-
 import dash
-import dash_renderer
-import dash_core_components as dcc
 import dash_html_components as html
-import dash_table
-import dash_daq
-
-import plotly
 
 from dash_docs import styles, tools
 from dash_docs import reusable_components as rc
 
 layout = html.Div([
 
-    rc.Markdown('''
+    rc.Markdown("""
     # Dash Installation
 
-    In your terminal, install several dash libraries.
-    These libraries are under active development,
-    so install and upgrade frequently. These docs are run
-    using the versions listed below.
-    Python 2 and 3 are supported.'''),
+    In your terminal, install `dash`. This brings along three component libraries
+    that make up the core of Dash: `dash_html_components`, `dash_core_components`,
+    `dash_table`, along with the `plotly` graphing library. These libraries are
+    under active development, so install and upgrade frequently.
+    These docs are running `dash` version `{}`.
+    Python 2 and 3 are supported.
+    """.format(dash.__version__)),
 
-    rc.Markdown('''
+    rc.Markdown("""
     ```shell
-    pip install dash=={}
+    pip install dash
     ```
-    '''.format(
-        dash.__version__,
-        dash_daq.__version__
-    ), style=styles.code_container),
+    """, style=styles.code_container),
+
+    html.Br(),
+
+    rc.Markdown("""
+    We also recommend installing [Pandas](https://pandas.pydata.org/), which is
+    required by [Plotly Express](https://plotly.com/python/plotly-express/) and
+    used in many of our examples.
+    """),
+
+    rc.Markdown("""
+    ```shell
+    pip install pandas
+    ```
+    """, style=styles.code_container),
 
     html.Hr(),
 
-    rc.WorkspaceBlurb if not tools.is_in_dash_enterprise() else '',
+    rc.WorkspaceBlurb if not tools.is_in_dash_enterprise() else "",
 
-    html.Div([
-        'Ready? Now, let\'s ',
-        dcc.Link('make your first Dash app', href=tools.relpath('/layout')),
-        '.'
-    ]),
-
+    rc.Markdown("Ready? Now, let's [make your first Dash app](/layout)."),
 ])


### PR DESCRIPTION
Most of our examples use pandas or require it indirectly via px - so until we bring it in implicitly (planned for plotly.py 6.0, dash 2.0) we should mention it in the installation section.

Also cleans up the prose - the displayed command was correct, but the description still said "In your terminal, install several dash libraries" left over from when you had to install dcc, html, and table separately.