### PR TITLE
add dcc.Clipboard

### DIFF
--- a/dash_docs/chapters/dash_core_components/Clipboard/__init__.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/__init__.py
@@ -1,0 +1,1 @@
+from .import index

--- a/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_markdown.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_markdown.py
@@ -1,0 +1,65 @@
+
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+code = """   
+```
+    html.Div(
+    [
+        dcc.Markdown(
+            code,
+            id="code",
+            style={"width": 500, "height": 200, "overflow": "auto"},
+        ),
+        dcc.Clipboard(
+            target_id="code",
+            style={
+                "position": "absolute",
+                "top": 0,
+                "right": 20,
+                "fontSize": 20,
+            },
+        ),
+    ],
+    style={
+        "width": 500,
+        "height": 200,
+        "position": "relative",
+    },
+)
+
+```"""
+
+app.layout = html.Div(
+    [
+        dcc.Markdown(
+            code,
+            id="code",
+            style={"width": 500, "height": 200, "overflow": "auto"},
+        ),
+        dcc.Clipboard(
+            target_id="code",
+            style={
+                "position": "absolute",
+                "top": 0,
+                "right": 20,
+                "fontSize": 20,
+            },
+        ),
+    ],
+    style={
+        "width": 500,
+        "height": 200,
+        "position": "relative",
+    },
+)
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)
+

--- a/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_table.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_table.py
@@ -1,0 +1,62 @@
+
+import dash
+from dash.dependencies import Input, Output, State
+import dash_core_components as dcc
+import dash_html_components as html
+import dash_table
+import pandas as pd
+
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+df = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/solar.csv")
+
+app.layout = html.Div(
+    [
+        dcc.Clipboard(
+            id="DataTable_copy",
+            style={"fontSize": 30, "color": "white", "backgroundColor": "grey", "height":38},
+            className="button",
+        ),
+        dcc.RadioItems(
+            id="copy_selected",
+            options=[
+                {"label": "Copy All", "value": "all"},
+                {"label": "Copy Selected", "value": "some"},
+            ],
+            value="all",
+            style={"display": "inline-block"},
+        ),
+        dash_table.DataTable(
+            id="DataTable",
+            columns=[{"name": i, "id": i} for i in df.columns],
+            data=df.to_dict("records"),
+            sort_action="native",
+            page_size=10,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("DataTable_copy", "text"),
+    Input("DataTable_copy", "n_clicks"),
+    State("DataTable", "start_cell"),
+    State("DataTable", "end_cell"),
+    State("DataTable", "derived_virtual_data"),
+    State("copy_selected", "value")
+)
+def custom_copy(_, start, end, data, copy_selected):
+    dff = pd.DataFrame(data)
+    if start and (copy_selected == 'some'):
+        copy_cells = dff.loc[
+            start["row"]: end["row"], start["column_id"]: end["column_id"]
+        ]
+        return copy_cells.to_string(header=False)
+    else:
+        return dff.to_string()  # includes headers
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_textarea.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/examples/clipboard_textarea.py
@@ -1,0 +1,31 @@
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+app.layout = html.Div(
+    [
+        dcc.Textarea(
+            id="textarea_id",
+            value="Copy and paste here",
+            style={ "height": 100},
+        ),
+        dcc.Clipboard(
+            target_id="textarea_id",
+            title="copy",
+            style={
+                "display": "inline-block",
+                "fontSize": 20,
+                "verticalAlign": "top",
+            },
+        ),
+    ],
+)
+
+if __name__ == "__main__":
+    app.run_server(debug=True)
+
+

--- a/dash_docs/chapters/dash_core_components/Clipboard/index.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/index.py
@@ -8,59 +8,68 @@ from dash_docs import reusable_components as rc
 
 examples = tools.load_examples(__file__)
 
-layout = html.Div(children=[
-    html.H1('Clipboard Examples and Reference'),
-
-    rc.Markdown("""
+layout = html.Div(
+    children=[
+        html.H1("Clipboard Examples and Reference"),
+        rc.Markdown(
+            """
         The Clipboard component copies text to the 
         browser's clipboard by clicking on a copy icon.    
-    """),
-    html.H3('Simple Clipboard Example'),
-    rc.Markdown("""
+    """
+        ),
+        html.H3("Simple Clipboard Example"),
+        rc.Markdown(
+            """
         The easiest way to trigger the copy is by using the the `target_id` 
         property. No callback is required!
 
         Place `dcc.Clipboard()` in the layout where you would like the copy
          icon located. Specify the `target_id` of the component with text to copy.
          In this example, the content of the `value` prop of the dcc.Textarea() is copied to the clipboard.    
-    """),
-    rc.Markdown(
-        examples['clipboard_textarea.py'][0],
-        style=styles.code_container,
-    ),
-    html.Div(examples['clipboard_textarea.py'][1], className='example-container'),
-
-
-    html.H3('Clipboard icon inside a scrollable div'),
-    rc.Markdown("""The `style` and `className` can be used to change the design or the position 
+    """
+        ),
+        rc.Markdown(examples["clipboard_textarea.py"][0], style=styles.code_container,),
+        html.Div(examples["clipboard_textarea.py"][1], className="example-container"),
+        html.H3("Clipboard icon inside a scrollable div"),
+        rc.Markdown(
+            """The `style` and `className` can be used to change the design or the position 
     of the copy icon.  This example shows the icon placed in the top right corner of a scrollable div. 
      The next example shows the icon styled like a button.  
-   """),
-
-    html.Div(
-        examples['clipboard_markdown.py'][1],
-        className='example-container',
-        style={'overflow': 'hidden', 'padding': '20px'}
-    ),
-
-    html.H3('Updating the Clipboard Text in a callback'),
-    rc.Markdown("""When `target_id` is not specified, the content of the `text` prop
+   """
+        ),
+        html.Div(
+            examples["clipboard_markdown.py"][1],
+            className="example-container",
+            style={"overflow": "hidden", "padding": "20px"},
+        ),
+        html.H3("Updating the Clipboard Text in a callback"),
+        rc.Markdown(
+            """When `target_id` is not specified, the content of the `text` prop
     is copied to the clipboard.  This works well with components like the DataTable where
     you may want to customized the text in a callback.  In this example, 
     the dataframe is converted to text with pandas `to_string()`.  See the pandas documentation 
         for other formatting options such as including or excluding headers.  
     """
-    ),
-    rc.Markdown(
-        examples['clipboard_table.py'][0],
-        style=styles.code_container,
-    ),
-    html.Div(
-        examples['clipboard_table.py'][1],
-        className='example-container',
-        style={'overflow': 'hidden', 'padding': '20px'}
-    ),
-
-    html.H3("Clipboard Properties"),
-    rc.ComponentReference('Clipboard')
-])
+        ),
+        rc.Markdown(examples["clipboard_table.py"][0], style=styles.code_container,),
+        html.Div(
+            examples["clipboard_table.py"][1],
+            className="example-container",
+            style={"overflow": "hidden", "padding": "20px"},
+        ),
+        html.H3("Limitations"),
+        rc.Markdown(
+            """
+    This component uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
+     which is not supported by older browsers like Internet Explorer. When the Clipboard API is unavailable, the 
+     icon will not appear in the app and a warning message is written to the console.
+     
+     Currently dcc.Clipboard only supports copying text to the clipboard.
+     
+     
+    """
+        ),
+        html.H3("Clipboard Properties"),
+        rc.ComponentReference("Clipboard"),
+    ]
+)

--- a/dash_docs/chapters/dash_core_components/Clipboard/index.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/index.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import dash_core_components as dcc
+import dash_html_components as html
+
+from dash_docs import styles
+from dash_docs import tools
+from dash_docs import reusable_components as rc
+
+examples = tools.load_examples(__file__)
+
+layout = html.Div(children=[
+    html.H1('Clipboard Examples and Reference'),
+
+    rc.Markdown("""
+        The Clipboard component copies text to the 
+        browser's clipboard by clicking on a copy icon.    
+    """),
+    html.H3('Simple Clipboard Example'),
+    rc.Markdown("""
+        The easiest way to trigger the copy is by using the the `target_id` 
+        prop. No callback is required!
+
+        Place dcc.Clipboard() in the layout where you would like the copy
+         icon located. Specify the `target_id` of the component with text to copy.
+         In this example, the content of the `value` prop of the dcc.Textarea() is copied to the clipboard.    
+    """),
+    rc.Markdown(
+        examples['clipboard_textarea.py'][0],
+        style=styles.code_container,
+    ),
+    html.Div(examples['clipboard_textarea.py'][1], className='example-container'),
+
+
+    html.H3('Clipboard icon inside a scrollable div'),
+    rc.Markdown("""The `style` and `className` can be used to change the design or the position 
+    of the copy icon.  This example shows the icon placed in the top right corner of a scrollable div. 
+     The next example shows the icon styled like a button.  
+   """),
+
+    html.Div(
+        examples['clipboard_markdown.py'][1],
+        className='example-container',
+        style={'overflow': 'hidden', 'padding': '20px'}
+    ),
+
+    html.H3('Updating Text in a callback'),
+    rc.Markdown("""When `target_id` is not specified, the content of the `text` prop
+    is copied to the clipboard.  This works well with components like the DataTable where
+    you may want to customized the text in a callback.  In this example, 
+    the dataframe is converted to text with pandas `to_string()`.  See the pandas documentation 
+        for other formatting options such as including or excluding headers.  
+    """
+    ),
+    rc.Markdown(
+        examples['clipboard_table.py'][0],
+        style=styles.code_container,
+    ),
+    html.Div(
+        examples['clipboard_table.py'][1],
+        className='example-container',
+        style={'overflow': 'hidden', 'padding': '20px'}
+    ),
+
+    html.H3("Clipboard Properties"),
+    rc.ComponentReference('Clipboard')
+])

--- a/dash_docs/chapters/dash_core_components/Clipboard/index.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/index.py
@@ -43,7 +43,7 @@ layout = html.Div(children=[
         style={'overflow': 'hidden', 'padding': '20px'}
     ),
 
-    html.H3('Updating Text in a callback'),
+    html.H3('Updating the Clipboard Text in a callback'),
     rc.Markdown("""When `target_id` is not specified, the content of the `text` prop
     is copied to the clipboard.  This works well with components like the DataTable where
     you may want to customized the text in a callback.  In this example, 

--- a/dash_docs/chapters/dash_core_components/Clipboard/index.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/index.py
@@ -20,7 +20,7 @@ layout = html.Div(children=[
         The easiest way to trigger the copy is by using the the `target_id` 
         property. No callback is required!
 
-        Place dcc.Clipboard() in the layout where you would like the copy
+        Place `dcc.Clipboard()` in the layout where you would like the copy
          icon located. Specify the `target_id` of the component with text to copy.
          In this example, the content of the `value` prop of the dcc.Textarea() is copied to the clipboard.    
     """),

--- a/dash_docs/chapters/dash_core_components/Clipboard/index.py
+++ b/dash_docs/chapters/dash_core_components/Clipboard/index.py
@@ -18,7 +18,7 @@ layout = html.Div(children=[
     html.H3('Simple Clipboard Example'),
     rc.Markdown("""
         The easiest way to trigger the copy is by using the the `target_id` 
-        prop. No callback is required!
+        property. No callback is required!
 
         Place dcc.Clipboard() in the layout where you would like the copy
          icon located. Specify the `target_id` of the component with text to copy.

--- a/dash_docs/chapters/dash_core_components/content_module.py
+++ b/dash_docs/chapters/dash_core_components/content_module.py
@@ -1,4 +1,5 @@
 from .Checklist.index import layout as Checklist
+from .Clipboard.index import layout as Clipboard
 from .ConfirmDialog.index import layout as ConfirmDialog
 from .ConfirmDialogProvider.index import layout as ConfirmDialogProvider
 from .DatePickerRange.index import layout as DatePickerRange


### PR DESCRIPTION
This is a first draft of the documentation for the new dcc.Clipboard component added in [dcc 932](https://github.com/plotly/dash-core-components/pull/932