### PR TITLE
fix #1151: xlxs->xlsx typo

### DIFF
--- a/dash_docs/chapters/dash_core_components/Download/examples/download-dataframe-xlxs.py
+++ b/dash_docs/chapters/dash_core_components/Download/examples/download-dataframe-xlxs.py
@@ -6,8 +6,8 @@ import dash_core_components as dcc
 app = dash.Dash(prevent_initial_callbacks=True)
 app.layout = html.Div(
     [
-        html.Button("Download Excel", id="btn_xlxs"),
-        dcc.Download(id="download-dataframe-xlxs"),
+        html.Button("Download Excel", id="btn_xlsx"),
+        dcc.Download(id="download-dataframe-xlsx"),
     ]
 )
 
@@ -18,12 +18,12 @@ df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 1, 5, 6], "c": ["x", "x", "y", "y
 
 
 @app.callback(
-    Output("download-dataframe-xlxs", "data"),
-    Input("btn_xlxs", "n_clicks"),
+    Output("download-dataframe-xlsx", "data"),
+    Input("btn_xlsx", "n_clicks"),
     prevent_initial_call=True,
 )
 def func(n_clicks):
-    return dcc.send_data_frame(df.to_excel, "mydf.xlxs", sheet_name="Sheet_name_1")
+    return dcc.send_data_frame(df.to_excel, "mydf.xlsx", sheet_name="Sheet_name_1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Post-merge checklist:

The master branch is auto-deployed to `dash.plotly.com`.
Once you have merged your PR, wait 5-10 minutes and check dash.plotly.com
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.

If this PR includes a new dataset available at a remote URL:
- [ ] I have added this dataset to the `datasets/` folder
- [ ] I have added a mapping between the remote URL and the filename in the
`datasets/` folder into the `find_and_replace` dict in `dash_docs/tools.py`

If this PR adds an image or animated GIF:
- [ ] This image was saved and referenced locally rather than via an external link

If I introduced a new relative link inside `dcc.Markdown`:
- [ ] I considered whether I could replace the `dcc.Markdown` call with `rc.Markdown`, which will replace relative links with `tools.relpath` internally. Otherwise, I used e.g. `<dccLink href=tools.relpath('/layout') children="the first chapter"/>` instead of `[the first chapter](/layout)` (importing `tools` from `dash_docs`), and set `dangerously_allow_html=true` in the `dcc.Markdown` call.

If I changed the `chapter_index` by removing or relocating a page:
- [ ] I added a redirect in `dash_docs/server.py` from the old URL to the new URL