### PR TITLE
redis cache key deprecation

### DIFF
--- a/dash_docs/chapters/performance/examples/performance_flask_caching.py
+++ b/dash_docs/chapters/performance/examples/performance_flask_caching.py
@@ -12,7 +12,7 @@ external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
 cache = Cache(app.server, config={
     # try 'filesystem' if you don't want to setup redis
-    'CACHE_TYPE': 'redis',
+    'CACHE_TYPE': 'RedisCache',
     'CACHE_REDIS_URL': os.environ.get('REDIS_URL', '')
 })
 app.config.suppress_callback_exceptions = True


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x ] I understand

---
According to https://flask-caching.readthedocs.io/en/latest/index.html#rediscache, 

![image](https://user-images.githubusercontent.com/39112330/112702573-55143f80-8e6a-11eb-994e-b5444697dfc5.png)

I don't know if there are other instances where redis caches were shown using the deprecated string.