### PR TITLE
reference docstrings for dash

### DIFF
--- a/dash_docs/assets/override.css
+++ b/dash_docs/assets/override.css
@@ -31,6 +31,10 @@ h4 { font-size: 26px; line-height: 1.35; margin-bottom: 1.2rem; margin-top: 1.2r
 h5 { font-size: 22px; line-height: 1.5;  margin-bottom: 0.6rem; margin-top: 0.6rem;}
 h6 { font-size: 20px; line-height: 1.6;  margin-bottom: 0.75rem; margin-top: 0.75rem;}
 
+pre {
+    overflow-x: auto;
+}
+
 ._dash-loading {
   text-align: center;
   margin-top: 50px;
@@ -87,6 +91,7 @@ h6 { font-size: 20px; line-height: 1.6;  margin-bottom: 0.75rem; margin-top: 0.7
     margin-top: 30px;
     margin-left: 10px;
     font-size: 12px;
+    overflow-y: auto;
 }
 .page-menu--header {
     font-weight: bold;

--- a/dash_docs/assets/sitemap.xml
+++ b/dash_docs/assets/sitemap.xml
@@ -813,6 +813,9 @@
     <loc>https://dash.plotly.com/react-for-python-developers</loc>
 </url>
 <url>
+    <loc>https://dash.plotly.com/reference</loc>
+</url>
+<url>
     <loc>https://dash.plotly.com/sharing-data-between-callbacks</loc>
 </url>
 <url>

--- a/dash_docs/chapter_index.py
+++ b/dash_docs/chapter_index.py
@@ -1249,6 +1249,18 @@ URLS = [
             },
 
             {
+                'url': '/reference',
+                'content': chapters.reference.index.layout,
+                'name': 'API Reference',
+                'description': (
+                    '''
+                    The docstrings and options for the public methods of the
+                    `dash` module and the `app` object.
+                    '''
+                )
+            },
+
+            {
                 'url': '/dash-1-0-migration',
                 'name': 'Dash 1.0.0 Migration',
                 'description': (

--- a/dash_docs/chapters/__init__.py
+++ b/dash_docs/chapters/__init__.py
@@ -25,6 +25,7 @@ from .import migration
 from .import performance
 from .import persistence
 from .import plugins
+from .import reference
 from .import sharing_data
 from .import clientside_callbacks
 from .import advanced_callbacks

--- a/dash_docs/chapters/reference/__init__.py
+++ b/dash_docs/chapters/reference/__init__.py
@@ -1,0 +1,1 @@
+from .import index

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -80,7 +80,9 @@ PUBLIC_API = [
     # app,
     # dash.Dash,
     # dash.resources,
-    dict(obj=dash, prefix='', skip=[], preamble=dcc.Markdown(
+    dict(obj=dash, prefix='', skip=[
+        'fingerprint',
+    ], preamble=dcc.Markdown(
     '''
     # The `dash` module
     ```
@@ -94,7 +96,6 @@ PUBLIC_API = [
         'dependencies',
         'dispatch',
         'exceptions',
-        'fingerprint',
         'logger',
         'registered_paths',
         'renderer',
@@ -133,6 +134,19 @@ PUBLIC_API = [
             gunicorn app:server
             ```
             '''
+        ),
+        title=dcc.Markdown(
+            '''
+            Configures the document.title (the text that appears in a browser tab).
+
+            Default is "Dash".
+            
+            This is now configurable in the `dash.Dash(title='...')` constructor 
+            instead of as a property of `app`. We have kept this property
+            in the `app` object for backwards compatibility.
+            '''
+            
+            
         )
     )),
 
@@ -154,7 +168,7 @@ PUBLIC_API = [
     handle this particular scenario.
     These exception classes are in this module.
     '''
-    ))
+    ), global_override='')
 ]
 
 
@@ -179,6 +193,8 @@ def create_docstrings():
                 docstring.append(doc_signature(docitem['obj'], method, docitem['prefix']))
                 if 'override' in docitem and method in docitem['override']:
                     docstring.append(docitem['override'][method])
+                elif 'global_override' in docitem:
+                    docstring.append(docitem['global_override'])
                 else:
                     docstring.append(dcc.Markdown(convert_docstring_to_markdown(getattr(docitem['obj'], method).__doc__)))
         docstring.append(html.Hr())

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -83,7 +83,8 @@ PUBLIC_API = [
     import dash
     ```
     '''
-    ),
+    )),
+
     dict(obj=app, prefix='app', skip=[
         'css',
         'dependencies',
@@ -106,6 +107,7 @@ PUBLIC_API = [
     ```
     '''
     )),
+
     dict(obj=dash.dependencies, prefix='', skip=[], preamble=dcc.Markdown(
     '''
     # dash.dependencies
@@ -114,6 +116,7 @@ PUBLIC_API = [
     signature.
     '''
     )),
+
     dict(obj=dash.exceptions, prefix='', skip=[], preamble=dcc.Markdown(
     '''
     # dash.exceptions

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -1,0 +1,98 @@
+import dash_html_components as html
+import dash_core_components as dcc
+import dash
+
+METHODS = [
+    method
+    for method in dir(dash)
+    if not method.startswith("_")
+]
+
+
+import dash
+import dash_html_components as html
+import dash_core_components as dcc
+import textwrap
+import re
+
+def convert_method_name_to_markdown(obj, method):
+    method_name = f'{obj}.{method}'
+    method_name = method_name.replace("<class 'dash.dash.Dash'>", 'app')
+    return method_name
+
+def convert_docstring_to_markdown(docstring):
+    if not docstring:
+        return '\n\nUndocumented\n'
+
+    lines = docstring.split('\n')
+
+    # For some reason the second block of lines is indented
+    docstring = lines[0] + textwrap.dedent('\n'.join(lines[1:]))
+
+    # Replace ':param <variable>' with `<variable>`
+    docstring = re.sub(r'\:param (\w*)\:', r'**`\1`**\n\n', docstring)
+
+    docstring = re.sub(r'\:type (\w*)\:', r'\ntype:', docstring)
+
+    # Remove leading ': from rst Example
+    docstring = docstring.replace(':Example:', 'Example:')
+
+    docstring = docstring.replace('``', '`')
+
+    return docstring
+
+app = dash.Dash(__name__)
+
+SKIP = ['dash']
+
+PUBLIC_API = [
+    dash.Dash,
+    dash.resources,
+    dash.exceptions,
+    dash.dependencies,
+    dash
+]
+
+DOCSTRINGS = ''
+def recursively_create_docstrings(obj):
+    docstring = ''
+    for method in dir(obj):
+        if (obj and not method.startswith('_') and 
+                method not in SKIP and 
+                'dash' in str(obj) and 
+                'class' not in method and
+                'development' not in method):
+            print(str(obj))
+            print(method)
+            try:
+                getattr(obj, method).__doc__
+            except:
+                print(f'Error accessing {obj}.{method}')
+                continue
+            docstring = docstring + f'\n\n***\n\n**`{convert_method_name_to_markdown(obj, method)}`**\n\n' + (convert_docstring_to_markdown(getattr(obj, method).__doc__)) 
+            docstring = docstring + recursively_create_docstrings(getattr(obj, method))
+                
+    return docstring
+
+def public_methods(obj):
+    methods = []    
+    for method in dir(obj):
+        if (obj and not method.startswith('_') and 
+                method not in SKIP and 
+                'dash' in str(obj) and 
+                'class' not in method and
+                'development' not in method):
+            methods.append(method)
+    return methods
+
+def create_docstrings():
+    docstring = ''
+    for obj in PUBLIC_API:
+        for method in public_methods(obj):
+            docstring = docstring + f'\n\n***\n\n**`{convert_method_name_to_markdown(obj, method)}`**\n\n' + (convert_docstring_to_markdown(getattr(obj, method).__doc__)) 
+    return docstring          
+
+layout = html.Div([
+
+    dcc.Markdown(create_docstrings()),
+])

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -57,6 +57,7 @@ def doc_signature(obj, method, prefix):
             html.H2(
                 html.Code("{}.{}".format(prefix, name)),
                 className="docs-article",
+                style={'overflowX': 'auto'}
             ),
             html.Pre(
                 className="docs-article",

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -177,8 +177,8 @@ def create_docstrings():
         for method in public_methods(docitem['obj']):
             if method not in docitem['skip']:
                 docstring.append(doc_signature(docitem['obj'], method, docitem['prefix']))
-                if 'override' in docitem:
-                    docstring.append(docitem['override'])
+                if 'override' in docitem and method in docitem['override']:
+                    docstring.append(docitem['override'][method])
                 else:
                     docstring.append(dcc.Markdown(convert_docstring_to_markdown(getattr(docitem['obj'], method).__doc__)))
         docstring.append(html.Hr())

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -78,7 +78,7 @@ PUBLIC_API = [
     # dash.resources,
     dict(obj=dash, prefix='', skip=[], preamble=dcc.Markdown(
     '''
-    # dash
+    # The `dash` module
     ```
     import dash
     ```
@@ -100,7 +100,7 @@ PUBLIC_API = [
         'validation_layout'
     ], preamble=dcc.Markdown(
     '''
-    # app
+    # The `app` Object
     ```
     import dash
     app = dash.Dash(__name__)
@@ -110,7 +110,7 @@ PUBLIC_API = [
 
     dict(obj=dash.dependencies, prefix='', skip=[], preamble=dcc.Markdown(
     '''
-    # dash.dependencies
+    # The `dash.dependencies` module
     
     The classes in `dash.dependencies` are all used in the `app.callback`
     signature.
@@ -119,7 +119,7 @@ PUBLIC_API = [
 
     dict(obj=dash.exceptions, prefix='', skip=[], preamble=dcc.Markdown(
     '''
-    # dash.exceptions
+    # The `dash.exceptions` module
     
     Dash will raise exceptions under certain scenarios. 
     Dash will always use a special exception class that can be caught to 
@@ -145,10 +145,10 @@ def public_methods(obj):
 def create_docstrings():
     docstring = []
     for docitem in PUBLIC_API:
+        docstring.append(docitem['preamble']),
         for method in public_methods(docitem['obj']):
             if method not in docitem['skip']:
                 docstring.append(doc_signature(docitem['obj'], method, docitem['prefix']))
-                docstring.append(docitem['preamble']),
                 docstring.append(dcc.Markdown(convert_docstring_to_markdown(getattr(docitem['obj'], method).__doc__)))
     return docstring          
 

--- a/dash_docs/chapters/reference/index.py
+++ b/dash_docs/chapters/reference/index.py
@@ -1,28 +1,13 @@
-import dash_html_components as html
-import dash_core_components as dcc
-import dash
-
-METHODS = [
-    method
-    for method in dir(dash)
-    if not method.startswith("_")
-]
-
-
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
 import textwrap
 import re
-
-def convert_method_name_to_markdown(obj, method):
-    method_name = f'{obj}.{method}'
-    method_name = method_name.replace("<class 'dash.dash.Dash'>", 'app')
-    return method_name
+import inspect
 
 def convert_docstring_to_markdown(docstring):
     if not docstring:
-        return '\n\nUndocumented\n'
+        return '\n\(Not officially documented)\n'
 
     lines = docstring.split('\n')
 
@@ -43,41 +28,110 @@ def convert_docstring_to_markdown(docstring):
 
 app = dash.Dash(__name__)
 
-SKIP = ['dash']
+SKIP = ['dash', 'json', 'dedent']
+
+def doc_signature(obj, method, prefix):
+    try:
+        signature = str(inspect.signature(getattr(obj, method)))
+    except:
+        signature = ''
+
+    try:
+        name = method.__name__
+    except:
+        name = str(method)
+
+    if not prefix:
+        try:
+            prefix = obj.__name__
+        except:
+            prefix = str(obj)
+    prefix_signature = prefix
+
+    return html.Div(
+        [
+            html.H2(
+                html.Code("{}.{}".format(prefix, name)),
+                className="docs-article",
+            ),
+            html.Pre(
+                className="docs-article",
+                children=html.Code(
+                    "{}.{}{}".format(
+                        prefix_signature,
+                        name,
+                        signature
+                        .replace(",", ",\n   ")
+                        .replace("(", "(\n    ")
+                        .replace(")", "\n)")
+                        .replace("    self,\n", "")
+                        .replace("\n    self\n", ""),
+                    )
+                ),
+            ),
+        ]
+    )
 
 PUBLIC_API = [
-    dash.Dash,
-    dash.resources,
-    dash.exceptions,
-    dash.dependencies,
-    dash
+    # app,
+    # dash.Dash,
+    # dash.resources,
+    dict(obj=dash, prefix='', skip=[], preamble=dcc.Markdown(
+    '''
+    # dash
+    ```
+    import dash
+    ```
+    '''
+    ),
+    dict(obj=app, prefix='app', skip=[
+        'css',
+        'dependencies',
+        'dispatch',
+        'logger',
+        'registered_paths',
+        'renderer',
+        'routes',
+        'scripts',
+        'serve_component_suites',
+        'serve_layout',
+        'serve_reload_hash',
+        'validation_layout'
+    ], preamble=dcc.Markdown(
+    '''
+    # app
+    ```
+    import dash
+    app = dash.Dash(__name__)
+    ```
+    '''
+    )),
+    dict(obj=dash.dependencies, prefix='', skip=[], preamble=dcc.Markdown(
+    '''
+    # dash.dependencies
+    
+    The classes in `dash.dependencies` are all used in the `app.callback`
+    signature.
+    '''
+    )),
+    dict(obj=dash.exceptions, prefix='', skip=[], preamble=dcc.Markdown(
+    '''
+    # dash.exceptions
+    
+    Dash will raise exceptions under certain scenarios. 
+    Dash will always use a special exception class that can be caught to 
+    handle this particular scenario.
+    These exception classes are in this module.
+    '''
+    ))
 ]
 
-DOCSTRINGS = ''
-def recursively_create_docstrings(obj):
-    docstring = ''
-    for method in dir(obj):
-        if (obj and not method.startswith('_') and 
-                method not in SKIP and 
-                'dash' in str(obj) and 
-                'class' not in method and
-                'development' not in method):
-            print(str(obj))
-            print(method)
-            try:
-                getattr(obj, method).__doc__
-            except:
-                print(f'Error accessing {obj}.{method}')
-                continue
-            docstring = docstring + f'\n\n***\n\n**`{convert_method_name_to_markdown(obj, method)}`**\n\n' + (convert_docstring_to_markdown(getattr(obj, method).__doc__)) 
-            docstring = docstring + recursively_create_docstrings(getattr(obj, method))
-                
-    return docstring
 
 def public_methods(obj):
     methods = []    
     for method in dir(obj):
-        if (obj and not method.startswith('_') and 
+        if (obj and
+                not method.startswith('_') and 
                 method not in SKIP and 
                 'dash' in str(obj) and 
                 'class' not in method and
@@ -86,13 +140,30 @@ def public_methods(obj):
     return methods
 
 def create_docstrings():
-    docstring = ''
-    for obj in PUBLIC_API:
-        for method in public_methods(obj):
-            docstring = docstring + f'\n\n***\n\n**`{convert_method_name_to_markdown(obj, method)}`**\n\n' + (convert_docstring_to_markdown(getattr(obj, method).__doc__)) 
+    docstring = []
+    for docitem in PUBLIC_API:
+        for method in public_methods(docitem['obj']):
+            if method not in docitem['skip']:
+                docstring.append(doc_signature(docitem['obj'], method, docitem['prefix']))
+                docstring.append(docitem['preamble']),
+                docstring.append(dcc.Markdown(convert_docstring_to_markdown(getattr(docitem['obj'], method).__doc__)))
     return docstring          
 
 layout = html.Div([
 
-    dcc.Markdown(create_docstrings()),
+    dcc.Markdown(
+    '''
+    # API Reference
+    
+    This page displays the docstrings for the public methods of the
+    `dash` module including the `app` object.
+    
+    Curious about the implementation details? 
+    [Browse the Dash source code](https://github.com/plotly/dash).
+    '''
+    ),
+
+    html.Div(create_docstrings()),
+
 ])
+


### PR DESCRIPTION
Displays docstrings for `dash.Dash` and other modules & objects at long last.

Fixes https://github.com/plotly/dash-core/issues/115.

Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL