### PR TITLE
First cut at custom hover docs

### DIFF
--- a/dash_docs/assets/sitemap.xml
+++ b/dash_docs/assets/sitemap.xml
@@ -789,6 +789,9 @@
     <loc>https://dash.plotly.com/persistence</loc>
 </url>
 <url>
+    <loc>https://dash.plotly.com/custom-hover-content</loc>
+</url>
+<url>
     <loc>https://dash.plotly.com/plugins</loc>
 </url>
 <url>

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -1204,6 +1204,16 @@ URLS = [
             },
 
             {
+                'url': '/custom-hover-content',
+                'content': chapters.custom_hover_content.index.layout,
+                'name': 'Custom Hover Content',
+                'description': '''
+                    (Released February 2021 with Dash X.X) Add custom Dash content
+                    to plot hovers.
+                '''
+            },
+
+            {
                 'url': '/devtools',
                 'content': chapters.devtools.index.layout,
                 'name': 'Dev tools',

--- a/dash_docs/chapters/__init__.py
+++ b/dash_docs/chapters/__init__.py
@@ -23,6 +23,7 @@ from .import live_updates
 from .import migration
 from .import performance
 from .import persistence
+from .import custom_hover_content
 from .import plugins
 from .import sharing_data
 from .import clientside_callbacks

--- a/dash_docs/chapters/custom_hover_content/__init__.py
+++ b/dash_docs/chapters/custom_hover_content/__init__.py
@@ -1,0 +1,1 @@
+from .import index

--- a/dash_docs/chapters/custom_hover_content/examples/basic_hover.py
+++ b/dash_docs/chapters/custom_hover_content/examples/basic_hover.py
@@ -1,0 +1,60 @@
+import math
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+from plotly import express as px
+import pandas as pd
+
+
+df = pd.DataFrame({
+    "Fruit": ["Apples", "Oranges", "Bananas", "Apples", "Oranges", "Bananas"],
+    "Amount": [4, 1, 2, 2, 4, 5],
+    "City": ["SF", "SF", "SF", "Montreal", "Montreal", "Montreal"]
+})
+fig = px.scatter(df, x="Fruit", y="Amount", color="City")
+fig.update_traces(hoverinfo="none", hovertemplate=None)
+
+# This does not work because I'm not a PRO CodePen user.
+external_stylesheets = ['https://codepen.io/rsreusser/pen/RwoBXpK.css']
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+app.layout = html.Div(children=[
+    html.Div( id='my-hovers'),
+    dcc.Graph( id='graph', figure=fig, clear_on_unhover=True )
+])
+
+@app.callback(
+    Output('my-hovers', 'children'),
+    Input('graph', 'hoverData')
+)
+def display_hover(hoverData):
+    hovers = []
+    if not hoverData:
+        return []
+
+    for pt in hoverData['points']:
+        # TODO: Decide based on page size
+        hoverLeft = pt['offsetX1'] > 200
+
+        hovers.append(html.Div(
+            className='hover {}'.format('hover-left' if hoverLeft else ''),
+            style={
+                # Be sure to round these to avoid fractional pixel offsets
+                # Align veritcally with the middle of the bounding box
+                'top': round(0.5 * (pt['offsetY0'] + pt['offsetY1'])),
+
+                # Align to the left or right edge, depending on the hover direction
+                'left': round(pt['offsetX0'] if hoverLeft else pt['offsetX1'])
+            },
+            children=[
+                html.Div(
+                    className='hover-content',
+                    children=[html.Div('{} {}'.format(pt['y'], pt['x']))],
+                ),
+            ]
+        ))
+    return hovers
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/dash_docs/chapters/custom_hover_content/examples/loading_indicator.py
+++ b/dash_docs/chapters/custom_hover_content/examples/loading_indicator.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+import plotly.express as px
+import pandas as pd
+
+df = pd.DataFrame({
+    "Fruit": ["Apples", "Oranges", "Bananas", "Apples", "Oranges", "Bananas"],
+    "Amount": [4, 1, 2, 2, 4, 5],
+    "City": ["SF", "SF", "SF", "Montreal", "Montreal", "Montreal"]
+})
+fig = px.bar(df, x="Fruit", y="Amount", color="City", barmode="group")
+fig.update_traces(
+    hovertemplate=None,
+    hoverinfo="none"
+)
+
+# This does not work because I'm not a PRO CodePen user.
+external_stylesheets = ['https://codepen.io/rsreusser/pen/RwoBXpK.css']
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+app.layout = html.Div(children=[
+    html.Div( id='my-hovers' ),
+
+    html.Div( id='my-hovers-loader', className='hover hover-loader', children=[
+        html.Div( className='hover-content', children='Loading…' )
+    ]),
+
+    dcc.Graph( id='my-graph', figure=fig, clear_on_unhover=True )
+])
+
+app.clientside_callback(
+    """
+    function(hoverData) {
+        if (!hoverData || !hoverData.points || !hoverData.points.length) {
+            return { display: 'none' };
+        }
+        var pt = hoverData.points[0];
+        return {
+            top: Math.round((pt.offsetY0 + pt.offsetY1) / 2),
+            left: Math.round(pt.offsetX1)
+        };
+    }
+    """,
+    Output('my-hovers-loader', 'style'),
+    Input('graph', 'hoverData')
+)
+
+@app.callback(
+    Output('my-hovers', 'children'),
+    Input('my-graph', 'hoverData')
+)
+def display_hover(hoverData):
+    if not hoverData:
+        return []
+
+    hovers = []
+    for pt in hoverData['points']:
+        left = pt['offsetX1'] + 2
+        top = (pt['offsetY0'] + pt['offsetY1']) / 2
+
+        hovers.append(html.Div(
+            className='hover hover-right',
+            style={
+                'top': round((pt['offsetY0'] + pt['offsetY1']) / 2),
+                'left': pt['offsetX1']
+            },
+            children=[
+                html.Div(
+                    className='hover-content',
+                    children=[html.Div('{} {}'.format(pt['y'], pt['x']))],
+                ),
+            ],
+        ))
+    return hovers
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/dash_docs/chapters/custom_hover_content/index.py
+++ b/dash_docs/chapters/custom_hover_content/index.py
@@ -1,0 +1,106 @@
+import dash_core_components as dcc
+import dash_html_components as html
+
+from dash_docs.tools import load_examples
+from dash_docs import reusable_components as rc
+
+examples = load_examples(__file__)
+
+layout = html.Div([
+    rc.Markdown('''
+    # Custom Hover Content
+
+    *New - released March 2021 with Dash X.X*
+
+    When you hover over items, Plotly plots show customizable hover information.
+    This built-in behavior is often enough, but sometimes you may wish to display
+    more complicated information including Dash content like images, custom HTML,
+    or even other plots. In this case, built-in Dash and Plotly.js features allow
+    you to build and position your own hover boxes.
+
+    ## A basic example
+
+    The first example illustrates how to build custom hover boxes from Dash
+    content. The basic mechanism is that we simply hide built-in Plotly hovers
+    and replace them with carefully positioned HTML elements.
+
+    To hide the hovers, we set both `'hoverinfo': 'skip'` and `'hovertemplate': None`.
+    Setting `skip` hides visual display of hover content while still emitting
+    hover events.
+
+    The second step is to attach a Dash callback to `hoverData`. The example
+    below shows the `hoverData` ouptut of `my-graph` connected to the `children`
+    property of the HTML div, `my-hovers`.
+
+    The final step is to construct and attach the HTML hover content. This step
+    may experience the greatest amount of variation, depending on your needs.
+    The example below constructs a single hover box for each hovered item,
+    centered on the bounding box of each hovered item and opening either to the
+    left or right, depending on the position on the plot.
+
+    Positioning items with CSS can be complicated, but the bounding box
+    coordinates returned by Plotly are carefully constructed to make this step
+    as easy as possible. The bounding box is computed relative to the CSS
+    [offset parent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent).
+    What this means for us is that as long as the custom Dash hover content is
+    a *sibling* of the graph element, other details like positioning, margins,
+    or padding shouldn't matter.
+
+    The bounding box properties returned are:
+
+    - `offsetX0`: distance from the left to the left edge of the bounding box
+    - `offsetX1`: distance from the left to the right edge of the bounding box
+    - `offsetY0`: distance from the top to the top edge of the bounding box
+    - `offsetY1`: distance from the top to the bottom edge of the bounding box
+
+    Additional notes are that it's advisable to \`round\` all pixel coordinates
+    to avoid fractional offsets, and that additional CSS properties like
+    `pointer-events: none` may be used to prevent the hover box from capturing
+    pointer events and remaining open while the mouse is within it.
+
+    The example below illustrates using these properties to position the hover
+    content.
+
+    '''),
+
+    rc.Syntax(examples['basic_hover.py'][0]),
+    rc.Example(examples['basic_hover.py'][1]),
+
+    rc.Markdown('''
+    ## Adding a loading indicator
+
+    While Dash is generating and returning the hover content, nothing is
+    displayed on the screen. This may result a laggy and confusing UI. To
+    resolve this, we may use a client-side callback to position a hover box
+    with a loading indicator while Dash is generating the actual hover content.
+
+    To accomplish this, we may use the `data-dash-is-loading` data attribute
+    of the hover content which, in a fortunate turn of events, is `true` exactly
+    while Dash is generating the content. Thus we add a single loading hover,
+    position it using a client-side callback, and control its visibility with
+    the following CSS:
+
+    ```
+    /* By default, hide the loader */
+    .hover-loader {
+        display: none;
+    }
+
+    /* Don't display hovers while server-side computation is taking place */
+    [data-dash-is-loading=true] .hover {
+        display: none;
+    }
+
+    /* Show a loader when the hover immediately preceeding it is loading */
+    [data-dash-is-loading=true] + .hover-loader {
+        display: block;
+    }
+    ```
+
+    '''),
+
+    rc.Syntax(examples['loading_indicator.py'][0]),
+    rc.Example(examples['loading_indicator.py'][1]),
+
+
+])


### PR DESCRIPTION
A first cut at dash docs for custom hover content. I've created a codepen here, which I can imagine being used for the real thing in order to provide a basic template for CSS which would apply in the majority of cases: https://codepen.io/rsreusser/pen/RwoBXpK (though I'm not a PRO user on CodePen so can't host the CSS assets there.)

More details to follow.

<!--

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL

-->