### PR TITLE
Add jupyter-dash to installation page

### DIFF
--- a/dash_docs/chapters/installation/index.py
+++ b/dash_docs/chapters/installation/index.py
@@ -26,7 +26,20 @@ layout = html.Div([
     that make up the core of Dash: `dash_html_components`, `dash_core_components`,
     `dash_table`, as well as the `plotly` graphing library. These libraries are
     under active development, so install and upgrade frequently.
+    
+    If you prefer [Jupyter notebook](https://plotly.com/dash/workspaces/?tab=jupyter-notebooks) 
+    or JupyterLab as your development environment, we recommend installing [jupyter-dash](https://github.com/plotly/jupyter-dash):
+    """),
 
+    rc.Markdown("""
+    ```shell
+    pip install jupyter-dash
+    ```
+    """, style=styles.code_container),
+
+    html.Br(),    
+    
+    rc.Markdown("""
     These docs are running `dash` version `{}`.
     Python 2 and 3 are supported.
 
@@ -41,9 +54,7 @@ layout = html.Div([
     ```
     """, style=styles.code_container),
 
-    html.Hr(),
+    rc.Markdown("Ready? Now, let's [make your first Dash app](/layout)."),
 
     rc.WorkspaceBlurb if not tools.is_in_dash_enterprise() else "",
-
-    rc.Markdown("Ready? Now, let's [make your first Dash app](/layout)."),
 ])


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL