### PR TITLE
Edits required to use updated buildpack for Dash for R docs deployment + minor fixes

### DIFF
--- a/dash_docs/chapters/sharing_data/index.R
+++ b/dash_docs/chapters/sharing_data/index.R
@@ -24,7 +24,7 @@ layout <- htmlDiv(
 > covered how to use callbacks with the `dashCoreComponents.Graph` component.
 > The rest of the Dash documentation covers other topics like multi-page apps and component libraries.
 > Just getting started? Make sure to [install the necessary dependencies](/installation).
-> The [next and final chapter](/faq-gotchas) covers frequently asked questions and gotchas.
+> The [next and final chapter](/faqs) covers frequently asked questions and gotchas.
 
 One of the core Dash principles explained in the
 [Getting Started Guide on Callbacks](/getting-started-part-2)

--- a/run.R
+++ b/run.R
@@ -630,19 +630,19 @@ app$callback(
             ),
 
             components$Section(
-            'Dash Deployment Server',
+            'Dash Enterprise',
               list(
                 components$Chapter(
-                'About Dash Deployment Server',
+                'About Dash Enterprise',
                 href='https://plotly.com/dash/?_ga=2.180458663.1075922756.1562168385-916141078.1562168385'
                 ),
                 components$Chapter(
-                'Dash Deployment Server Documentation',
-                href='https://dash.plotly.com/dash-deployment-server'
+                'Dash Enterprise Documentation',
+                href='https://dash.plotly.com/dash-enterprise'
                 )
               ),
-              description="Dash Deployment Server is Plotly's commercial offering for hosting and sharing
-              Dash apps on-premises or in the cloud.",
+              description="Dash Enterprise helps businesses operationalize data science, AI, and ML
+              models. It’s everything you need to deliver your AI or ML initiative at scale.",
               headerStyle=list('color'='#0D76BF')
             )
           )

--- a/web.sh
+++ b/web.sh
@@ -1,5 +1,5 @@
 #/bin/sh
 if [ "$LANGUAGE" = "R" ]
-then fakechroot fakeroot chroot /app/.root /bin/sh -c '/usr/bin/R -f /app/run.R --gui-none --no-save'
+then R --file=run.R --gui-none --no-save
 else gunicorn --preload index:server 
 fi


### PR DESCRIPTION
This PR proposes to
- modify `web.sh` to remove reference to `fakeroot` and `fakechroot`, as these are no longer required to be included in the [current version](https://github.com/virtualstaticvoid/heroku-buildpack-r) of the `virtualstaticvoid` buildpack
- correct link to _FAQs and Gotchas_ section
- update references to DDS to describe Dash Enterprise instead

The changes proposed here have already been pushed to Heroku, this PR is just intended to bring the repo up to date as well. If further edits are necessary, the documentation will be redeployed as required.

---

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [x] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL