### PR TITLE
Fix datatable example so pagination buttons are visible

### DIFF
--- a/dash_docs/chapters/dash_datatable/interactivity/examples/interactivity_connected_to_graph.py
+++ b/dash_docs/chapters/dash_datatable/interactivity/examples/interactivity_connected_to_graph.py
@@ -5,47 +5,55 @@ import dash_core_components as dcc
 import dash_html_components as html
 import pandas as pd
 
-df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/gapminder2007.csv')
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/plotly/datasets/master/gapminder2007.csv"
+)
 
 app = dash.Dash(__name__)
 
-app.layout = html.Div([
-    dash_table.DataTable(
-        id='datatable-interactivity',
-        columns=[
-            {"name": i, "id": i, "deletable": True, "selectable": True} for i in df.columns
-        ],
-        data=df.to_dict('records'),
-        editable=True,
-        filter_action="native",
-        sort_action="native",
-        sort_mode="multi",
-        column_selectable="single",
-        row_selectable="multi",
-        row_deletable=True,
-        selected_columns=[],
-        selected_rows=[],
-        page_action="native",
-        page_current= 0,
-        page_size= 10,
-    ),
-    html.Div(id='datatable-interactivity-container')
-])
+app.layout = html.Div(
+    [
+        dash_table.DataTable(
+            id="datatable-interactivity",
+            columns=[
+                {"name": i, "id": i, "deletable": True, "selectable": True}
+                for i in df.columns
+            ],
+            data=df.to_dict("records"),
+            editable=True,
+            filter_action="native",
+            sort_action="native",
+            sort_mode="multi",
+            column_selectable="single",
+            row_selectable="multi",
+            row_deletable=True,
+            selected_columns=[],
+            selected_rows=[],
+            page_action="native",
+            page_current=0,
+            page_size=10,
+        ),
+        html.Div(id="datatable-interactivity-container", style={"marginTop": 35}),
+    ]
+)
+
 
 @app.callback(
-    Output('datatable-interactivity', 'style_data_conditional'),
-    Input('datatable-interactivity', 'selected_columns')
+    Output("datatable-interactivity", "style_data_conditional"),
+    Input("datatable-interactivity", "selected_columns"),
 )
 def update_styles(selected_columns):
-    return [{
-        'if': { 'column_id': i },
-        'background_color': '#D2F3FF'
-    } for i in selected_columns]
+    return [
+        {"if": {"column_id": i}, "background_color": "#D2F3FF"}
+        for i in selected_columns
+    ]
+
 
 @app.callback(
-    Output('datatable-interactivity-container', "children"),
-    Input('datatable-interactivity', "derived_virtual_data"),
-    Input('datatable-interactivity', "derived_virtual_selected_rows"))
+    Output("datatable-interactivity-container", "children"),
+    Input("datatable-interactivity", "derived_virtual_data"),
+    Input("datatable-interactivity", "derived_virtual_selected_rows"),
+)
 def update_graphs(rows, derived_virtual_selected_rows):
     # When the table is first rendered, `derived_virtual_data` and
     # `derived_virtual_selected_rows` will be `None`. This is due to an
@@ -61,8 +69,10 @@ def update_graphs(rows, derived_virtual_selected_rows):
 
     dff = df if rows is None else pd.DataFrame(rows)
 
-    colors = ['#7FDBFF' if i in derived_virtual_selected_rows else '#0074D9'
-              for i in range(len(dff))]
+    colors = [
+        "#7FDBFF" if i in derived_virtual_selected_rows else "#0074D9"
+        for i in range(len(dff))
+    ]
 
     return [
         dcc.Graph(
@@ -78,10 +88,7 @@ def update_graphs(rows, derived_virtual_selected_rows):
                 ],
                 "layout": {
                     "xaxis": {"automargin": True},
-                    "yaxis": {
-                        "automargin": True,
-                        "title": {"text": column}
-                    },
+                    "yaxis": {"automargin": True, "title": {"text": column}},
                     "height": 250,
                     "margin": {"t": 10, "l": 10, "r": 10},
                 },
@@ -90,9 +97,10 @@ def update_graphs(rows, derived_virtual_selected_rows):
         # check if column exists - user may have deleted it
         # If `column.deletable=False`, then you don't
         # need to do this check.
-        for column in ["pop", "lifeExp", "gdpPercap"] if column in dff
+        for column in ["pop", "lifeExp", "gdpPercap"]
+        if column in dff
     ]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run_server(debug=True)


### PR DESCRIPTION
This fixes the example in the [DataTable Interactivity chapter](https://dash.plotly.com/datatable/interactivity) so  the pagination buttons are visible. 


Thanks to @sujeet.cusat  for reporting this on the [forum](
https://community.plotly.com/t/pagination-is-not-visible-when-using-dash-table-with-graph/53216)

The only real change is to add some margin, the other changes are from running `black`

![image](https://user-images.githubusercontent.com/72614349/119377696-42ec2d00-bc72-11eb-8e53-fc39812baa7a.png)
